### PR TITLE
Add nodepool cleanup

### DIFF
--- a/opensearch-operator/pkg/helpers/reconcile-helpers.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	sts "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/kube-openapi/pkg/validation/errors"
 	opsterv1 "opensearch.opster.io/api/v1"
 )
@@ -21,7 +21,7 @@ func CreateInitMasters(cr *opsterv1.OpenSearchCluster) string {
 	return strings.Join(masters, ",")
 }
 
-func CheckEquels(from_env *sts.StatefulSetSpec, from_crd *sts.StatefulSetSpec, text string) (int32, bool, error) {
+func CheckEquels(from_env *appsv1.StatefulSetSpec, from_crd *appsv1.StatefulSetSpec, text string) (int32, bool, error) {
 	field_env := GetField(from_env, text)
 	field_env_int_ptr, ok := field_env.(*int32)
 	if !ok {

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -2,15 +2,11 @@ package reconcilers
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	"github.com/banzaicloud/operator-tools/pkg/reconciler"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
 	opsterv1 "opensearch.opster.io/api/v1"
-	"opensearch.opster.io/opensearch-gateway/services"
 	"opensearch.opster.io/pkg/builders"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,9 +57,6 @@ func (r *ClusterReconciler) Reconcile() (ctrl.Result, error) {
 		result.Combine(r.reconcileNodeStatefulSet(nodePool))
 	}
 
-	// Clean up statefulsets that are no longer in the spec
-	r.cleanupStatefulSets(&result)
-
 	return result.Result, result.Err
 }
 
@@ -97,82 +90,4 @@ func (r *ClusterReconciler) reconcileNodeStatefulSet(nodePool opsterv1.NodePool)
 func (r *ClusterReconciler) DeleteResources() (ctrl.Result, error) {
 	result := reconciler.CombinedResult{}
 	return result.Result, result.Err
-}
-
-func (r *ClusterReconciler) cleanupStatefulSets(result *reconciler.CombinedResult) {
-	stsList := &appsv1.StatefulSetList{}
-	if err := r.Client.List(
-		r.ctx,
-		stsList,
-		client.InNamespace(r.instance.Name),
-		client.MatchingLabels{builders.ClusterLabel: r.instance.Name},
-	); err != nil {
-		result.Combine(&ctrl.Result{}, err)
-		return
-	}
-
-	for _, sts := range stsList.Items {
-		if !builders.STSInNodePools(sts, r.instance.Spec.NodePools) {
-			result.Combine(r.removeStatefulSet(sts))
-		}
-	}
-
-}
-
-func (r *ClusterReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Result, error) {
-	if !r.instance.Spec.ConfMgmt.SmartScaler {
-		return r.ReconcileResource(&sts, reconciler.StateAbsent)
-	}
-
-	// Gracefully remove nodes
-	lg := log.FromContext(r.ctx)
-	username, password := builders.UsernameAndPassword(r.instance)
-
-	clusterClient, err := services.NewOsClusterClient(fmt.Sprintf("https://%s.%s", r.instance.Spec.General.ServiceName, r.instance.Name), username, password)
-	if err != nil {
-		lg.Error(err, "failed to create os client")
-		return nil, err
-	}
-
-	workingOrdinal := pointer.Int32Deref(sts.Spec.Replicas, 1) - 1
-	lastReplicaNodeName := builders.ReplicaHostName(sts, workingOrdinal)
-	_, err = services.AppendExcludeNodeHost(clusterClient, lastReplicaNodeName)
-	if err != nil {
-		lg.Error(err, fmt.Sprintf("failed to exclude node %s", lastReplicaNodeName))
-		return nil, err
-	}
-
-	nodeNotEmpty, err := services.HasShardsOnNode(clusterClient, lastReplicaNodeName)
-	if err != nil {
-		lg.Error(err, "failed to check shards on node")
-		return nil, err
-	}
-
-	if nodeNotEmpty {
-		return &ctrl.Result{
-			Requeue:      true,
-			RequeueAfter: 15 * time.Second,
-		}, nil
-	}
-
-	if workingOrdinal == 0 {
-		result, err := r.ReconcileResource(&sts, reconciler.StateAbsent)
-		if err != nil {
-			return result, err
-		}
-		_, err = services.RemoveExcludeNodeHost(clusterClient, lastReplicaNodeName)
-		if err != nil {
-			lg.Error(err, fmt.Sprintf("failed to remove node exclusion for %s", lastReplicaNodeName))
-		}
-		return result, err
-	}
-
-	sts.Spec.Replicas = &workingOrdinal
-	result, err := r.ReconcileResource(&sts, reconciler.StatePresent)
-
-	_, err = services.RemoveExcludeNodeHost(clusterClient, lastReplicaNodeName)
-	if err != nil {
-		lg.Error(err, fmt.Sprintf("failed to remove node exclusion for %s", lastReplicaNodeName))
-	}
-	return result, err
 }

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -3,9 +3,11 @@ package reconcilers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/pointer"
 	"opensearch.opster.io/opensearch-gateway/services"
 	"opensearch.opster.io/pkg/builders"
 
@@ -49,14 +51,20 @@ func NewScalerReconciler(
 
 func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 	requeue := false
+	results := &reconciler.CombinedResult{}
 	var err error
 	for _, nodePool := range r.instance.Spec.NodePools {
 		requeue, err = r.reconcileNodePool(&nodePool)
 		if err != nil {
-			return ctrl.Result{Requeue: requeue}, err
+			results.Combine(&ctrl.Result{Requeue: requeue}, err)
 		}
 	}
-	return ctrl.Result{Requeue: requeue}, nil
+	results.Combine(&ctrl.Result{Requeue: requeue}, nil)
+
+	// Clean up old node pools
+	r.cleanupStatefulSets(results)
+
+	return results.Result, results.Err
 }
 
 func (r *ScalerReconciler) reconcileNodePool(nodePool *opsterv1.NodePool) (bool, error) {
@@ -306,4 +314,85 @@ func (r *ScalerReconciler) DeleteNodePortService(service corev1.Service) {
 		lg.Error(err, "Cannot delete service")
 		r.recorder.Event(r.instance, "Warning", "Cannot delete service", "Requeue - Fix the problem you have on main Opensearch Headless Service ")
 	}
+}
+
+func (r *ScalerReconciler) cleanupStatefulSets(result *reconciler.CombinedResult) {
+	stsList := &appsv1.StatefulSetList{}
+	if err := r.Client.List(
+		r.ctx,
+		stsList,
+		client.InNamespace(r.instance.Name),
+		client.MatchingLabels{builders.ClusterLabel: r.instance.Name},
+	); err != nil {
+		result.Combine(&ctrl.Result{}, err)
+		return
+	}
+
+	for _, sts := range stsList.Items {
+		if !builders.STSInNodePools(sts, r.instance.Spec.NodePools) {
+			result.Combine(r.removeStatefulSet(sts))
+		}
+	}
+
+}
+
+func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Result, error) {
+	if !r.instance.Spec.ConfMgmt.SmartScaler {
+		return r.ReconcileResource(&sts, reconciler.StateAbsent)
+	}
+
+	// Gracefully remove nodes
+	lg := log.FromContext(r.ctx)
+	username, password := builders.UsernameAndPassword(r.instance)
+
+	clusterClient, err := services.NewOsClusterClient(fmt.Sprintf("https://%s.%s:9200", r.instance.Spec.General.ServiceName, r.instance.Name), username, password)
+	if err != nil {
+		lg.Error(err, "failed to create os client")
+		return nil, err
+	}
+
+	workingOrdinal := pointer.Int32Deref(sts.Spec.Replicas, 1) - 1
+	lastReplicaNodeName := builders.ReplicaHostName(sts, workingOrdinal)
+	_, err = services.AppendExcludeNodeHost(clusterClient, lastReplicaNodeName)
+	if err != nil {
+		lg.Error(err, fmt.Sprintf("failed to exclude node %s", lastReplicaNodeName))
+		return nil, err
+	}
+
+	nodeNotEmpty, err := services.HasShardsOnNode(clusterClient, lastReplicaNodeName)
+	if err != nil {
+		lg.Error(err, "failed to check shards on node")
+		return nil, err
+	}
+
+	if nodeNotEmpty {
+		return &ctrl.Result{
+			Requeue:      true,
+			RequeueAfter: 15 * time.Second,
+		}, nil
+	}
+
+	if workingOrdinal == 0 {
+		result, err := r.ReconcileResource(&sts, reconciler.StateAbsent)
+		if err != nil {
+			return result, err
+		}
+		_, err = services.RemoveExcludeNodeHost(clusterClient, lastReplicaNodeName)
+		if err != nil {
+			lg.Error(err, fmt.Sprintf("failed to remove node exclusion for %s", lastReplicaNodeName))
+		}
+		return result, err
+	}
+
+	sts.Spec.Replicas = &workingOrdinal
+	result, err := r.ReconcileResource(&sts, reconciler.StatePresent)
+	if err != nil {
+		return result, err
+	}
+
+	_, err = services.RemoveExcludeNodeHost(clusterClient, lastReplicaNodeName)
+	if err != nil {
+		lg.Error(err, fmt.Sprintf("failed to remove node exclusion for %s", lastReplicaNodeName))
+	}
+	return result, err
 }


### PR DESCRIPTION
I've updated the STS labels to match Kubernetes naming conventions as well as adding the logic to remove NodePools no longer defined in the spec.

I've made the assumption that if a cluster admin removes the nodepool from the spec they don't need to gracefully drain it first.  Let me know if you think this is fair.