### PR TITLE
Do not create a namespace for each cluster

### DIFF
--- a/opensearch-operator/Makefile
+++ b/opensearch-operator/Makefile
@@ -48,7 +48,7 @@ fmt: ## Run go fmt against code.
 	go fmt ./...
 
 lint:
-	docker run --rm --volume="${PROJECT_PATH}:/go/src/opensearch-operator" -w /go/src/opensearch-operator golangci/golangci-lint:v1.42-alpine golangci-lint run -E gofmt --skip-dirs=./vendor --deadline=3m
+	docker run --rm --volume="${PROJECT_PATH}:/go/src/opensearch-operator" -w /go/src/opensearch-operator golangci/golangci-lint:v1.42-alpine golangci-lint run -E gofmt --deadline=3m --skip-dirs=opensearch-gateway/responses
 
 vet: ## Run go vet against code.
 	go vet ./...

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -30,9 +30,6 @@ const (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 type GeneralConfig struct {
-
-	//+kubebuilder:default="opster-cluster"
-	ClusterName string `json:"clusterName,omitempty"`
 	//+kubebuilder:default=9200
 	HttpPort int32 `json:"httpPort,omitempty"`
 	//+kubebuilder:validation:Enum=Opensearch;Op;OP;os;opensearch

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -96,9 +96,6 @@ spec:
                 description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
                   Important: Run "make" to regenerate code after modifying this file'
                 properties:
-                  clusterName:
-                    default: opster-cluster
-                    type: string
                   httpPort:
                     default: 9200
                     format: int32

--- a/opensearch-operator/controllers/cluster_test.go
+++ b/opensearch-operator/controllers/cluster_test.go
@@ -7,7 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	sts "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	//+kubebuilder:scaffold:imports
@@ -16,44 +16,34 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var _ = Describe("OpensearchCluster Controller", func() {
-	//	ctx := context.Background()
+var _ = Describe("Cluster Reconciler", func() {
 
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
-		ClusterName       = "cluster-test-cluster"
-		ClusterNameSpaces = "default"
-		timeout           = time.Second * 30
-		interval          = time.Second * 1
+		clusterName = "cluster-test-cluster"
+		namespace   = clusterName
+		timeout     = time.Second * 30
+		interval    = time.Second * 1
 	)
 	var (
-		OpensearchCluster = ComposeOpensearchCrd(ClusterName, ClusterNameSpaces)
-		nodePool          = sts.StatefulSet{}
+		OpensearchCluster = ComposeOpensearchCrd(clusterName, namespace)
+		nodePool          = appsv1.StatefulSet{}
 		service           = corev1.Service{}
-		//deploy            = sts.Deployment{}
-		//cluster           = opsterv1.OpenSearchCluster{}
-		//cluster2 = opsterv1.OpenSearchCluster{}
 	)
 
 	/// ------- Creation Check phase -------
 
-	ns := ComposeNs(ClusterName)
-	Context("When create OpenSearch CRD instance", func() {
-		It("should create cluster NS and CRD instance", func() {
-
-			Expect(k8sClient.Create(context.Background(), &OpensearchCluster)).Should(Succeed())
-			fmt.Println(OpensearchCluster)
-
+	Context("When creating a OpenSearch CRD instance", func() {
+		It("Should create the namespace first", func() {
+			Expect(CreateNamespace(k8sClient, &OpensearchCluster)).Should(Succeed())
 			By("Create cluster ns ")
 			Eventually(func() bool {
-				if !IsNsCreated(k8sClient, ns) {
-					return false
-				}
-				if !IsClusterCreated(k8sClient, OpensearchCluster) {
-					return false
-				}
-				return true
+				return IsNsCreated(k8sClient, namespace)
 			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should apply the cluster instance successfully", func() {
+			Expect(k8sClient.Create(context.Background(), &OpensearchCluster)).Should(Succeed())
 		})
 	})
 
@@ -61,24 +51,20 @@ var _ = Describe("OpensearchCluster Controller", func() {
 
 	Context("When creating a OpenSearchCluster kind Instance", func() {
 		It("should create a new opensearch cluster ", func() {
-
-			By("Opensearch cluster")
 			Eventually(func() bool {
-
-				if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: ClusterName, Name: OpensearchCluster.Spec.General.ServiceName}, &service); err != nil {
+				if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: clusterName, Name: OpensearchCluster.Spec.General.ServiceName}, &service); err != nil {
 					return false
 				}
 				for _, name := range []string{"master", "nodes", "client"} {
-					if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: ClusterName, Name: fmt.Sprintf("%s-%s", OpensearchCluster.Spec.General.ServiceName, name)}, &service); err != nil {
+					if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: clusterName, Name: fmt.Sprintf("%s-%s", OpensearchCluster.Spec.General.ServiceName, name)}, &service); err != nil {
 						return false
 					}
 				}
 				for _, nodePoolSpec := range OpensearchCluster.Spec.NodePools {
-					if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: ClusterName, Name: ClusterName + "-" + nodePoolSpec.Component}, &nodePool); err != nil {
+					if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: clusterName, Name: clusterName + "-" + nodePoolSpec.Component}, &nodePool); err != nil {
 						return false
 					}
 				}
-
 				return true
 			}, timeout, interval).Should(BeTrue())
 		})
@@ -87,13 +73,16 @@ var _ = Describe("OpensearchCluster Controller", func() {
 	/// ------- Deletion Check phase -------
 
 	Context("When deleting OpenSearch CRD ", func() {
-		It("should delete cluster NS and resources", func() {
-
+		It("should delete cluster resources", func() {
 			Expect(k8sClient.Delete(context.Background(), &OpensearchCluster)).Should(Succeed())
 
-			By("Delete cluster ns ")
 			Eventually(func() bool {
-				return IsNsDeleted(k8sClient, ns)
+				for _, nodePool := range OpensearchCluster.Spec.NodePools {
+					if !IsSTSDeleted(k8sClient, clusterName+"-"+nodePool.Component, clusterName) {
+						return false
+					}
+				}
+				return IsServiceDeleted(k8sClient, OpensearchCluster.Spec.General.ServiceName, clusterName)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/opensearch-operator/controllers/dashboard_test.go
+++ b/opensearch-operator/controllers/dashboard_test.go
@@ -74,21 +74,10 @@ var _ = Describe("Dashboards Reconciler", func() {
 				return true
 			}, timeout, interval).Should(BeTrue())
 		})
-	})
-
-	/// ------- Deletion Check phase -------
-
-	Context("When deleting OpenSearch CRD ", func() {
-		It("should delete cluster resources", func() {
-			Expect(k8sClient.Delete(context.Background(), &OpensearchCluster)).Should(Succeed())
-
-			Eventually(func() bool {
-				if !IsDeploymentDeleted(k8sClient, clusterName+"-dashboards", clusterName) {
-					return false
-				}
-				return IsServiceDeleted(k8sClient, clusterName+"-dashboards", clusterName)
-			}, timeout, interval).Should(BeTrue())
+		It("should set correct owner references", func() {
+			Expect(HasOwnerReference(&deploy, &OpensearchCluster)).To(BeTrue())
+			Expect(HasOwnerReference(&cm, &OpensearchCluster)).To(BeTrue())
+			Expect(HasOwnerReference(&service, &OpensearchCluster)).To(BeTrue())
 		})
 	})
-
 })

--- a/opensearch-operator/controllers/dashboard_test.go
+++ b/opensearch-operator/controllers/dashboard_test.go
@@ -17,43 +17,35 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var _ = Describe("OpensearchCluster Controller", func() {
-	//	ctx := context.Background()
+var _ = Describe("Dashboards Reconciler", func() {
 
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
-		ClusterName       = "cluster-test-dash"
-		ClusterNameSpaces = "default"
-		timeout           = time.Second * 30
-		interval          = time.Second * 1
+		clusterName = "cluster-test-dash"
+		namespace   = clusterName
+		timeout     = time.Second * 30
+		interval    = time.Second * 1
 	)
 	var (
-		OpensearchCluster = ComposeOpensearchCrd(ClusterName, ClusterNameSpaces)
+		OpensearchCluster = ComposeOpensearchCrd(clusterName, namespace)
 		cm                = corev1.ConfigMap{}
-		//	nodePool          = sts.StatefulSet{}
-		service = corev1.Service{}
-		deploy  = sts.Deployment{}
-		//cluster           = opsterv1.OpenSearchCluster{}
-		//cluster2 = opsterv1.OpenSearchCluster{}
+		service           = corev1.Service{}
+		deploy            = sts.Deployment{}
 	)
 
 	/// ------- Creation Check phase -------
 
-	ns := ComposeNs(ClusterName)
 	Context("When create OpenSearch CRD - dash", func() {
-		It("should create cluster NS", func() {
-			Expect(k8sClient.Create(context.Background(), &OpensearchCluster)).Should(Succeed())
+		It("Should create the namespace first", func() {
+			Expect(CreateNamespace(k8sClient, &OpensearchCluster)).Should(Succeed())
 			By("Create cluster ns ")
 			Eventually(func() bool {
-
-				if !IsNsCreated(k8sClient, ns) {
-					return false
-				}
-				if !IsClusterCreated(k8sClient, OpensearchCluster) {
-					return false
-				}
-				return true
+				return IsNsCreated(k8sClient, namespace)
 			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should apply the cluster instance successfully", func() {
+			Expect(k8sClient.Create(context.Background(), &OpensearchCluster)).Should(Succeed())
 		})
 	})
 
@@ -69,13 +61,13 @@ var _ = Describe("OpensearchCluster Controller", func() {
 				fmt.Println("\n DAShBOARD - START - 2")
 				//// -------- Dashboard tests ---------
 				if OpensearchCluster.Spec.Dashboards.Enable {
-					if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: ClusterName, Name: ClusterName + "-dashboards"}, &deploy); err != nil {
+					if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: clusterName, Name: clusterName + "-dashboards"}, &deploy); err != nil {
 						return false
 					}
-					if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: ClusterName, Name: ClusterName + "-dashboards-config"}, &cm); err != nil {
+					if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: clusterName, Name: clusterName + "-dashboards-config"}, &cm); err != nil {
 						return false
 					}
-					if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: ClusterName, Name: OpensearchCluster.Spec.General.ServiceName + "-dashboards"}, &service); err != nil {
+					if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: clusterName, Name: OpensearchCluster.Spec.General.ServiceName + "-dashboards"}, &service); err != nil {
 						return false
 					}
 				}
@@ -87,14 +79,14 @@ var _ = Describe("OpensearchCluster Controller", func() {
 	/// ------- Deletion Check phase -------
 
 	Context("When deleting OpenSearch CRD ", func() {
-		It("should delete cluster NS and resources", func() {
-
+		It("should delete cluster resources", func() {
 			Expect(k8sClient.Delete(context.Background(), &OpensearchCluster)).Should(Succeed())
 
-			By("Delete cluster ns ")
 			Eventually(func() bool {
-				fmt.Println("\n check ns dashboard")
-				return IsNsDeleted(k8sClient, ns)
+				if !IsDeploymentDeleted(k8sClient, clusterName+"-dashboards", clusterName) {
+					return false
+				}
+				return IsServiceDeleted(k8sClient, clusterName+"-dashboards", clusterName)
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/opensearch-operator/controllers/opensearchController.go
+++ b/opensearch-operator/controllers/opensearchController.go
@@ -21,11 +21,9 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
-	"opensearch.opster.io/pkg/builders"
 	"opensearch.opster.io/pkg/helpers"
 	"opensearch.opster.io/pkg/reconcilers"
 
@@ -104,10 +102,10 @@ func (r *OpenSearchClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	} else {
 		if helpers.ContainsString(r.Instance.GetFinalizers(), myFinalizerName) {
 			// our finalizer is present, so lets handle any external dependency
-			if err := r.deleteExternalResources(r.Instance); err != nil {
+			if result, err := r.deleteExternalResources(ctx); err != nil {
 				// if fail to delete the external dependency here, return with error
 				// so that it can be retried
-				return ctrl.Result{}, err
+				return result, err
 			}
 
 			// remove our finalizer from the list and update it.
@@ -121,8 +119,8 @@ func (r *OpenSearchClusterReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			return ctrl.Result{}, nil
 		}
+		return ctrl.Result{}, nil
 	}
 
 	/// if crd not deleted started phase 1
@@ -149,17 +147,53 @@ func (r *OpenSearchClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // delete associated cluster resources //
-func (r *OpenSearchClusterReconciler) deleteExternalResources(cluster *opsterv1.OpenSearchCluster) error {
-	namespace := cluster.Spec.General.ClusterName
-	nsToDel := builders.NewNsForCR(cluster)
+func (r *OpenSearchClusterReconciler) deleteExternalResources(ctx context.Context) (ctrl.Result, error) {
+	r.Logger.Info("Deleting resources")
+	// Run through all sub controllers to delete existing objects
+	reconcilerContext := reconcilers.NewReconcilerContext()
 
-	r.Logger.Info("Cluster has been deleted. Deleting namespace")
-	err := r.Delete(context.TODO(), nsToDel)
-	if err != nil {
-		return err
+	tls := reconcilers.NewTLSReconciler(
+		r.Client,
+		ctx,
+		&reconcilerContext,
+		r.Instance,
+	)
+	config := reconcilers.NewConfigurationReconciler(
+		r.Client,
+		ctx,
+		r.Recorder,
+		&reconcilerContext,
+		r.Instance,
+	)
+	cluster := reconcilers.NewClusterReconciler(
+		r.Client,
+		ctx,
+		r.Recorder,
+		&reconcilerContext,
+		r.Instance,
+	)
+	dashboards := reconcilers.NewDashboardsReconciler(
+		r.Client,
+		ctx,
+		r.Recorder,
+		&reconcilerContext,
+		r.Instance,
+	)
+
+	componentReconcilers := []reconcilers.ComponentReconciler{
+		tls.DeleteResources,
+		config.DeleteResources,
+		cluster.DeleteResources,
+		dashboards.DeleteResources,
 	}
-	r.Logger.Info("Namespace deleted successfully", "namespace", namespace)
-	return nil
+	for _, rec := range componentReconcilers {
+		result, err := rec()
+		if err != nil || result.Requeue {
+			return result, err
+		}
+	}
+	r.Logger.Info("Finished deleting resources")
+	return ctrl.Result{}, nil
 }
 
 func (r *OpenSearchClusterReconciler) reconcilePhasePending(ctx context.Context) (ctrl.Result, error) {
@@ -186,19 +220,6 @@ func (r *OpenSearchClusterReconciler) reconcilePhasePending(ctx context.Context)
 }
 
 func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context) (ctrl.Result, error) {
-
-	/// ------ Create NameSpace -------
-	ns_query := &corev1.Namespace{}
-	// try to see if the ns already exists
-	err := r.Get(ctx, client.ObjectKey{Name: r.Instance.Spec.General.ClusterName}, ns_query)
-	if errors.IsNotFound(err) {
-		result, err := r.createNamespace(r.Instance)
-		if err != nil {
-			return result, err
-		}
-	} else if err != nil {
-		return ctrl.Result{}, err
-	}
 
 	// Run through all sub controllers to create or update all needed objects
 	reconcilerContext := reconcilers.NewReconcilerContext()
@@ -254,17 +275,4 @@ func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context)
 
 	// -------- all resources has been created -----------
 	return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
-}
-
-func (r *OpenSearchClusterReconciler) createNamespace(instance *opsterv1.OpenSearchCluster) (ctrl.Result, error) {
-	ns := builders.NewNsForCR(instance)
-	err := r.Create(context.TODO(), ns)
-	if err != nil {
-		// if ns cannot create ,  inform it and done reconcile
-		r.Logger.Error(err, "Failed to create namespace")
-		r.Recorder.Event(r.Instance, "Warning", "Cannot create Namespace for cluster", "requeuing - fix the problem that you have with creating Namespace for cluster")
-		return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
-	}
-	r.Logger.Info("Namespace created successfully", "namespace", ns.Name)
-	return ctrl.Result{}, nil
 }

--- a/opensearch-operator/controllers/scaler_test.go
+++ b/opensearch-operator/controllers/scaler_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	sts "k8s.io/api/apps/v1"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
 	opsterv1 "opensearch.opster.io/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,61 +17,63 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var _ = Describe("OpensearchCLuster Controller", func() {
-	//	ctx := context.Background()
+var _ = Describe("Scaler Reconciler", func() {
 
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
-		ClusterName = "cluster-test-nodes"
-		NameSpace   = "default"
+		clusterName = "cluster-test-nodes"
+		namespace   = clusterName
 		timeout     = time.Second * 30
 		interval    = time.Second * 1
 	)
 	var (
-		OpensearchCluster = ComposeOpensearchCrd(ClusterName, NameSpace)
+		OpensearchCluster = ComposeOpensearchCrd(clusterName, namespace)
 		nodePool          = sts.StatefulSet{}
 		cluster2          = opsterv1.OpenSearchCluster{}
 	)
 
 	/// ------- Creation Check phase -------
 
-	ns := ComposeNs(ClusterName)
 	Context("When create OpenSearch CRD - nodes", func() {
-		It("should create cluster NS and CRD instance", func() {
-			Expect(k8sClient.Create(context.Background(), &OpensearchCluster)).Should(Succeed())
+		It("Should create the namespace first", func() {
+			Expect(CreateNamespace(k8sClient, &OpensearchCluster)).Should(Succeed())
 			By("Create cluster ns ")
 			Eventually(func() bool {
-				if !IsNsCreated(k8sClient, ns) {
-					return false
-				}
-				if !IsClusterCreated(k8sClient, OpensearchCluster) {
-					return false
-				}
-				return true
+				return IsNsCreated(k8sClient, namespace)
 			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should apply the cluster instance successfully", func() {
+			Expect(k8sClient.Create(context.Background(), &OpensearchCluster)).Should(Succeed())
 		})
 	})
 
 	/// ------- Tests logic Check phase -------
 
 	Context("When changing Opensearch NodePool Replicas", func() {
-		It("should to add new status about the operation", func() {
-
-			Expect(k8sClient.Get(context.Background(), client.ObjectKey{Namespace: OpensearchCluster.Namespace, Name: OpensearchCluster.Name}, &OpensearchCluster)).Should(Succeed())
-
-			newRep := OpensearchCluster.Spec.NodePools[0].Replicas - 1
-			OpensearchCluster.Spec.NodePools[0].Replicas = newRep
-
-			status := len(OpensearchCluster.Status.ComponentsStatus)
-			Expect(k8sClient.Update(context.Background(), &OpensearchCluster)).Should(Succeed())
-
-			By("ComponentsStatus checker ")
+		It("should add a new status about the operation", func() {
+			By("Wait for cluster instance to be created")
 			Eventually(func() bool {
-				if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: OpensearchCluster.Namespace, Name: OpensearchCluster.Name}, &cluster2); err != nil {
+				return k8sClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: OpensearchCluster.Name}, &OpensearchCluster) == nil
+			}, time.Second*10, interval).Should(BeTrue())
+			By("Update replicas")
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: OpensearchCluster.Name}, &OpensearchCluster); err != nil {
+					return err
+				}
+				OpensearchCluster.Spec.NodePools[0].Replicas = 2
+
+				return k8sClient.Update(context.Background(), &OpensearchCluster)
+			})
+			Expect(err).ToNot(HaveOccurred())
+			status := len(OpensearchCluster.Status.ComponentsStatus)
+
+			By("Check ComponentsStatus")
+			Eventually(func() bool {
+				if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: OpensearchCluster.Name}, &cluster2); err != nil {
 					return false
 				}
-				newStatuss := len(cluster2.Status.ComponentsStatus)
-				return status != newStatuss
+				return status != len(cluster2.Status.ComponentsStatus)
 			}, time.Second*60, 30*time.Millisecond).Should(BeFalse())
 		})
 	})
@@ -79,10 +82,10 @@ var _ = Describe("OpensearchCLuster Controller", func() {
 		It("should implement new number of replicas to the cluster", func() {
 			By("check replicas")
 			Eventually(func() bool {
-				if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: ClusterName, Name: ClusterName + "-" + cluster2.Spec.NodePools[0].Component}, &nodePool); err != nil {
+				if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: clusterName + "-" + cluster2.Spec.NodePools[0].Component}, &nodePool); err != nil {
 					return false
 				}
-				if pointer.Int32Deref(nodePool.Spec.Replicas, 1) != cluster2.Spec.NodePools[0].Replicas {
+				if pointer.Int32Deref(nodePool.Spec.Replicas, 1) != 2 {
 					return false
 				}
 				return true
@@ -93,13 +96,16 @@ var _ = Describe("OpensearchCLuster Controller", func() {
 	/// ------- Deletion Check phase -------
 
 	Context("When deleting OpenSearch CRD ", func() {
-		It("should delete cluster NS and resources", func() {
-
+		It("should delete cluster resources", func() {
 			Expect(k8sClient.Delete(context.Background(), &OpensearchCluster)).Should(Succeed())
 
-			By("Delete cluster ns ")
 			Eventually(func() bool {
-				return IsNsDeleted(k8sClient, ns)
+				for _, nodePool := range OpensearchCluster.Spec.NodePools {
+					if !IsSTSDeleted(k8sClient, clusterName+"-"+nodePool.Component, namespace) {
+						return false
+					}
+				}
+				return true
 			}, timeout, interval).Should(BeTrue())
 		})
 	})

--- a/opensearch-operator/controllers/suite_test_helpers.go
+++ b/opensearch-operator/controllers/suite_test_helpers.go
@@ -2,11 +2,18 @@ package controllers
 
 import (
 	"context"
+
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	opsterv1 "opensearch.opster.io/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+func CreateNamespace(k8sClient client.Client, cluster *opsterv1.OpenSearchCluster) error {
+	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.Spec.General.ClusterName}}
+	return k8sClient.Create(context.Background(), &ns)
+}
 
 func IsCreated(ctx context.Context, k8sClient client.Client, obj client.Object) bool {
 	if err := k8sClient.Get(ctx, client.ObjectKey{
@@ -26,25 +33,46 @@ func IsNsDeleted(k8sClient client.Client, namespace corev1.Namespace) bool {
 	return true
 }
 
-func IsNsCreated(k8sClient client.Client, namespace corev1.Namespace) bool {
+func IsNsCreated(k8sClient client.Client, name string) bool {
 	ns := corev1.Namespace{}
-	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: namespace.Name}, &ns); err == nil {
+	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: name}, &ns); err == nil {
 		return true
 	} else {
 		return false
 	}
 }
 
-func IsClusterCreated(k8sClient client.Client, cluster opsterv1.OpenSearchCluster) bool {
-	ns := corev1.Namespace{}
-	if err := k8sClient.Get(context.Background(), client.ObjectKey{Name: cluster.Name, Namespace: cluster.Namespace}, &ns); err == nil {
-		return true
-	} else {
-		return false
-	}
+func IsSTSDeleted(k8sClient client.Client, name string, namespace string) bool {
+	sts := appsv1.StatefulSet{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, &sts)
+	return err != nil
 }
 
-func ComposeOpensearchCrd(ClusterName string, ClusterNameSpaces string) opsterv1.OpenSearchCluster {
+func IsDeploymentDeleted(k8sClient client.Client, name string, namespace string) bool {
+	deployment := appsv1.Deployment{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, &deployment)
+	return err != nil
+}
+
+func IsServiceDeleted(k8sClient client.Client, name string, namespace string) bool {
+	service := corev1.Service{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, &service)
+	return err != nil
+}
+
+func IsSecretDeleted(k8sClient client.Client, name string, namespace string) bool {
+	service := corev1.Secret{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, &service)
+	return err != nil
+}
+
+func IsConfigMapDeleted(k8sClient client.Client, name string, namespace string) bool {
+	service := corev1.ConfigMap{}
+	err := k8sClient.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, &service)
+	return err != nil
+}
+
+func ComposeOpensearchCrd(clusterName string, namespace string) opsterv1.OpenSearchCluster {
 
 	OpensearchCluster := &opsterv1.OpenSearchCluster{
 		TypeMeta: metav1.TypeMeta{
@@ -52,12 +80,12 @@ func ComposeOpensearchCrd(ClusterName string, ClusterNameSpaces string) opsterv1
 			APIVersion: "opensearch.opster.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ClusterName,
-			Namespace: ClusterNameSpaces,
+			Name:      clusterName,
+			Namespace: namespace,
 		},
 		Spec: opsterv1.ClusterSpec{
 			General: opsterv1.GeneralConfig{
-				ClusterName: ClusterName,
+				ClusterName: clusterName,
 				HttpPort:    9200,
 				Vendor:      "opensearch",
 				Version:     "latest",
@@ -113,13 +141,4 @@ func ComposeOpensearchCrd(ClusterName string, ClusterNameSpaces string) opsterv1
 	}
 	return *OpensearchCluster
 
-}
-
-func ComposeNs(name string) corev1.Namespace {
-
-	return corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-	}
 }

--- a/opensearch-operator/controllers/suite_test_helpers.go
+++ b/opensearch-operator/controllers/suite_test_helpers.go
@@ -11,7 +11,7 @@ import (
 )
 
 func CreateNamespace(k8sClient client.Client, cluster *opsterv1.OpenSearchCluster) error {
-	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.Spec.General.ClusterName}}
+	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.Name}}
 	return k8sClient.Create(context.Background(), &ns)
 }
 
@@ -85,7 +85,6 @@ func ComposeOpensearchCrd(clusterName string, namespace string) opsterv1.OpenSea
 		},
 		Spec: opsterv1.ClusterSpec{
 			General: opsterv1.GeneralConfig{
-				ClusterName: clusterName,
 				HttpPort:    9200,
 				Vendor:      "opensearch",
 				Version:     "latest",

--- a/opensearch-operator/controllers/suite_test_helpers.go
+++ b/opensearch-operator/controllers/suite_test_helpers.go
@@ -72,6 +72,15 @@ func IsConfigMapDeleted(k8sClient client.Client, name string, namespace string) 
 	return err != nil
 }
 
+func HasOwnerReference(object client.Object, owner *opsterv1.OpenSearchCluster) bool {
+	for _, ownerRef := range object.GetOwnerReferences() {
+		if ownerRef.Name == owner.ObjectMeta.Name {
+			return true
+		}
+	}
+	return false
+}
+
 func ComposeOpensearchCrd(clusterName string, namespace string) opsterv1.OpenSearchCluster {
 
 	OpensearchCluster := &opsterv1.OpenSearchCluster{

--- a/opensearch-operator/controllers/tls_test.go
+++ b/opensearch-operator/controllers/tls_test.go
@@ -17,54 +17,78 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var _ = Describe("OpensearchCluster Controller", func() {
-	//	ctx := context.Background()
+var _ = Describe("TLS Reconciler", func() {
 
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
-		ClusterName       = "cluster-test-dash"
-		ClusterNameSpaces = "default"
-		timeout           = time.Second * 30
-		interval          = time.Second * 1
+		clusterName = "cluster-test-tls"
+		namespace   = clusterName
+		timeout     = time.Second * 30
+		interval    = time.Second * 1
 	)
 	Context("When Creating an OpenSearchCluster with TLS configured", func() {
-		It("Should start a cluster successfully", func() {
-			clusterName := "tls-cluster"
-			spec := opsterv1.OpenSearchCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: "default"},
-				Spec: opsterv1.ClusterSpec{
-					General: opsterv1.GeneralConfig{ClusterName: clusterName, ServiceName: clusterName},
-					Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
-						Transport: &opsterv1.TlsConfigTransport{
-							Generate: true,
-							PerNode:  true,
-						},
-						Http: &opsterv1.TlsConfigHttp{
-							Generate: true,
-						},
-					}},
-					NodePools: []opsterv1.NodePool{
-						{
-							Component: "masters",
-							Replicas:  3,
-							Roles:     []string{"master", "data"},
-						},
+		spec := opsterv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: namespace},
+			Spec: opsterv1.ClusterSpec{
+				General: opsterv1.GeneralConfig{ClusterName: clusterName, ServiceName: clusterName},
+				Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
+					Transport: &opsterv1.TlsConfigTransport{
+						Generate: true,
+						PerNode:  true,
 					},
-				}}
-			Expect(k8sClient.Create(context.Background(), &spec)).Should(Succeed())
+					Http: &opsterv1.TlsConfigHttp{
+						Generate: true,
+					},
+				}},
+				NodePools: []opsterv1.NodePool{
+					{
+						Component: "masters",
+						Replicas:  3,
+						Roles:     []string{"master", "data"},
+					},
+				},
+			}}
 
+		It("Should create the namespace first", func() {
+			Expect(CreateNamespace(k8sClient, &spec)).Should(Succeed())
+			By("Create cluster ns ")
+			Eventually(func() bool {
+				return IsNsCreated(k8sClient, namespace)
+			}, timeout, interval).Should(BeTrue())
+		})
+
+		It("should apply the cluster instance successfully", func() {
+			Expect(k8sClient.Create(context.Background(), &spec)).Should(Succeed())
+		})
+
+		It("Should start a cluster successfully", func() {
 			By("Checking for Statefulset")
 			sts := appsv1.StatefulSet{}
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: clusterName + "-masters", Namespace: clusterName}, &sts)
+				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: clusterName + "-masters", Namespace: namespace}, &sts)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 			Expect(*sts.Spec.Replicas).To(Equal(int32(3)))
 			Expect(helpers.CheckVolumeExists(sts.Spec.Template.Spec.Volumes, sts.Spec.Template.Spec.Containers[0].VolumeMounts, clusterName+"-transport-cert", "transport-cert")).Should((BeTrue()))
 			Expect(helpers.CheckVolumeExists(sts.Spec.Template.Spec.Volumes, sts.Spec.Template.Spec.Containers[0].VolumeMounts, clusterName+"-http-cert", "http-cert")).Should((BeTrue()))
 			Expect(helpers.CheckVolumeExists(sts.Spec.Template.Spec.Volumes, sts.Spec.Template.Spec.Containers[0].VolumeMounts, clusterName+"-config", "config")).Should((BeTrue()))
-			// Cleanup
+		})
+
+		It("Should cleanup successfully", func() {
 			Expect(k8sClient.Delete(context.Background(), &spec)).Should(Succeed())
+
+			Eventually(func() bool {
+				if !IsConfigMapDeleted(k8sClient, clusterName+"-config", namespace) {
+					return false
+				}
+				if !IsSecretDeleted(k8sClient, clusterName+"-http-cert", namespace) {
+					return false
+				}
+				if !IsSecretDeleted(k8sClient, clusterName+"-transport-cert", namespace) {
+					return false
+				}
+				return IsSecretDeleted(k8sClient, clusterName+"-ca", namespace)
+			}, timeout, interval).Should(BeTrue())
 		})
 	})
 

--- a/opensearch-operator/controllers/tls_test.go
+++ b/opensearch-operator/controllers/tls_test.go
@@ -30,7 +30,7 @@ var _ = Describe("TLS Reconciler", func() {
 		spec := opsterv1.OpenSearchCluster{
 			ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: namespace},
 			Spec: opsterv1.ClusterSpec{
-				General: opsterv1.GeneralConfig{ClusterName: clusterName, ServiceName: clusterName},
+				General: opsterv1.GeneralConfig{ServiceName: clusterName},
 				Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
 					Transport: &opsterv1.TlsConfigTransport{
 						Generate: true,

--- a/opensearch-operator/opensearch-cluster.yaml
+++ b/opensearch-operator/opensearch-cluster.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: default
 spec:
   general:
-    clusterName: my-cluster
     httpPort: 9200
     vendor: opensearch
     version: latest
@@ -25,8 +24,8 @@ spec:
       replicas: 3
       diskSize: 30
       NodeSelector:
-      cpu: 4
-      memory: 16
+      cpu: 1
+      memory: 1
       roles:
         - "master"
         - "data"
@@ -34,14 +33,14 @@ spec:
       replicas: 3
       diskSize: 100
       NodeSelector:
-      cpu: 4
-      memory: 16
+      cpu: 1
+      memory: 1
       roles:
         - "data"
     - component: coordinators
       replicas: 3
       diskSize: 100
       NodeSelector:
-      cpu: 4
+      cpu: 1
       roles:
         - "ingest"

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -95,7 +95,7 @@ func NewSTSForNodePool(cr *opsterv1.OpenSearchCluster, node opsterv1.NodePool, v
 
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Spec.General.ClusterName + "-" + node.Component,
+			Name:      cr.Name + "-" + node.Component,
 			Namespace: cr.Namespace,
 			Labels:    labels,
 		},
@@ -125,7 +125,7 @@ func NewSTSForNodePool(cr *opsterv1.OpenSearchCluster, node opsterv1.NodePool, v
 								},
 								{
 									Name:  "cluster.name",
-									Value: cr.Spec.General.ClusterName,
+									Value: cr.Name,
 								},
 								{
 									Name:  "network.bind_host",
@@ -344,7 +344,7 @@ func DnsOfService(cr *opsterv1.OpenSearchCluster) string {
 }
 
 func StsName(cr *opsterv1.OpenSearchCluster, nodePool *opsterv1.NodePool) string {
-	return cr.Spec.General.ClusterName + "-" + nodePool.Component
+	return cr.Name + "-" + nodePool.Component
 }
 func UsernameAndPassword(cr *opsterv1.OpenSearchCluster) (string, string) {
 	return "admin", "admin"

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -96,7 +96,7 @@ func NewSTSForNodePool(cr *opsterv1.OpenSearchCluster, node opsterv1.NodePool, v
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Spec.General.ClusterName + "-" + node.Component,
-			Namespace: cr.Spec.General.ClusterName,
+			Namespace: cr.Namespace,
 			Labels:    labels,
 		},
 		Spec: appsv1.StatefulSetSpec{
@@ -205,7 +205,7 @@ func NewHeadlessServiceForNodePool(cr *opsterv1.OpenSearchCluster, nodePool *ops
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%s", cr.Spec.General.ServiceName, nodePool.Component),
-			Namespace: cr.Spec.General.ClusterName,
+			Namespace: cr.Namespace,
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
@@ -248,7 +248,7 @@ func NewServiceForCR(cr *opsterv1.OpenSearchCluster) *corev1.Service {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Spec.General.ServiceName,
-			Namespace: cr.Spec.General.ClusterName,
+			Namespace: cr.Namespace,
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
@@ -295,28 +295,6 @@ func NewServiceForCR(cr *opsterv1.OpenSearchCluster) *corev1.Service {
 	}
 }
 
-func NewNsForCR(cr *opsterv1.OpenSearchCluster) *corev1.Namespace {
-
-	return &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: cr.Spec.General.ClusterName,
-		},
-	}
-}
-
-func NewCmForCR(cr *opsterv1.OpenSearchCluster) *corev1.ConfigMap {
-
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "opensearch-yml",
-			Namespace: cr.Spec.General.ClusterName,
-		},
-		Data: map[string]string{
-			"opensearch.yml": " plugins:\n        security:\n          allow_default_init_securityindex: true\n          allow_unsafe_democertificates: true\n          audit.type: internal_opensearch\n          authcz:\n            admin_dn:\n            - CN=kirk,OU=client,O=client,L=test, C=de\n          check_snapshot_restore_write_privileges: true\n          enable_snapshot_restore_privilege: true\n          restapi:\n            roles_enabled:\n            - all_access\n            - security_rest_api_access\n          ssl:\n            http:\n              enabled: true\n              pemcert_filepath: esnode.pem\n              pemkey_filepath: esnode-key.pem\n              pemtrustedcas_filepath: root-ca.pem\n            transport:\n              enforce_hostname_verification: false\n              pemcert_filepath: esnode.pem\n              pemkey_filepath: esnode-key.pem\n              pemtrustedcas_filepath: root-ca.pem\n          system_indices:\n            enabled: true\n            indices:\n            - .opendistro-alerting-config\n            - .opendistro-alerting-alert*\n            - .opendistro-anomaly-results*\n            - .opendistro-anomaly-detector*\n            - .opendistro-anomaly-checkpoints\n            - .opendistro-anomaly-detection-state\n            - .opendistro-reports-*\n            - .opendistro-notifications-*\n            - .opendistro-notebooks\n            - .opendistro-asynchronous-search-response*",
-		},
-	}
-}
-
 func NewNodePortService(cr *opsterv1.OpenSearchCluster) *corev1.Service {
 	labels := map[string]string{
 		"opensearch.cluster": cr.Name,
@@ -329,7 +307,7 @@ func NewNodePortService(cr *opsterv1.OpenSearchCluster) *corev1.Service {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Spec.General.ServiceName + "-exposed",
-			Namespace: cr.Spec.General.ClusterName,
+			Namespace: cr.Namespace,
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{
@@ -362,7 +340,7 @@ func URLForCluster(cr *opsterv1.OpenSearchCluster) string {
 }
 
 func DnsOfService(cr *opsterv1.OpenSearchCluster) string {
-	return fmt.Sprintf("%s.%s", cr.Spec.General.ServiceName, cr.Spec.General.ClusterName)
+	return fmt.Sprintf("%s.%s", cr.Spec.General.ServiceName, cr.Namespace)
 }
 
 func StsName(cr *opsterv1.OpenSearchCluster, nodePool *opsterv1.NodePool) string {

--- a/opensearch-operator/pkg/builders/dashboards.go
+++ b/opensearch-operator/pkg/builders/dashboards.go
@@ -23,7 +23,7 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				DefaultMode:          &mode,
-				LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-dashboards-config", cr.Spec.General.ClusterName)},
+				LocalObjectReference: corev1.LocalObjectReference{Name: fmt.Sprintf("%s-dashboards-config", cr.Name)},
 			},
 		},
 	})
@@ -51,7 +51,7 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 
 	return &sts.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      cr.Spec.General.ClusterName + "-dashboards",
+			Name:      cr.Name + "-dashboards",
 			Namespace: cr.Namespace,
 			Labels:    labels,
 		},
@@ -109,7 +109,7 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 }
 
 func NewDashboardsConfigMapForCR(cr *opsterv1.OpenSearchCluster, name string, config map[string]string) *corev1.ConfigMap {
-	config["server.name"] = cr.Spec.General.ClusterName + "-dashboards"
+	config["server.name"] = cr.Name + "-dashboards"
 	config["opensearch.ssl.verificationMode"] = "none"
 
 	var sb strings.Builder

--- a/opensearch-operator/pkg/builders/dashboards.go
+++ b/opensearch-operator/pkg/builders/dashboards.go
@@ -52,7 +52,7 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 	return &sts.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Spec.General.ClusterName + "-dashboards",
-			Namespace: cr.Spec.General.ClusterName,
+			Namespace: cr.Namespace,
 			Labels:    labels,
 		},
 		Spec: sts.DeploymentSpec{
@@ -121,7 +121,7 @@ func NewDashboardsConfigMapForCR(cr *opsterv1.OpenSearchCluster, name string, co
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: cr.Spec.General.ClusterName,
+			Namespace: cr.Namespace,
 		},
 		Data: map[string]string{
 			"opensearch_dashboards.yml": data,
@@ -144,7 +144,7 @@ func NewDashboardsSvcForCr(cr *opsterv1.OpenSearchCluster) *corev1.Service {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Spec.General.ServiceName + "-dashboards",
-			Namespace: cr.Spec.General.ClusterName,
+			Namespace: cr.Namespace,
 			Labels:    labels,
 		},
 		Spec: corev1.ServiceSpec{

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -45,29 +45,6 @@ func GetField(v *sts.StatefulSetSpec, field string) interface{} {
 	return f
 }
 
-//func setField(v *sts.StatefulSetSpec, field string) reflect.Value {
-//
-//	//	reflect.ValueOf(v).Elem().FieldByName(field).SetString("sss")
-//
-//	r := reflect.ValueOf(v)
-//	ty := r.Type()
-//	fmt.Println(ty)
-//	f := reflect.Indirect(r).FieldByName(field)
-//	return f
-//}
-
-func getNamesInStruct(inter interface{}) []string {
-	rv := reflect.Indirect(reflect.ValueOf(inter))
-
-	var names []string
-
-	for i := 0; i < rv.NumField(); i++ {
-		x := rv.Type().Field(i).Name
-		names = append(names, x)
-	}
-	return names
-}
-
 func RemoveIt(ss opsterv1.ComponentStatus, ssSlice []opsterv1.ComponentStatus) []opsterv1.ComponentStatus {
 	for idx, v := range ssSlice {
 		if v == ss {

--- a/opensearch-operator/pkg/helpers/reconcile-helpers.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers.go
@@ -9,61 +9,12 @@ import (
 	opsterv1 "opensearch.opster.io/api/v1"
 )
 
-func CheckUpdates(sts_env sts.StatefulSetSpec, sts_crd sts.StatefulSetSpec, instance *opsterv1.OpenSearchCluster, count int, check string) (x sts.StatefulSetSpec, err error, changes []string) {
-
-	fields := getNamesInStruct(sts_env)
-	changes = []string{}
-
-	//type fields_changes struct{
-	//	nodegroup string `json:"nodegroup,omitempty"`
-	//	change []string `json:"changes,omitempty"`
-	//}
-	//changes := []fields_changes{}
-
-	for i := 0; i < len(fields); i++ {
-
-		field := fields[i]
-		field_env := GetField(&sts_env, field)
-		field_env_int_ptr, ok := field_env.(*int32)
-		if !ok {
-			fmt.Println(!ok)
-			return sts_env, err, changes
-		}
-		if field_env_int_ptr == nil {
-			return sts_env, err, changes
-		}
-		field_env_int := *field_env_int_ptr
-
-		field_crd := GetField(&sts_crd, field)
-		field_crd_int_ptr, ok := field_crd.(*int32)
-		if !ok {
-			fmt.Println(!ok)
-			return sts_env, err, changes
-		}
-		if field_crd_int_ptr == nil {
-			return sts_env, err, changes
-		}
-		field_crd_int := *field_crd_int_ptr
-
-		// Check if sts replica count from cluster is equal to what configured in CRD
-		if field_env_int != field_crd_int {
-			//if not equal - change env replica count to what configured in CRD
-			changes = append(changes, field)
-
-			//scaled := true
-			//fmt.Println("You scaled - Replicas on " + instance.Spec.General.ClusterName + "-" + instance.Spec.nodePools[count].Component)
-		}
-	}
-	return sts_env, nil, changes
-
-}
-
 func CreateInitMasters(cr *opsterv1.OpenSearchCluster) string {
 	var masters []string
 	for _, nodePool := range cr.Spec.NodePools {
 		if ContainsString(nodePool.Roles, "master") {
 			for i := 0; int32(i) < nodePool.Replicas; i++ {
-				masters = append(masters, fmt.Sprintf("%s-%s-%d", cr.Spec.General.ClusterName, nodePool.Component, i))
+				masters = append(masters, fmt.Sprintf("%s-%s-%d", cr.Name, nodePool.Component, i))
 			}
 		}
 	}

--- a/opensearch-operator/pkg/helpers/test-helpers.go
+++ b/opensearch-operator/pkg/helpers/test-helpers.go
@@ -57,6 +57,7 @@ func (cert *CertMock) SecretDataCA() map[string][]byte {
 		"ca.key": []byte("ca.key"),
 	}
 }
+
 func (cert *CertMock) SecretData(ca tls.Cert) map[string][]byte {
 	return map[string][]byte{
 		"ca.crt":  []byte("ca.crt"),
@@ -64,12 +65,15 @@ func (cert *CertMock) SecretData(ca tls.Cert) map[string][]byte {
 		"tls.crt": []byte("tls.crt"),
 	}
 }
+
 func (cert *CertMock) KeyData() []byte {
 	return []byte("tls.key")
 }
+
 func (cert *CertMock) CertData() []byte {
 	return []byte("tls.crt")
 }
+
 func (ca *CertMock) CreateAndSignCertificate(commonName string, orgUnit string, dnsnames []string) (cert tls.Cert, err error) {
 	return &CertMock{}, nil
 }
@@ -77,6 +81,7 @@ func (ca *CertMock) CreateAndSignCertificate(commonName string, orgUnit string, 
 func (pki *PkiMock) GenerateCA(name string) (ca tls.Cert, err error) {
 	return &CertMock{}, nil
 }
+
 func (pki *PkiMock) CAFromSecret(data map[string][]byte) tls.Cert {
 	return &CertMock{}
 }

--- a/opensearch-operator/pkg/helpers/test-helpers.go
+++ b/opensearch-operator/pkg/helpers/test-helpers.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"opensearch.opster.io/pkg/tls"
 )
 
 // A simple mock to use whenever a record.EventRecorder is needed for a test
@@ -42,4 +43,44 @@ func CheckVolumeExists(volumes []corev1.Volume, volumeMounts []corev1.VolumeMoun
 func HasKeyWithBytes(data map[string][]byte, key string) bool {
 	_, exists := data[key]
 	return exists
+}
+
+type PkiMock struct {
+}
+
+type CertMock struct {
+}
+
+func (cert *CertMock) SecretDataCA() map[string][]byte {
+	return map[string][]byte{
+		"ca.crt": []byte("ca.crt"),
+		"ca.key": []byte("ca.key"),
+	}
+}
+func (cert *CertMock) SecretData(ca tls.Cert) map[string][]byte {
+	return map[string][]byte{
+		"ca.crt":  []byte("ca.crt"),
+		"tls.key": []byte("tls.key"),
+		"tls.crt": []byte("tls.crt"),
+	}
+}
+func (cert *CertMock) KeyData() []byte {
+	return []byte("tls.key")
+}
+func (cert *CertMock) CertData() []byte {
+	return []byte("tls.crt")
+}
+func (ca *CertMock) CreateAndSignCertificate(commonName string, orgUnit string, dnsnames []string) (cert tls.Cert, err error) {
+	return &CertMock{}, nil
+}
+
+func (pki *PkiMock) GenerateCA(name string) (ca tls.Cert, err error) {
+	return &CertMock{}, nil
+}
+func (pki *PkiMock) CAFromSecret(data map[string][]byte) tls.Cert {
+	return &CertMock{}
+}
+
+func NewMockPKI() tls.PKI {
+	return &PkiMock{}
 }

--- a/opensearch-operator/pkg/reconcilers/configuration.go
+++ b/opensearch-operator/pkg/reconcilers/configuration.go
@@ -96,7 +96,7 @@ func (r *ConfigurationReconciler) buildConfigMap() *corev1.ConfigMap {
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-config", r.instance.Spec.General.ClusterName),
+			Name:      fmt.Sprintf("%s-config", r.instance.Name),
 			Namespace: r.instance.Namespace,
 		},
 		Data: map[string]string{

--- a/opensearch-operator/pkg/reconcilers/configuration.go
+++ b/opensearch-operator/pkg/reconcilers/configuration.go
@@ -57,6 +57,9 @@ func (r *ConfigurationReconciler) Reconcile() (ctrl.Result, error) {
 	r.reconcilerContext.AddConfig("plugins.security.system_indices.indices", `[".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]`)
 
 	cm := r.buildConfigMap()
+	if err := ctrl.SetControllerReference(r.instance, cm, r.Client.Scheme()); err != nil {
+		return ctrl.Result{}, err
+	}
 	result, err := r.ReconcileResource(cm, reconciler.StatePresent)
 	if err != nil {
 		r.recorder.Event(r.instance, "Warning", "Cannot create Configmap ", "Requeue - Fix the problem you have on main Opensearch ConfigMap")
@@ -106,7 +109,5 @@ func (r *ConfigurationReconciler) buildConfigMap() *corev1.ConfigMap {
 }
 
 func (r *ConfigurationReconciler) DeleteResources() (ctrl.Result, error) {
-	cm := r.buildConfigMap()
-	_, err := r.ReconcileResource(cm, reconciler.StateAbsent)
-	return ctrl.Result{}, err
+	return ctrl.Result{}, nil
 }

--- a/opensearch-operator/pkg/reconcilers/configuration.go
+++ b/opensearch-operator/pkg/reconcilers/configuration.go
@@ -97,10 +97,16 @@ func (r *ConfigurationReconciler) buildConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-config", r.instance.Spec.General.ClusterName),
-			Namespace: r.instance.Spec.General.ClusterName,
+			Namespace: r.instance.Namespace,
 		},
 		Data: map[string]string{
 			"opensearch.yml": data,
 		},
 	}
+}
+
+func (r *ConfigurationReconciler) DeleteResources() (ctrl.Result, error) {
+	cm := r.buildConfigMap()
+	_, err := r.ReconcileResource(cm, reconciler.StateAbsent)
+	return ctrl.Result{}, err
 }

--- a/opensearch-operator/pkg/reconcilers/configuration_test.go
+++ b/opensearch-operator/pkg/reconcilers/configuration_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Configuration Controller", func() {
 		It("should not create a configmap ", func() {
 			spec := opsterv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
-				Spec:       opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{ClusterName: clusterName}}}
+				Spec:       opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{}}}
 
 			reconcilerContext := NewReconcilerContext()
 
@@ -54,7 +54,7 @@ var _ = Describe("Configuration Controller", func() {
 
 			spec := opsterv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
-				Spec:       opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{ClusterName: clusterName}}}
+				Spec:       opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{}}}
 
 			reconcilerContext := NewReconcilerContext()
 

--- a/opensearch-operator/pkg/reconcilers/configuration_test.go
+++ b/opensearch-operator/pkg/reconcilers/configuration_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Configuration Controller", func() {
 	Context("When Reconciling the configuration controller with no configuration snippets", func() {
 		It("should not create a configmap ", func() {
 			spec := opsterv1.OpenSearchCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
 				Spec:       opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{}}}
 
 			reconcilerContext := NewReconcilerContext()
@@ -53,7 +53,7 @@ var _ = Describe("Configuration Controller", func() {
 			Expect(CreateNamespace(k8sClient, clusterName)).Should(Succeed())
 
 			spec := opsterv1.OpenSearchCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
 				Spec:       opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{}}}
 
 			reconcilerContext := NewReconcilerContext()

--- a/opensearch-operator/pkg/reconcilers/configuration_test.go
+++ b/opensearch-operator/pkg/reconcilers/configuration_test.go
@@ -26,7 +26,9 @@ var _ = Describe("Configuration Controller", func() {
 
 	Context("When Reconciling the configuration controller with no configuration snippets", func() {
 		It("should not create a configmap ", func() {
-			spec := opsterv1.OpenSearchCluster{Spec: opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{ClusterName: clusterName}}}
+			spec := opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				Spec:       opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{ClusterName: clusterName}}}
 
 			reconcilerContext := NewReconcilerContext()
 
@@ -48,14 +50,11 @@ var _ = Describe("Configuration Controller", func() {
 
 	Context("When Reconciling the configuration controller with some configuration snippets", func() {
 		It("should create a configmap ", func() {
-			ns := corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: clusterName,
-				},
-			}
-			err := k8sClient.Create(context.Background(), &ns)
-			Expect(err).ToNot(HaveOccurred())
-			spec := opsterv1.OpenSearchCluster{Spec: opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{ClusterName: clusterName}}}
+			Expect(CreateNamespace(k8sClient, clusterName)).Should(Succeed())
+
+			spec := opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				Spec:       opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{ClusterName: clusterName}}}
 
 			reconcilerContext := NewReconcilerContext()
 
@@ -69,7 +68,7 @@ var _ = Describe("Configuration Controller", func() {
 			reconcilerContext.AddConfig("foo", "bar")
 			reconcilerContext.AddConfig("bar", "something")
 			reconcilerContext.AddConfig("bar", "baz")
-			_, err = underTest.Reconcile()
+			_, err := underTest.Reconcile()
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() bool {

--- a/opensearch-operator/pkg/reconcilers/dashboards.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards.go
@@ -61,7 +61,7 @@ func (r *DashboardsReconciler) Reconcile() (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 
-	cm := builders.NewDashboardsConfigMapForCR(r.instance, fmt.Sprintf("%s-dashboards-config", r.instance.Spec.General.ClusterName), r.reconcilerContext.DashboardsConfig)
+	cm := builders.NewDashboardsConfigMapForCR(r.instance, fmt.Sprintf("%s-dashboards-config", r.instance.Name), r.reconcilerContext.DashboardsConfig)
 	result.Combine(r.ReconcileResource(cm, reconciler.StatePresent))
 
 	deployment := builders.NewDashboardsDeploymentForCR(r.instance, volumes, volumeMounts)
@@ -77,7 +77,7 @@ func (r *DashboardsReconciler) handleTls() ([]corev1.Volume, []corev1.VolumeMoun
 	if r.instance.Spec.Dashboards.Tls == nil || !r.instance.Spec.Dashboards.Tls.Enable {
 		return nil, nil, nil
 	}
-	clusterName := r.instance.Spec.General.ClusterName
+	clusterName := r.instance.Name
 	namespace := r.instance.Namespace
 	caSecretName := clusterName + "-ca"
 	tlsSecretName := clusterName + "-dashboards-cert"
@@ -179,7 +179,7 @@ func (r *DashboardsReconciler) caCert(secretName string, namespace string, clust
 }
 
 func (r *DashboardsReconciler) DeleteResources() (ctrl.Result, error) {
-	clusterName := r.instance.Spec.General.ClusterName
+	clusterName := r.instance.Name
 	namespace := r.instance.Namespace
 	tlsSecretName := clusterName + "-dashboards-cert"
 	result := reconciler.CombinedResult{}
@@ -192,7 +192,7 @@ func (r *DashboardsReconciler) DeleteResources() (ctrl.Result, error) {
 	deployment := builders.NewDashboardsDeploymentForCR(r.instance, volumes, volumeMounts)
 	result.Combine(r.ReconcileResource(deployment, reconciler.StateAbsent))
 
-	cm := builders.NewDashboardsConfigMapForCR(r.instance, fmt.Sprintf("%s-dashboards-config", r.instance.Spec.General.ClusterName), r.reconcilerContext.DashboardsConfig)
+	cm := builders.NewDashboardsConfigMapForCR(r.instance, fmt.Sprintf("%s-dashboards-config", clusterName), r.reconcilerContext.DashboardsConfig)
 	result.Combine(r.ReconcileResource(cm, reconciler.StateAbsent))
 
 	svc := builders.NewDashboardsSvcForCr(r.instance)

--- a/opensearch-operator/pkg/reconcilers/dashboards_test.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Dashboards Reconciler", func() {
 			Expect(CreateNamespace(k8sClient, clusterName)).Should(Succeed())
 
 			spec := opsterv1.OpenSearchCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
 				Spec: opsterv1.ClusterSpec{
 					General: opsterv1.GeneralConfig{ServiceName: clusterName},
 					Dashboards: opsterv1.DashboardsConfig{
@@ -80,7 +80,7 @@ var _ = Describe("Dashboards Reconciler", func() {
 			Expect(CreateNamespace(k8sClient, clusterName)).Should(Succeed())
 
 			spec := opsterv1.OpenSearchCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
 				Spec: opsterv1.ClusterSpec{
 					General: opsterv1.GeneralConfig{ServiceName: clusterName},
 					Dashboards: opsterv1.DashboardsConfig{
@@ -111,7 +111,7 @@ var _ = Describe("Dashboards Reconciler", func() {
 		It("should create a cert", func() {
 			clusterName := "dashboards-test-generate"
 			spec := opsterv1.OpenSearchCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
 				Spec: opsterv1.ClusterSpec{
 					General: opsterv1.GeneralConfig{ServiceName: clusterName},
 					Dashboards: opsterv1.DashboardsConfig{

--- a/opensearch-operator/pkg/reconcilers/dashboards_test.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards_test.go
@@ -2,7 +2,6 @@ package reconcilers
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -19,6 +18,19 @@ import (
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+func newDashboardsReconciler(spec *opsterv1.OpenSearchCluster) (ReconcilerContext, *DashboardsReconciler) {
+	reconcilerContext := NewReconcilerContext()
+	underTest := NewDashboardsReconciler(
+		k8sClient,
+		context.Background(),
+		&helpers.MockEventRecorder{},
+		&reconcilerContext,
+		spec,
+	)
+	underTest.pki = helpers.NewMockPKI()
+	return reconcilerContext, underTest
+}
 
 var _ = Describe("Dashboards Reconciler", func() {
 	// Define utility constants for object names and testing timeouts/durations and intervals.
@@ -47,18 +59,10 @@ var _ = Describe("Dashboards Reconciler", func() {
 					Name: clusterName,
 				},
 			}
-			fmt.Printf("%s", k8sClient)
 			err := k8sClient.Create(context.Background(), &ns)
 			Expect(err).ToNot(HaveOccurred())
 
-			reconcilerContext := NewReconcilerContext()
-			underTest := NewDashboardsReconciler(
-				k8sClient,
-				context.Background(),
-				&helpers.MockEventRecorder{},
-				&reconcilerContext,
-				&spec,
-			)
+			_, underTest := newDashboardsReconciler(&spec)
 			_, err = underTest.Reconcile()
 			Expect(err).ToNot(HaveOccurred())
 			deployment := appsv1.Deployment{}
@@ -92,17 +96,9 @@ var _ = Describe("Dashboards Reconciler", func() {
 					Name: clusterName,
 				},
 			}
-			fmt.Printf("%s", k8sClient)
 			err := k8sClient.Create(context.Background(), &ns)
 			Expect(err).ToNot(HaveOccurred())
-			reconcilerContext := NewReconcilerContext()
-			underTest := NewDashboardsReconciler(
-				k8sClient,
-				context.Background(),
-				&helpers.MockEventRecorder{},
-				&reconcilerContext,
-				&spec,
-			)
+			_, underTest := newDashboardsReconciler(&spec)
 			_, err = underTest.Reconcile()
 			Expect(err).ToNot(HaveOccurred())
 			deployment := appsv1.Deployment{}
@@ -133,17 +129,10 @@ var _ = Describe("Dashboards Reconciler", func() {
 					Name: clusterName,
 				},
 			}
-			fmt.Printf("%s", k8sClient)
 			err := k8sClient.Create(context.Background(), &ns)
 			Expect(err).ToNot(HaveOccurred())
-			reconcilerContext := NewReconcilerContext()
-			underTest := NewDashboardsReconciler(
-				k8sClient,
-				context.Background(),
-				&helpers.MockEventRecorder{},
-				&reconcilerContext,
-				&spec,
-			)
+			_, underTest := newDashboardsReconciler(&spec)
+			underTest.pki = helpers.NewMockPKI()
 			_, err = underTest.Reconcile()
 			Expect(err).ToNot(HaveOccurred())
 			// Check if secret is mounted

--- a/opensearch-operator/pkg/reconcilers/dashboards_test.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Dashboards Reconciler", func() {
 			spec := opsterv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
 				Spec: opsterv1.ClusterSpec{
-					General: opsterv1.GeneralConfig{ClusterName: clusterName, ServiceName: clusterName},
+					General: opsterv1.GeneralConfig{ServiceName: clusterName},
 					Dashboards: opsterv1.DashboardsConfig{
 						Enable: true,
 						Tls: &opsterv1.DashboardsTlsConfig{
@@ -82,7 +82,7 @@ var _ = Describe("Dashboards Reconciler", func() {
 			spec := opsterv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
 				Spec: opsterv1.ClusterSpec{
-					General: opsterv1.GeneralConfig{ClusterName: clusterName, ServiceName: clusterName},
+					General: opsterv1.GeneralConfig{ServiceName: clusterName},
 					Dashboards: opsterv1.DashboardsConfig{
 						Enable: true,
 						Tls: &opsterv1.DashboardsTlsConfig{
@@ -113,7 +113,7 @@ var _ = Describe("Dashboards Reconciler", func() {
 			spec := opsterv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
 				Spec: opsterv1.ClusterSpec{
-					General: opsterv1.GeneralConfig{ClusterName: clusterName, ServiceName: clusterName},
+					General: opsterv1.GeneralConfig{ServiceName: clusterName},
 					Dashboards: opsterv1.DashboardsConfig{
 						Enable: true,
 						Tls: &opsterv1.DashboardsTlsConfig{

--- a/opensearch-operator/pkg/reconcilers/dashboards_test.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards_test.go
@@ -43,27 +43,25 @@ var _ = Describe("Dashboards Reconciler", func() {
 		It("should mount the secret", func() {
 			clusterName := "dashboards-singlesecret"
 			secretName := "my-cert"
-			spec := opsterv1.OpenSearchCluster{Spec: opsterv1.ClusterSpec{
-				General: opsterv1.GeneralConfig{ClusterName: clusterName, ServiceName: clusterName},
-				Dashboards: opsterv1.DashboardsConfig{
-					Enable: true,
-					Tls: &opsterv1.DashboardsTlsConfig{
-						Enable:   true,
-						Generate: false,
-						Secret:   secretName,
+
+			Expect(CreateNamespace(k8sClient, clusterName)).Should(Succeed())
+
+			spec := opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				Spec: opsterv1.ClusterSpec{
+					General: opsterv1.GeneralConfig{ClusterName: clusterName, ServiceName: clusterName},
+					Dashboards: opsterv1.DashboardsConfig{
+						Enable: true,
+						Tls: &opsterv1.DashboardsTlsConfig{
+							Enable:   true,
+							Generate: false,
+							Secret:   secretName,
+						},
 					},
-				},
-			}}
-			ns := corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: clusterName,
-				},
-			}
-			err := k8sClient.Create(context.Background(), &ns)
-			Expect(err).ToNot(HaveOccurred())
+				}}
 
 			_, underTest := newDashboardsReconciler(&spec)
-			_, err = underTest.Reconcile()
+			_, err := underTest.Reconcile()
 			Expect(err).ToNot(HaveOccurred())
 			deployment := appsv1.Deployment{}
 			Eventually(func() bool {
@@ -79,27 +77,25 @@ var _ = Describe("Dashboards Reconciler", func() {
 			clusterName := "dashboards-test-multisecret"
 			keySecretName := "my-key"
 			certSecretName := "my-cert"
-			spec := opsterv1.OpenSearchCluster{Spec: opsterv1.ClusterSpec{
-				General: opsterv1.GeneralConfig{ClusterName: clusterName, ServiceName: clusterName},
-				Dashboards: opsterv1.DashboardsConfig{
-					Enable: true,
-					Tls: &opsterv1.DashboardsTlsConfig{
-						Enable:     true,
-						Generate:   false,
-						KeySecret:  &opsterv1.TlsSecret{SecretName: keySecretName},
-						CertSecret: &opsterv1.TlsSecret{SecretName: certSecretName},
+			Expect(CreateNamespace(k8sClient, clusterName)).Should(Succeed())
+
+			spec := opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				Spec: opsterv1.ClusterSpec{
+					General: opsterv1.GeneralConfig{ClusterName: clusterName, ServiceName: clusterName},
+					Dashboards: opsterv1.DashboardsConfig{
+						Enable: true,
+						Tls: &opsterv1.DashboardsTlsConfig{
+							Enable:     true,
+							Generate:   false,
+							KeySecret:  &opsterv1.TlsSecret{SecretName: keySecretName},
+							CertSecret: &opsterv1.TlsSecret{SecretName: certSecretName},
+						},
 					},
-				},
-			}}
-			ns := corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: clusterName,
-				},
-			}
-			err := k8sClient.Create(context.Background(), &ns)
-			Expect(err).ToNot(HaveOccurred())
+				}}
+
 			_, underTest := newDashboardsReconciler(&spec)
-			_, err = underTest.Reconcile()
+			_, err := underTest.Reconcile()
 			Expect(err).ToNot(HaveOccurred())
 			deployment := appsv1.Deployment{}
 			Eventually(func() bool {
@@ -114,16 +110,18 @@ var _ = Describe("Dashboards Reconciler", func() {
 	Context("When running the dashboards reconciler with TLS enabled and generate enabled", func() {
 		It("should create a cert", func() {
 			clusterName := "dashboards-test-generate"
-			spec := opsterv1.OpenSearchCluster{Spec: opsterv1.ClusterSpec{
-				General: opsterv1.GeneralConfig{ClusterName: clusterName, ServiceName: clusterName},
-				Dashboards: opsterv1.DashboardsConfig{
-					Enable: true,
-					Tls: &opsterv1.DashboardsTlsConfig{
-						Enable:   true,
-						Generate: true,
+			spec := opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				Spec: opsterv1.ClusterSpec{
+					General: opsterv1.GeneralConfig{ClusterName: clusterName, ServiceName: clusterName},
+					Dashboards: opsterv1.DashboardsConfig{
+						Enable: true,
+						Tls: &opsterv1.DashboardsTlsConfig{
+							Enable:   true,
+							Generate: true,
+						},
 					},
-				},
-			}}
+				}}
 			ns := corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: clusterName,

--- a/opensearch-operator/pkg/reconcilers/reconcilers.go
+++ b/opensearch-operator/pkg/reconcilers/reconcilers.go
@@ -27,7 +27,7 @@ func NewReconcilerContext() ReconcilerContext {
 func (c *ReconcilerContext) AddConfig(key string, value string) {
 	_, exists := c.OpenSearchConfig[key]
 	if exists {
-		fmt.Printf("Warning: Config key '%s' already exists. Will be overwritten", key)
+		fmt.Printf("Warning: Config key '%s' already exists. Will be overwritten\n", key)
 	}
 	c.OpenSearchConfig[key] = value
 }
@@ -35,7 +35,7 @@ func (c *ReconcilerContext) AddConfig(key string, value string) {
 func (c *ReconcilerContext) AddDashboardsConfig(key string, value string) {
 	_, exists := c.DashboardsConfig[key]
 	if exists {
-		fmt.Printf("Warning: Config key '%s' already exists. Will be overwritten", key)
+		fmt.Printf("Warning: Config key '%s' already exists. Will be overwritten\n", key)
 	}
 	c.DashboardsConfig[key] = value
 }

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -3,6 +3,7 @@ package reconcilers
 import (
 	"context"
 	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"opensearch.opster.io/opensearch-gateway/services"
@@ -59,7 +60,7 @@ func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 }
 
 func (r *ScalerReconciler) reconcileNodePool(nodePool *opsterv1.NodePool) (bool, error) {
-	namespace := r.instance.Spec.General.ClusterName
+	namespace := r.instance.Namespace
 	sts_name := builders.StsName(r.instance, nodePool)
 	currentSts := appsv1.StatefulSet{}
 	if err := r.Get(context.TODO(), client.ObjectKey{Name: sts_name, Namespace: namespace}, &currentSts); err != nil {
@@ -277,7 +278,7 @@ func getByDescriptionAndGroup(left opsterv1.ComponentStatus, right opsterv1.Comp
 
 func (r *ScalerReconciler) CreateNodePortServiceIfNotExists() (corev1.Service, bool, error) {
 	lg := log.FromContext(r.ctx)
-	namespace := r.instance.Spec.General.ClusterName
+	namespace := r.instance.Namespace
 	targetService := builders.NewNodePortService(r.instance)
 	existingService := corev1.Service{}
 	if err := r.Get(context.TODO(), client.ObjectKey{Name: targetService.Name, Namespace: namespace}, &existingService); err != nil {

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -282,6 +282,9 @@ func (r *ScalerReconciler) CreateNodePortServiceIfNotExists() (corev1.Service, b
 	targetService := builders.NewNodePortService(r.instance)
 	existingService := corev1.Service{}
 	if err := r.Get(context.TODO(), client.ObjectKey{Name: targetService.Name, Namespace: namespace}, &existingService); err != nil {
+		if err := ctrl.SetControllerReference(r.instance, targetService, r.Client.Scheme()); err != nil {
+			return *targetService, false, err
+		}
 		err = r.Create(context.TODO(), targetService)
 		if err != nil {
 			if !errors.IsAlreadyExists(err) {

--- a/opensearch-operator/pkg/reconcilers/suite_test.go
+++ b/opensearch-operator/pkg/reconcilers/suite_test.go
@@ -36,6 +36,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -125,3 +127,8 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
 })
+
+func CreateNamespace(k8sClient client.Client, name string) error {
+	ns := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	return k8sClient.Create(context.Background(), &ns)
+}

--- a/opensearch-operator/pkg/reconcilers/tls.go
+++ b/opensearch-operator/pkg/reconcilers/tls.go
@@ -99,7 +99,7 @@ func (r *TLSReconciler) handleTransport() error {
 func (r *TLSReconciler) handleAdminCertificate() error {
 	tlsConfig := r.instance.Spec.Security.Tls.Transport
 	namespace := r.instance.Namespace
-	clusterName := r.instance.Spec.General.ClusterName
+	clusterName := r.instance.Name
 	caSecretName := clusterName + "-ca"
 	adminSecretName := clusterName + "-admin-cert"
 
@@ -141,7 +141,7 @@ func (r *TLSReconciler) handleAdminCertificate() error {
 
 func (r *TLSReconciler) handleTransportGenerateGlobal() error {
 	namespace := r.instance.Namespace
-	clusterName := r.instance.Spec.General.ClusterName
+	clusterName := r.instance.Name
 	caSecretName := clusterName + "-ca"
 	nodeSecretName := clusterName + "-transport-cert"
 
@@ -197,7 +197,7 @@ func (r *TLSReconciler) handleTransportGeneratePerNode() error {
 	r.logger.Info("Generating certificates", "interface", "transport")
 
 	namespace := r.instance.Namespace
-	clusterName := r.instance.Spec.General.ClusterName
+	clusterName := r.instance.Name
 	caSecretName := clusterName + "-ca"
 	nodeSecretName := clusterName + "-transport-cert"
 
@@ -318,7 +318,7 @@ func (r *TLSReconciler) handleTransportExistingCerts() error {
 func (r *TLSReconciler) handleHttp() error {
 	tlsConfig := r.instance.Spec.Security.Tls.Http
 	namespace := r.instance.Namespace
-	clusterName := r.instance.Spec.General.ClusterName
+	clusterName := r.instance.Name
 	caSecretName := clusterName + "-ca"
 	nodeSecretName := clusterName + "-http-cert"
 
@@ -430,7 +430,7 @@ func mountFolder(interfaceName string, name string, secretName string, reconcile
 }
 
 func (r *TLSReconciler) DeleteResources() (ctrl.Result, error) {
-	clusterName := r.instance.Spec.General.ClusterName
+	clusterName := r.instance.Name
 	result := reconciler.CombinedResult{}
 	// Delete CA cert
 	secret := corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: r.instance.Namespace, Name: clusterName + "-ca"}}

--- a/opensearch-operator/pkg/reconcilers/tls_test.go
+++ b/opensearch-operator/pkg/reconcilers/tls_test.go
@@ -43,7 +43,7 @@ var _ = Describe("TLS Controller", func() {
 			httpSecretName := clusterName + "-http-cert"
 			adminSecretName := clusterName + "-admin-cert"
 			spec := opsterv1.OpenSearchCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
 				Spec: opsterv1.ClusterSpec{
 					General: opsterv1.GeneralConfig{},
 					Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
@@ -97,7 +97,7 @@ var _ = Describe("TLS Controller", func() {
 			httpSecretName := clusterName + "-http-cert"
 			adminSecretName := clusterName + "-admin-cert"
 			spec := opsterv1.OpenSearchCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
 				Spec: opsterv1.ClusterSpec{
 					General: opsterv1.GeneralConfig{},
 					Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
@@ -169,7 +169,7 @@ var _ = Describe("TLS Controller", func() {
 		It("Should not create secrets but only mount them", func() {
 			clusterName := "tls-test-existingsecrets"
 			spec := opsterv1.OpenSearchCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
 				Spec: opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{}, Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
 					Transport: &opsterv1.TlsConfigTransport{
 						Generate: false,
@@ -216,7 +216,7 @@ var _ = Describe("TLS Controller", func() {
 		It("Should not create secrets but only mount them", func() {
 			clusterName := "tls-test-existingsecretspernode"
 			spec := opsterv1.OpenSearchCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
 				Spec: opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{}, Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
 					Transport: &opsterv1.TlsConfigTransport{
 						Generate: false,
@@ -254,7 +254,7 @@ var _ = Describe("TLS Controller", func() {
 			clusterName := "tls-withca"
 			caSecretName := clusterName + "-myca"
 			spec := opsterv1.OpenSearchCluster{
-				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
 				Spec: opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{}, Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
 					Transport: &opsterv1.TlsConfigTransport{
 						Generate: true,

--- a/opensearch-operator/pkg/reconcilers/tls_test.go
+++ b/opensearch-operator/pkg/reconcilers/tls_test.go
@@ -45,7 +45,7 @@ var _ = Describe("TLS Controller", func() {
 			spec := opsterv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
 				Spec: opsterv1.ClusterSpec{
-					General: opsterv1.GeneralConfig{ClusterName: clusterName},
+					General: opsterv1.GeneralConfig{},
 					Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
 						Transport: &opsterv1.TlsConfigTransport{Generate: true},
 						Http:      &opsterv1.TlsConfigHttp{Generate: true},
@@ -99,7 +99,7 @@ var _ = Describe("TLS Controller", func() {
 			spec := opsterv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
 				Spec: opsterv1.ClusterSpec{
-					General: opsterv1.GeneralConfig{ClusterName: clusterName},
+					General: opsterv1.GeneralConfig{},
 					Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
 						Transport: &opsterv1.TlsConfigTransport{Generate: true, PerNode: true},
 						Http:      &opsterv1.TlsConfigHttp{Generate: true},
@@ -170,7 +170,7 @@ var _ = Describe("TLS Controller", func() {
 			clusterName := "tls-test-existingsecrets"
 			spec := opsterv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
-				Spec: opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{ClusterName: clusterName}, Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
+				Spec: opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{}, Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
 					Transport: &opsterv1.TlsConfigTransport{
 						Generate: false,
 						CertificateConfig: opsterv1.TlsCertificateConfig{
@@ -217,7 +217,7 @@ var _ = Describe("TLS Controller", func() {
 			clusterName := "tls-test-existingsecretspernode"
 			spec := opsterv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
-				Spec: opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{ClusterName: clusterName}, Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
+				Spec: opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{}, Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
 					Transport: &opsterv1.TlsConfigTransport{
 						Generate: false,
 						PerNode:  true,
@@ -255,7 +255,7 @@ var _ = Describe("TLS Controller", func() {
 			caSecretName := clusterName + "-myca"
 			spec := opsterv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName},
-				Spec: opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{ClusterName: clusterName}, Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
+				Spec: opsterv1.ClusterSpec{General: opsterv1.GeneralConfig{}, Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
 					Transport: &opsterv1.TlsConfigTransport{
 						Generate: true,
 						PerNode:  true,


### PR DESCRIPTION
Currently the operator is implemented to always create a separate namespace for each cluster. This leads to several problems:
* Many usecases (like multi-tenancy or restricted permissions) require resources to be created in specific existing namespaces
* Configmaps and secrets can only be referenced in the same namespace. This means if a user supplies e.g. a custom securityconfig the operator would have to copy the secret into the namespace of the cluster.
* In some situations the admin might not want to give the operator permission to create a namespace

This PR changes the behaviour of the operator to always create the objects for an opensearch cluster in the namespace of the custom resource. Is a user wants the old behaviour they need to create a new namespace beforehand and create the cluster CR in that namespace. The PR makes this sepcific usecase more complicated but supports more usecases/situations this way.
With this change the clusterName field is redundant as the combination name+namespace is unique and would probably lead to confusion why a user needs to supply two names (`meta.name` and `spec.general.clusterName`) so I removed it.

Detailed changes:
* Removed creation/deletion of namespace from controller
* Changed all reconcilers to use CR namespace as namespace for all objects
* Added a `DeleteResources` method to each reconciler to delete the objects created by the reconciler
* Changed tests to create namespace beforehand and not use namespace existence as proof of cluster creation
* Removed `clusterName` field and changed all reconcilers to use `meta.name`
* Changed tests for TLS reconciler to use mocks for all PKI/certificate functions to speed up the test run