### PR TITLE
Add field for extra config for opensearch.yml

### DIFF
--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -37,6 +37,8 @@ type GeneralConfig struct {
 	Version        string `json:"version,omitempty"`
 	ServiceAccount string `json:"serviceAccount,omitempty"`
 	ServiceName    string `json:"serviceName"`
+	// Extra items to add to the opensearch.yml
+	ExtraConfig string `json:"extraConfig,omitempty"`
 }
 
 type NodePool struct {

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -96,6 +96,9 @@ spec:
                 description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
                   Important: Run "make" to regenerate code after modifying this file'
                 properties:
+                  extraConfig:
+                    description: Extra items to add to the opensearch.yml
+                    type: string
                   httpPort:
                     default: 9200
                     format: int32

--- a/opensearch-operator/pkg/reconcilers/configuration.go
+++ b/opensearch-operator/pkg/reconcilers/configuration.go
@@ -44,17 +44,19 @@ func NewConfigurationReconciler(
 }
 
 func (r *ConfigurationReconciler) Reconcile() (ctrl.Result, error) {
-	if r.reconcilerContext.OpenSearchConfig == nil || len(r.reconcilerContext.OpenSearchConfig) == 0 {
+	if (r.reconcilerContext.OpenSearchConfig == nil || len(r.reconcilerContext.OpenSearchConfig) == 0) && r.instance.Spec.General.ExtraConfig == "" {
 		return ctrl.Result{}, nil
 	}
-	// Add some default config for the security plugin
-	r.reconcilerContext.AddConfig("plugins.security.audit.type", "internal_opensearch")
-	r.reconcilerContext.AddConfig("plugins.security.allow_default_init_securityindex", "true") // TODO: Remove after securityconfig is managed by controller
-	r.reconcilerContext.AddConfig("plugins.security.enable_snapshot_restore_privilege", "true")
-	r.reconcilerContext.AddConfig("plugins.security.check_snapshot_restore_write_privileges", "true")
-	r.reconcilerContext.AddConfig("plugins.security.restapi.roles_enabled", `["all_access", "security_rest_api_access"]`)
-	r.reconcilerContext.AddConfig("plugins.security.system_indices.enabled", "true")
-	r.reconcilerContext.AddConfig("plugins.security.system_indices.indices", `[".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]`)
+	if len(r.reconcilerContext.OpenSearchConfig) > 0 {
+		// Add some default config for the security plugin
+		r.reconcilerContext.AddConfig("plugins.security.audit.type", "internal_opensearch")
+		r.reconcilerContext.AddConfig("plugins.security.allow_default_init_securityindex", "true") // TODO: Remove after securityconfig is managed by controller
+		r.reconcilerContext.AddConfig("plugins.security.enable_snapshot_restore_privilege", "true")
+		r.reconcilerContext.AddConfig("plugins.security.check_snapshot_restore_write_privileges", "true")
+		r.reconcilerContext.AddConfig("plugins.security.restapi.roles_enabled", `["all_access", "security_rest_api_access"]`)
+		r.reconcilerContext.AddConfig("plugins.security.system_indices.enabled", "true")
+		r.reconcilerContext.AddConfig("plugins.security.system_indices.indices", `[".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]`)
+	}
 
 	cm := r.buildConfigMap()
 	if err := ctrl.SetControllerReference(r.instance, cm, r.Client.Scheme()); err != nil {
@@ -94,6 +96,10 @@ func (r *ConfigurationReconciler) buildConfigMap() *corev1.ConfigMap {
 	var sb strings.Builder
 	for key, value := range r.reconcilerContext.OpenSearchConfig {
 		sb.WriteString(fmt.Sprintf("%s: %s\n", key, value))
+	}
+	if r.instance.Spec.General.ExtraConfig != "" {
+		sb.WriteString(r.instance.Spec.General.ExtraConfig)
+		sb.WriteString("\n")
 	}
 	data := sb.String()
 


### PR DESCRIPTION
A user can use this field to add their own snippets to the `opensearch.yml` in addition to what the other reconcilers provide