### PR TITLE
Improve user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
 ![build](https://github.com/opster/opensearch-k8s-operator/actions/workflows/docker-build.yaml/badge.svg) ![test](https://github.com/opster/opensearch-k8s-operator/actions/workflows/testing.yaml/badge.svg)
 
 # OpenSearch-k8s-operator
+
 The Kubernetes OpenSearch Operator is used for automating the deployment, provisioning, management, and orchestration of OpenSearch clusters and OpenSearch dashboards.
 
-# Roadmap
-The full roadmap is available here: [Development plan](https://github.com/Opster/opensearch-k8s-operator/blob/main/docs/designs/dev-plan.md)
+## Getting started
 
-## The Operator features:
+The operator can be installed easily using helm on any CNCF-certified kubernetes cluster. Please refer to the [User Guide](./docs/userguide/main.md) for installation instructions.
+
+## Roadmap
+
+The full roadmap is available in the [Development plan](./docs/designs/dev-plan.md)
+
+Currently planned features:
+
 - [x] Deploy a new OS cluster.
 - [x] Ability to deploy multiple clusters.
 - [x] Spin up OS dashboards.
 - [x] Configuration of all node roles (master, data, coordinating..).
-- [x] Scale the cluster resources (manually), per nodes' role group. 
+- [x] Scale the cluster resources (manually), per nodes' role group.
 - [x] Drain strategy for scale down.
 - [x] Version updates.
 - [x] Change nodes' memory allocation and limits.
@@ -24,45 +31,30 @@ The full roadmap is available here: [Development plan](https://github.com/Opster
 - [ ] Operator Monitoring, with Prometheus and Grafana.
 - [ ] Control shard balancing and allocation: AZ/Rack awareness, Hot/Warm.
 
-# Getting Started
+## Development
 
-## Installing the Operator on your k8s cluster with Helm
-  ## Installing using the repo
-    - Clone the repo
-    - Run cd charts
-    - Helm install -f values.yaml [RELEASE_NAME] ./
-  
-  ## Installing using artifactHub.io
-    - helm repo add opensearch-operator https://opster.github.io/opensearch-k8s-operator-chart/
-    - helm install my-opensearch-operator opensearch-operator/opensearch-operator --version 1.2.0
+### Running the Operator locally
 
-
-## Installing the Operator locally
-
-- Clone the repo and go to `opensearch-operator` folder.
+- Clone the repo and go to the `opensearch-operator` folder.
 - Run `make build manifests` to build the controller binary and the manifests
 - Start a kubernetes cluster (e.g. with k3d or minikube) and make sure your `~/.kube/config` points to it
 - Run `make install` to create the CRD in the kubernetes cluster
+- Start the operator by running `make run`
 
-## Deploying a new OpenSearch cluster
+Now you can deploy an opensearch cluster.
 
-Go to `opensearch-operator` and use `opensearch-cluster.yaml` as a starting point to define your cluster - note that the `clusterName` is also the namespace that the new cluster will reside in. Then run:
+Go to `opensearch-operator` and use `opensearch-cluster.yaml` as a starting point to define your cluster. Then run:
 
 ```bash
 kubectl apply -f opensearch-cluster.yaml
 ```
 
-Note: the current installation deploys with the default demo certificate provided by OpenSearch.
-
-## Deleting an OpenSearch cluster
-
-In order to delete the cluster, please delete your OpenSearch cluster resource; this will delete the cluster namespace and all its resources.
+In order to delete the cluster, you just delete your OpenSearch cluster resource. This will delete the cluster and all its resources.
 
 ```bash
-kubectl get opensearchclusters --all-namespaces
-kubectl delete opensearchclusters my-cluster -n <namespace>
+kubectl delete -f opensearch-cluster.yaml
 ```
 
-# Contributions
+## Contributions
 
-We welcome contributions! See how you can get involved [here](https://github.com/opster/opensearch-k8s-operator/blob/main/CONTRIBUTING.md).
+We welcome contributions! See how you can get involved by reading [CONTRIBUTING.md](./CONTRIBUTING.md).


### PR DESCRIPTION
* Add short sections on installing the operator and `opensearch.yml` to the user guide
* Restructure README to be more clear and avoid duplicate information and link to the user guide