### PR TITLE
Adds tolerations to manager deployment

### DIFF
--- a/charts/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/charts/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -36,6 +36,10 @@ spec:
         name: operator-controller-manager
         resources:
           {{- toYaml .Values.manager.resources | nindent 12 }}
+        {{- with .Values.tolerations }}
+        tolerations:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
       nodeSelector:

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,6 +1,7 @@
 namespaceName: opensearch-operator-system
 nodeSelector: {}
 manager:
+  tolerations: []
   resources:
     limits:
       cpu: 2


### PR DESCRIPTION
For running the controller-manager on tainted nodes a nodeSelector can be used in combination with a toleration.