### PR TITLE
adding ability to configure opensearch_dashboards.yml

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -133,6 +133,27 @@ Using `spec.general.additionalConfig` you can add settings to all nodes, using `
 
 As of right now the settings cannot be changed after the initial installation of the cluster (that feature is planned for the next version). If you need to change any settings please use the [Cluster Settings API](https://opensearch.org/docs/latest/opensearch/configuration/#update-cluster-settings-using-the-api) to change them at runtime.
 
+## Configuring opensearch_dashboards.yml
+
+You can customize the OpenSearch dashboard configuration file [`opensearch_dashboards.yml`](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/config/opensearch_dashboards.yml) using the `additionalConfig` field in the dashboards section of the `OpenSearchCluster` custom resource:
+
+```yaml
+apiVersion: opensearch.opster.io/v1
+kind: OpenSearchCluster
+...
+spec:
+  dashboards:
+    additionalConfig:
+      opensearch_security.auth.type: "proxy"
+      opensearch.requestHeadersWhitelist: |
+        ["securitytenant","Authorization","x-forwarded-for","x-auth-request-access-token", "x-auth-request-email", "x-auth-request-groups"]
+      opensearch_security.multitenancy.enabled: "true"
+```
+
+This allows one to set up any of the [backend](https://opensearch.org/docs/latest/security-plugin/configuration/configuration/) authentication types for the dashboard.
+
+*The configuration must be valid or the dashboard will fail to start.*
+
 ## TLS
 
 For security reasons communication with the opensearch cluster and between cluster nodes is only done encrypted. If you do not configure anything opensearch will use included demo TLS certificates that are not suited for real deployments.
@@ -159,7 +180,7 @@ spec:
           name:  # Name of the secret that contains the provided certificate
         caSecret:
           name:  # Name of the secret that contains a CA the operator should use
-        nodesDn: []  # List of certificate DNs allowed to connect 
+        nodesDn: []  # List of certificate DNs allowed to connect
         adminDn: []  # List of certificate DNs that should get admin access
 # ...
 ```

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -90,6 +90,8 @@ type DashboardsConfig struct {
 	Replicas  int32                       `json:"replicas"`
 	Tls       *DashboardsTlsConfig        `json:"tls,omitempty"`
 	Version   string                      `json:"version"`
+	// Additional properties for opensearch_dashboards.yaml
+	AdditionalConfig map[string]string `json:"additionalConfig,omitempty"`
 	// Secret that contains fields username and password for dashboards to use to login to opensearch, must only be supplied if a custom securityconfig is provided
 	OpensearchCredentialsSecret corev1.LocalObjectReference `json:"opensearchCredentialsSecret,omitempty"`
 }

--- a/opensearch-operator/api/v1/zz_generated.deepcopy.go
+++ b/opensearch-operator/api/v1/zz_generated.deepcopy.go
@@ -115,6 +115,13 @@ func (in *DashboardsConfig) DeepCopyInto(out *DashboardsConfig) {
 		*out = new(DashboardsTlsConfig)
 		**out = **in
 	}
+	if in.AdditionalConfig != nil {
+		in, out := &in.AdditionalConfig, &out.AdditionalConfig
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	out.OpensearchCredentialsSecret = in.OpensearchCredentialsSecret
 }
 

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -53,6 +53,11 @@ spec:
                 type: object
               dashboards:
                 properties:
+                  additionalConfig:
+                    additionalProperties:
+                      type: string
+                    description: Additional properties for opensearch_dashboards.yaml
+                    type: object
                   enable:
                     type: boolean
                   opensearchCredentialsSecret:

--- a/opensearch-operator/pkg/reconcilers/dashboards.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards.go
@@ -61,6 +61,11 @@ func (r *DashboardsReconciler) Reconcile() (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 
+	// add any aditional dashboard config to the reconciler context
+	for key, value := range r.instance.Spec.Dashboards.AdditionalConfig {
+		r.reconcilerContext.AddDashboardsConfig(key, value)
+	}
+
 	cm := builders.NewDashboardsConfigMapForCR(r.instance, fmt.Sprintf("%s-dashboards-config", r.instance.Name), r.reconcilerContext.DashboardsConfig)
 	result.CombineErr(ctrl.SetControllerReference(r.instance, cm, r.Client.Scheme()))
 	result.Combine(r.ReconcileResource(cm, reconciler.StatePresent))


### PR DESCRIPTION
Hi, this PR makes it possible to add [Backend Configuration](https://opensearch.org/docs/latest/security-plugin/configuration/configuration/) to `opensearch_dashbaords.yaml` using a `spec.dashboards.additionalConfig` property in the CRD. 