### PR TITLE
Add option to restrict opensearch operator to  watch a desired namespace

### DIFF
--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -29,6 +29,9 @@ spec:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
+        {{- if .Values.manager.watchNamespace }}
+        - --watch-namespace={{ .Values.manager.watchNamespace }}
+        {{- end }}
         command:
         - /manager
         image: "{{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}"

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -11,3 +11,6 @@ manager:
   image:
     repository: public.ecr.aws/opsterio/opensearch-operator
     tag: latest
+  # If a watchNamespace is specified, the manager's cache will be restricted to
+  # watch objects in the desired namespace. Defaults is to watch all namespaces.
+  watchNamespace:

--- a/opensearch-operator/main.go
+++ b/opensearch-operator/main.go
@@ -53,11 +53,14 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
+	var watchNamespace string
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&watchNamespace, "watch-namespace", "",
+		"The namespace that controller manager is restricted to watch. If not set, default is to watch all namespaces.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -73,6 +76,7 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "a867c7dc.opensearch.opster.io",
+		Namespace:              watchNamespace,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
**_Task_** Optionally restrict the opensearch operator to watch a specific namespace.

**_Scenarios 1_**  When a k8s cluster has 100 namespaces and each namespace holds one opensearch cluster. If there is only one opensearch operator to manager all 100 opensearch clusters, it will take a lot time to sync all of them. 

**_Scenarios 2_** With a single operator to control all the opensearch clusters within the same k8s cluster, you won't have the flexibility to upgrade, downgrade, or pin down certain opensearch clusters. 
In production, sometimes users need to run opensearch clusters with different favors - stable, canary, and long term support images within a k8s cluster.

**_Solution_** To solve the issues from both scenarios, we can deploy a opensearch operator to each namespace and each operator will be restricted to only manager the opensearch cluster within the same namespace.
When each namespace contains it's own opensearch operator and opensearch cluster, we can selectively upgrade/downgrade some of the namespaces with different opensearch opertor and cluster images. Or even pin down certain namespaces with current older version and upgrade the rest to latest.

**_watchNamespace_**
The watchNamespace can be set during helm deployment in values.yaml `manager.watchNamespace`, and past to the operator as env variable `--watch-namespace={{ .Values.manager.watchNamespace }}`, then has the operator to start the controller manager with `Namespace` option.
```
### sigs.k8s.io manager/manager.go
	// Namespace if specified restricts the manager's cache to watch objects in
	// the desired namespace Defaults to all namespaces
	Namespace string
```

**Note** In our production system, our operator used to watch all the CRs from all namespaces. After we grew our CRs/namespaces to few tens, we got hit really hard by the performance. We decided to change our design and used local (namespaced) operator few years ago. With that solution, we have been syncing of our applications every 30s and running different image favors on all our k8s fleets.