### PR TITLE
Fix examples using OpenSearch 2.0.0 instead of 1.3.2

### DIFF
--- a/opensearch-operator/examples/opensearch-cluster-securityconfig.yaml
+++ b/opensearch-operator/examples/opensearch-cluster-securityconfig.yaml
@@ -5,13 +5,12 @@ metadata:
   namespace: default
 spec:
   general:
-    version: 1.3.0
+    version: 1.3.2
     httpPort: 9200
     vendor: opensearch
-    version: latest
     serviceName: my-cluster
   dashboards:
-    version: 1.3.0
+    version: 1.3.2
     enable: true
     replicas: 2
     resources:

--- a/opensearch-operator/examples/opensearch-cluster.yaml
+++ b/opensearch-operator/examples/opensearch-cluster.yaml
@@ -5,10 +5,9 @@ metadata:
   namespace: default
 spec:
   general:
-    version: 1.3.0
+    version: 1.3.2
     httpPort: 9200
     vendor: opensearch
-    version: latest
     serviceName: my-cluster
   dashboards:
     version: 1.3.0


### PR DESCRIPTION
Example code pulls in OpenSearch with "latest" tag. Since a few days
ago this OpenSearch 2.0.0 which is incompatible with this operator.