### PR TITLE
Allow CR with custom dashboard image that is different from general custom image or default image

### DIFF
--- a/charts/opensearch-operator/templates/opensearchclusters.opensearch.opster.io-crd.yaml
+++ b/charts/opensearch-operator/templates/opensearchclusters.opensearch.opster.io-crd.yaml
@@ -65,6 +65,23 @@ spec:
                           TODO: Add other useful fields. apiVersion, kind, uid?'
                         type: string
                     type: object
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
+                    type: string
+                  imagePullSecrets:
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    type: array
                   replicas:
                     format: int32
                     type: integer

--- a/docs/designs/crd.md
+++ b/docs/designs/crd.md
@@ -223,6 +223,27 @@ Dashboards defines Opensearch-Dashboard configuration and deployment
         <td>false</td>
         <td> - </td>
       </tr><tr>
+      </tr><tr>
+        <td><b>image</b></td>
+        <td>string</td>
+        <td>Define Opensearch-dashboards image</td>
+        <td>false</td>
+        <td> - </td>
+      </tr><tr>
+      </tr><tr>
+        <td><b>imagePullPolicy</b></td>
+        <td>corev1.PullPolicy</td>
+        <td>Define Opensearch-dashboards image pull policy</td>
+        <td>false</td>
+        <td> - </td>
+      </tr><tr>
+      </tr><tr>
+        <td><b>imagePullSecrets</b></td>
+        <td>corev1.LocalObjectReference</td>
+        <td>Define Opensearch-dashboards image pull secrets</td>
+        <td>false</td>
+        <td> - </td>
+      </tr><tr>
 </table>
 
 

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -87,11 +87,12 @@ type ConfMgmt struct {
 }
 
 type DashboardsConfig struct {
-	Enable    bool                        `json:"enable,omitempty"`
-	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
-	Replicas  int32                       `json:"replicas"`
-	Tls       *DashboardsTlsConfig        `json:"tls,omitempty"`
-	Version   string                      `json:"version"`
+	Enable     bool                        `json:"enable,omitempty"`
+	Resources  corev1.ResourceRequirements `json:"resources,omitempty"`
+	Replicas   int32                       `json:"replicas"`
+	Tls        *DashboardsTlsConfig        `json:"tls,omitempty"`
+	Version    string                      `json:"version"`
+	*ImageSpec `json:",omitempty"`
 	// Additional properties for opensearch_dashboards.yaml
 	AdditionalConfig map[string]string `json:"additionalConfig,omitempty"`
 	// Secret that contains fields username and password for dashboards to use to login to opensearch, must only be supplied if a custom securityconfig is provided

--- a/opensearch-operator/api/v1/zz_generated.deepcopy.go
+++ b/opensearch-operator/api/v1/zz_generated.deepcopy.go
@@ -115,6 +115,11 @@ func (in *DashboardsConfig) DeepCopyInto(out *DashboardsConfig) {
 		*out = new(DashboardsTlsConfig)
 		**out = **in
 	}
+	if in.ImageSpec != nil {
+		in, out := &in.ImageSpec, &out.ImageSpec
+		*out = new(ImageSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.AdditionalConfig != nil {
 		in, out := &in.AdditionalConfig, &out.AdditionalConfig
 		*out = make(map[string]string, len(*in))

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -169,6 +169,23 @@ spec:
                       - name
                       type: object
                     type: array
+                  image:
+                    type: string
+                  imagePullPolicy:
+                    description: PullPolicy describes a policy for if/when to pull
+                      a container image
+                    type: string
+                  imagePullSecrets:
+                    items:
+                      description: LocalObjectReference contains enough information
+                        to let you locate the referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      type: object
+                    type: array
                   opensearchCredentialsSecret:
                     description: Secret that contains fields username and password
                       for dashboards to use to login to opensearch, must only be supplied


### PR DESCRIPTION
**Task** Allow config the OpenSearchCluster CR to use a specific image for the dashboards only

**Limit** Currently, the OpenSearchCluster CR _**only**_ allows customize the dashboard image through the `spec.general.image`. But the CR value in `spec.general.image` will also be used by all the opensearch cluster nodes (master, ingest, and data).

**Scenario** Some users build the opensearch cluster (a.k.a ES cluster) and opensearch dashboard (a.k.a Kibana) separately and put the images in two different docker registry repos. They need a way to individualize both images for opensearch cluster and opensearch dashboard.

**Solution** To allow the CR to customize the dashboard image only without affecting other components, the simplest way is to introduce an `ImageSpec` struct within `spec.dashboards`. For example:
```
spec:
  dashboards:
    imagePullPolicy: Always
    image: my.io/awesomeapps/opensearch-dashboard:3.2.1-canary
```

**Implementation** With this MR, the opensearch operator will choose the dashboard image in the following order:
1. CR value in`spec.dashboards.image` if specified.
2. CR value in `spec.general.image` if specified.
3. Default hard coded `docker.io/opensearchproject/opensearch-dashboards:` + cr.Spec.Dashboards.Version in reconcile-helpers.go.