### PR TITLE
Removed hardcoded "public.ecr.aws/opsterio"

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -808,4 +808,3 @@ func DataNodesCount(ctx context.Context, k8sClient client.Client, cr *opsterv1.O
 	}
 	return count
 }
-

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -62,6 +62,7 @@ func NewSTSForNodePool(
 		if helpers.ContainsString(availableRoles, role) {
 			selectedRoles = append(selectedRoles, role)
 		}
+		
 	}
 
 	pvc := corev1.PersistentVolumeClaim{}
@@ -277,7 +278,7 @@ func NewSTSForNodePool(
 					},
 					InitContainers: []corev1.Container{{
 						Name:    "init",
-						Image:   "public.ecr.aws/opsterio/busybox:latest",
+						Image:   "busybox:latest",
 						Command: []string{"sh", "-c"},
 						Args:    []string{"chown -R 1000:1000 /usr/share/opensearch/data"},
 						SecurityContext: &corev1.SecurityContext{
@@ -322,7 +323,7 @@ func NewSTSForNodePool(
 	if cr.Spec.General.SetVMMaxMapCount {
 		sts.Spec.Template.Spec.InitContainers = append(sts.Spec.Template.Spec.InitContainers, corev1.Container{
 			Name:  "init-sysctl",
-			Image: "public.ecr.aws/opsterio/busybox:1.27.2",
+			Image: "busybox:1.27.2",
 			Command: []string{
 				"sysctl",
 				"-w",

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -808,3 +808,4 @@ func DataNodesCount(ctx context.Context, k8sClient client.Client, cr *opsterv1.O
 	}
 	return count
 }
+


### PR DESCRIPTION
busybox images are hardcoded to public.ecr.aws/opsterio/busybox. That is not allowing the Opensearch cluster to be created in k8s environment behind firewalls or corp network. 
Busybox is a commonly used tool and is usually available in the corp network repositories.