### PR TITLE
Removed hardcoded "public.ecr.aws/opsterio"

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -277,7 +277,7 @@ func NewSTSForNodePool(
 					},
 					InitContainers: []corev1.Container{{
 						Name:    "init",
-						Image:   "public.ecr.aws/opsterio/busybox:latest",
+						Image:   "busybox:latest",
 						Command: []string{"sh", "-c"},
 						Args:    []string{"chown -R 1000:1000 /usr/share/opensearch/data"},
 						SecurityContext: &corev1.SecurityContext{
@@ -322,7 +322,7 @@ func NewSTSForNodePool(
 	if cr.Spec.General.SetVMMaxMapCount {
 		sts.Spec.Template.Spec.InitContainers = append(sts.Spec.Template.Spec.InitContainers, corev1.Container{
 			Name:  "init-sysctl",
-			Image: "public.ecr.aws/opsterio/busybox:1.27.2",
+			Image: "busybox:1.27.2",
 			Command: []string{
 				"sysctl",
 				"-w",


### PR DESCRIPTION
The operator installation is failing in corp network since public.ecr.aws is not available directly and needs some proxy. 

Signed-off-by: Akshay Polji <Akshay.Polji@gmail.com>