### PR TITLE
quote password in readiness check

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -171,7 +171,7 @@ func NewSTSForNodePool(
 				Command: []string{
 					"/bin/bash",
 					"-c",
-					"curl -k -u ${OPENSEARCH_USER}:${OPENSEARCH_PASSWORD} --silent --fail https://localhost:9200",
+					"curl -k -u \"${OPENSEARCH_USER}:${OPENSEARCH_PASSWORD}\" --silent --fail https://localhost:9200",
 				},
 			},
 		},


### PR DESCRIPTION
It would not work for usernames or passwords that contain special shell
characters like `$`, etc.