### PR TITLE
Helm v2.0 compatibility

### DIFF
--- a/charts/opensearch-operator/CHANGELOG.md
+++ b/charts/opensearch-operator/CHANGELOG.md
@@ -14,6 +14,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
+## [2.0.0]
+### Added
+### Changed
+- Modified `version` to `2.0.0` and `appVersion` to `v2.0`.
+- Allow chart image tag to pick from `appVersion`, unless explicitly passed `tag` values in `values.yaml` file.
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
 ## [1.0.3]
 ### Added
 ### Changed
@@ -43,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/Opster/opensearch-k8s-operator/compare/opensearch-operator-1.0.3...HEAD
+[Unreleased]: https://github.com/Opster/opensearch-k8s-operator/compare/opensearch-operator-2.0.0...HEAD
+[2.0.0]: https://github.com/Opster/opensearch-k8s-operator/compare/opensearch-operator-1.0.3...opensearch-operator-2.0.0
 [1.0.3]: https://github.com/Opster/opensearch-k8s-operator/compare/opensearch-operator-1.0.2...opensearch-operator-1.0.3
 [1.0.2]: https://github.com/Opster/opensearch-k8s-operator/compare/opensearch-operator-1.0.1...opensearch-operator-1.0.2


### PR DESCRIPTION
Signed-off-by: pgodithi <pgodithi@amazon.com>

- Modified `version` to `2.0.0` and `appVersion` to `v2.0`.
- Allow chart image tag to pick from `appVersion`, unless explicitly passed `tag` values in `values.yaml` file.