### PR TITLE
Add permissions to modify user,roles and rolebindings status to manager role

### DIFF
--- a/charts/opensearch-operator/templates/opensearch-operator-manager-role-cr.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-manager-role-cr.yaml
@@ -133,9 +133,10 @@ rules:
   - opensearch.opster.io
   resources:
   - opensearchclusters/status
+  - opensearchuserrolebindings/status
+  - opensearchusers/status
+  - opensearchroles/status
   verbs:
   - get
   - patch
   - update
-
-


### PR DESCRIPTION
Adding missing status resource permission for manager role in helm as proposed in https://github.com/Opster/opensearch-k8s-operator/issues/255.