### PR TITLE
Updating the readiness probe - adding retries and timeouts

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -174,8 +174,10 @@ func NewSTSForNodePool(
 	httpPort := PortForCluster(cr)
 	curlCmd := "curl -k -u \"${OPENSEARCH_USER}:${OPENSEARCH_PASSWORD}\" --silent --fail https://localhost:" + fmt.Sprint(httpPort)
 	readinessProbe := corev1.Probe{
-		InitialDelaySeconds: 30,
+		InitialDelaySeconds: 60,
 		PeriodSeconds:       30,
+		FailureThreshold:    5,
+		TimeoutSeconds:      30,
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
 				Command: []string{


### PR DESCRIPTION
@idanl21 , @swoehrl-mw : I have created this PR as part of improving the probes - issue https://github.com/Opster/opensearch-k8s-operator/issues/252. In my setup, I can see multiple pods failing due to readiness probe failures. Changes in this PR is adding retries to readiness probes along with some delays for the opensearch stateful sets.