### PR TITLE
Use correct cluster uuid for managedCluster ref

### DIFF
--- a/opensearch-operator/pkg/reconcilers/role.go
+++ b/opensearch-operator/pkg/reconcilers/role.go
@@ -123,7 +123,7 @@ func (r *RoleReconciler) Reconcile() (retResult ctrl.Result, retErr error) {
 				if err := r.Get(r.ctx, client.ObjectKeyFromObject(r.instance), r.instance); err != nil {
 					return err
 				}
-				r.instance.Status.ManagedCluster = &r.instance.UID
+				r.instance.Status.ManagedCluster = &r.cluster.UID
 				return r.Status().Update(r.ctx, r.instance)
 			})
 			if retErr != nil {


### PR DESCRIPTION
Fixes #271

There is a small bug in the code where the operator uses the UUID of the `Role` object instead of the `OpenSearchCluster` object for the `managedCluster` ref. 