### PR TITLE
Convert opensearch role master to cluster_manager on 2.x

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -62,6 +62,7 @@ func NewSTSForNodePool(
 	var selectedRoles []string
 	for _, role := range node.Roles {
 		if helpers.ContainsString(availableRoles, role) {
+			role = helpers.MapClusterRole(role, cr.Spec.General.Version)
 			selectedRoles = append(selectedRoles, role)
 		}
 	}

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1,0 +1,60 @@
+package builders
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	opsterv1 "opensearch.opster.io/api/v1"
+)
+
+func ClusterDescWithversion(version string) opsterv1.OpenSearchCluster {
+	return opsterv1.OpenSearchCluster{
+		Spec: opsterv1.ClusterSpec{
+			General: opsterv1.GeneralConfig{
+				Version: version,
+			},
+		},
+	}
+}
+
+var _ = Describe("Builders", func() {
+
+	When("Constructing a STS for a NodePool", func() {
+		It("should only use valid roles", func() {
+			var clusterObject = ClusterDescWithversion("2.2.1")
+			var nodePool = opsterv1.NodePool{
+				Component: "masters",
+				Roles:     []string{"cluster_manager", "foobar", "ingest"},
+			}
+			var result = NewSTSForNodePool("foobar", &clusterObject, nodePool, "foobar", nil, nil, nil)
+			Expect(result.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
+				Name:  "node.roles",
+				Value: "cluster_manager,ingest",
+			}))
+		})
+		It("should convert the master role", func() {
+			var clusterObject = ClusterDescWithversion("2.2.1")
+			var nodePool = opsterv1.NodePool{
+				Component: "masters",
+				Roles:     []string{"master"},
+			}
+			var result = NewSTSForNodePool("foobar", &clusterObject, nodePool, "foobar", nil, nil, nil)
+			Expect(result.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
+				Name:  "node.roles",
+				Value: "cluster_manager",
+			}))
+		})
+		It("should convert the cluster_manager role", func() {
+			var clusterObject = ClusterDescWithversion("1.3.0")
+			var nodePool = opsterv1.NodePool{
+				Component: "masters",
+				Roles:     []string{"cluster_manager"},
+			}
+			var result = NewSTSForNodePool("foobar", &clusterObject, nodePool, "foobar", nil, nil, nil)
+			Expect(result.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
+				Name:  "node.roles",
+				Value: "master",
+			}))
+		})
+	})
+})

--- a/opensearch-operator/pkg/builders/suite_test.go
+++ b/opensearch-operator/pkg/builders/suite_test.go
@@ -1,0 +1,49 @@
+/*
+
+First, it will contain the necessary imports.
+*/
+
+/*
+Copyright 2022 The Kubernetes authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+// +kubebuilder:docs-gen:collapse=Apache License
+package builders
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	//+kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+// +kubebuilder:docs-gen:collapse=Imports
+
+/*
+Now, let's go through the code generated.
+*/
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Builders Suite",
+		[]Reporter{printer.NewlineReporter{}})
+
+}

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -121,3 +121,20 @@ func ResolveClusterManagerRole(ver string) string {
 	}
 	return masterRole
 }
+
+// Map any cluster roles that have changed between major OpenSearch versions
+func MapClusterRole(role string, ver string) string {
+	osVer, err := version.NewVersion(ver)
+	if err != nil {
+		return role
+	}
+	clusterManagerVer, _ := version.NewVersion("2.0.0")
+	is2XVersion := osVer.GreaterThanOrEqual(clusterManagerVer)
+	if role == "master" && is2XVersion {
+		return "cluster_manager"
+	} else if role == "cluster_manager" && !is2XVersion {
+		return "master"
+	} else {
+		return role
+	}
+}


### PR DESCRIPTION
Fixes #281 

Map role `master` to `cluster_manager` for opensearch 2.x and vice versa for 1.x.