### PR TITLE
Adding checksum to dashboards deployment

### DIFF
--- a/opensearch-operator/pkg/builders/dashboards.go
+++ b/opensearch-operator/pkg/builders/dashboards.go
@@ -15,7 +15,7 @@ import (
 
 /// Package that declare and build all the resources that related to the OpenSearch-Dashboard ///
 
-func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount) *appsv1.Deployment {
+func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []corev1.Volume, volumeMounts []corev1.VolumeMount, annotations map[string]string) *appsv1.Deployment {
 	var replicas int32 = cr.Spec.Dashboards.Replicas
 	var port int32 = 5601
 	var mode int32 = 420
@@ -103,7 +103,7 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: nil,
+					Annotations: annotations,
 				},
 				Spec: corev1.PodSpec{
 					Volumes: volumes,
@@ -158,7 +158,7 @@ func NewDashboardsConfigMapForCR(cr *opsterv1.OpenSearchCluster, name string, co
 			Namespace: cr.Namespace,
 		},
 		Data: map[string]string{
-			"opensearch_dashboards.yml": data,
+			helpers.DashboardConfigName: data,
 		},
 	}
 }

--- a/opensearch-operator/pkg/builders/dashboards.go
+++ b/opensearch-operator/pkg/builders/dashboards.go
@@ -98,7 +98,7 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 				MatchLabels: labels,
 			},
 			Strategy: appsv1.DeploymentStrategy{
-				Type: appsv1.RecreateDeploymentStrategyType,
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/opensearch-operator/pkg/helpers/constants.go
+++ b/opensearch-operator/pkg/helpers/constants.go
@@ -1,5 +1,6 @@
 package helpers
 
 const (
-	DashboardConfigName = "opensearch_dashboards.yml"
+	DashboardConfigName   = "opensearch_dashboards.yml"
+	DashboardChecksumName = "checksum/dashboards.yml"
 )

--- a/opensearch-operator/pkg/helpers/constants.go
+++ b/opensearch-operator/pkg/helpers/constants.go
@@ -1,0 +1,5 @@
+package helpers
+
+const (
+	DashboardConfigName = "opensearch_dashboards.yml"
+)

--- a/opensearch-operator/pkg/reconcilers/dashboards.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards.go
@@ -93,7 +93,7 @@ func (r *DashboardsReconciler) Reconcile() (ctrl.Result, error) {
 			return ctrl.Result{}, err
 		}
 
-		annotations["checksum/sha1"] = sha1sum
+		annotations[helpers.DashboardChecksumName] = sha1sum
 	}
 
 	deployment := builders.NewDashboardsDeploymentForCR(r.instance, volumes, volumeMounts, annotations)

--- a/opensearch-operator/pkg/reconcilers/dashboards.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards.go
@@ -88,7 +88,7 @@ func (r *DashboardsReconciler) Reconcile() (ctrl.Result, error) {
 	annotations := make(map[string]string)
 
 	if cmData, ok := cm.Data[helpers.DashboardConfigName]; ok {
-		sha1sum, err := util.GetSha1Sum(cmData)
+		sha1sum, err := util.GetSha1Sum([]byte(cmData))
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/opensearch-operator/pkg/reconcilers/dashboards.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	opsterv1 "opensearch.opster.io/api/v1"
 	"opensearch.opster.io/pkg/builders"
+	"opensearch.opster.io/pkg/helpers"
 	"opensearch.opster.io/pkg/reconcilers/util"
 	"opensearch.opster.io/pkg/tls"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -84,7 +85,18 @@ func (r *DashboardsReconciler) Reconcile() (ctrl.Result, error) {
 	result.CombineErr(ctrl.SetControllerReference(r.instance, cm, r.Client.Scheme()))
 	result.Combine(r.ReconcileResource(cm, reconciler.StatePresent))
 
-	deployment := builders.NewDashboardsDeploymentForCR(r.instance, volumes, volumeMounts)
+	annotations := make(map[string]string)
+
+	if cmData, ok := cm.Data[helpers.DashboardConfigName]; ok {
+		sha1sum, err := util.GetSha1Sum(cmData)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+
+		annotations["checksum/sha1"] = sha1sum
+	}
+
+	deployment := builders.NewDashboardsDeploymentForCR(r.instance, volumes, volumeMounts, annotations)
 	result.CombineErr(ctrl.SetControllerReference(r.instance, deployment, r.Client.Scheme()))
 	result.Combine(r.ReconcileResource(deployment, reconciler.StatePresent))
 

--- a/opensearch-operator/pkg/reconcilers/dashboards_test.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Dashboards Reconciler", func() {
 					Dashboards: opsterv1.DashboardsConfig{
 						Enable: true,
 						AdditionalConfig: map[string]string{
-							helpers.DashboardConfigName: testConfig,
+							"some-key": testConfig,
 						},
 					},
 				}}

--- a/opensearch-operator/pkg/reconcilers/dashboards_test.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	opsterv1 "opensearch.opster.io/api/v1"
 	"opensearch.opster.io/pkg/helpers"
+	"opensearch.opster.io/pkg/reconcilers/util"
 
 	. "github.com/kralicky/kmatch"
 	. "github.com/onsi/ginkgo/v2"
@@ -186,6 +187,8 @@ var _ = Describe("Dashboards Reconciler", func() {
 	When("running the dashboards reconciler with additionalConfig supplied", func() {
 		It("should populate the dashboard config with these values", func() {
 			clusterName := "dashboards-add-config"
+			testConfig := "some-config-here"
+
 			spec := opsterv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
 				Spec: opsterv1.ClusterSpec{
@@ -193,7 +196,7 @@ var _ = Describe("Dashboards Reconciler", func() {
 					Dashboards: opsterv1.DashboardsConfig{
 						Enable: true,
 						AdditionalConfig: map[string]string{
-							"foo": "bar",
+							helpers.DashboardConfigName: testConfig,
 						},
 					},
 				}}
@@ -223,7 +226,7 @@ var _ = Describe("Dashboards Reconciler", func() {
 
 			data, exists := configMap.Data[helpers.DashboardConfigName]
 			Expect(exists).To(BeTrue())
-			Expect(strings.Contains(data, "foo: bar\n")).To(BeTrue())
+			Expect(strings.Contains(data, testConfig)).To(BeTrue())
 
 			deployment := appsv1.Deployment{}
 			Eventually(func() bool {
@@ -234,7 +237,8 @@ var _ = Describe("Dashboards Reconciler", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			Expect(deployment.Spec.Template.ObjectMeta.Annotations[helpers.DashboardConfigName], Equal("acbddbad2c491aab236e1025ad5b9ace129ea5667"))
+			expectedChecksum, _ := util.GetSha1Sum([]byte(data))
+			Expect(deployment.Spec.Template.ObjectMeta.Annotations[helpers.DashboardChecksumName]).To(Equal(expectedChecksum))
 		})
 	})
 

--- a/opensearch-operator/pkg/reconcilers/dashboards_test.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards_test.go
@@ -221,9 +221,20 @@ var _ = Describe("Dashboards Reconciler", func() {
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
-			data, exists := configMap.Data["opensearch_dashboards.yml"]
+			data, exists := configMap.Data[helpers.DashboardConfigName]
 			Expect(exists).To(BeTrue())
 			Expect(strings.Contains(data, "foo: bar\n")).To(BeTrue())
+
+			deployment := appsv1.Deployment{}
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), client.ObjectKey{
+					Name:      clusterName + "-dashboards",
+					Namespace: clusterName,
+				}, &deployment)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(deployment.Spec.Template.ObjectMeta.Annotations[helpers.DashboardConfigName], Equal("acbddbad2c491aab236e1025ad5b9ace129ea5667"))
 		})
 	})
 

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -241,12 +241,10 @@ func FetchOpensearchCluster(
 	return cluster, nil
 }
 
-// Generates a checksum of string data using SHA1.
-func GetSha1Sum(data string) (string, error) {
-	content := fmt.Sprint(data)
-
+// Generates a checksum of binary data using the SHA1 algorithm.
+func GetSha1Sum(data []byte) (string, error) {
 	hasher := sha1.New()
-	_, err := hasher.Write([]byte(content))
+	_, err := hasher.Write(data)
 
 	if err != nil {
 		return "", err

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"sort"
@@ -237,4 +239,18 @@ func FetchOpensearchCluster(
 		return nil, err
 	}
 	return cluster, nil
+}
+
+// Generates a checksum of string data using SHA1.
+func GetSha1Sum(data string) (string, error) {
+	content := fmt.Sprint(data)
+
+	hasher := sha1.New()
+	_, err := hasher.Write([]byte(content))
+
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
 }


### PR DESCRIPTION
This PR introduces functionality that patches a sha1 checksum of the dashboards additionalConfig data onto the dashboards deployment. This causes the dashboards pod to restart, when the ConfigMap is updated and adjusts the checksum accordingly.