### PR TITLE
Remove role from STS selector labels to allow changing roles for nodepools

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -120,13 +120,16 @@ func NewSTSForNodePool(
 		MountPath: "/usr/share/opensearch/data",
 	})
 
-	//var vendor string
 	labels := map[string]string{
 		ClusterLabel:  cr.Name,
 		NodePoolLabel: node.Component,
 	}
 	annotations := map[string]string{
 		ConfigurationChecksumAnnotation: configChecksum,
+	}
+	matchLabels := map[string]string{
+		ClusterLabel:  cr.Name,
+		NodePoolLabel: node.Component,
 	}
 
 	if helpers.ContainsString(selectedRoles, "master") {
@@ -216,7 +219,7 @@ func NewSTSForNodePool(
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &node.Replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: matchLabels,
 			},
 			PodManagementPolicy: appsv1.OrderedReadyPodManagement,
 			UpdateStrategy: func() appsv1.StatefulSetUpdateStrategy {

--- a/opensearch-operator/pkg/reconcilers/upgrade.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade.go
@@ -193,7 +193,7 @@ func (r *UpgradeReconciler) findWorkingNodePool() (opsterv1.NodePool, opsterv1.C
 	annotations := map[string]string{"cluster-name": r.instance.GetName()}
 	for _, nodePool := range r.instance.Spec.NodePools {
 		if helpers.ContainsString(nodePool.Roles, "data") {
-			if helpers.ContainsString(nodePool.Roles, "master") {
+			if helpers.ContainsString(nodePool.Roles, "master") || helpers.ContainsString(nodePool.Roles, "cluster_manager") {
 				dataAndMasterNodes = append(dataAndMasterNodes, nodePool)
 			} else {
 				dataNodes = append(dataNodes, nodePool)


### PR DESCRIPTION
Fixes #311 

Currently the master/cluster_manager role is part of  `selector.matchLabels`. This makes upgrading a cluster from 1.x to 2.x while also changing the role from `master` to `cluster_manager` impossible as the operator tries to change the `matchLabels` which are immutable.
This change removes the role from the `matchLabels` and contains logic to update existing statefulsets by deleting and recreating it while orphaning pods.

After this is merged we should create a bugfix release 2.1.1.