### PR TITLE
Adding resource requests and limits and health probes

### DIFF
--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -22,6 +22,12 @@ spec:
         - --v=10
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         name: kube-rbac-proxy
+        resources:
+{{- toYaml .Values.kubeRbacProxy.resources | nindent 10 }}
+        readinessProbe:
+{{- toYaml .Values.kubeRbacProxy.readinessProbe | nindent 10 }}
+        livenessProbe:
+{{- toYaml .Values.kubeRbacProxy.livenessProbe | nindent 10 }}
         ports:
         - containerPort: 8443
           name: https
@@ -38,13 +44,17 @@ spec:
         name: operator-controller-manager
         imagePullPolicy: "{{ .Values.manager.image.pullPolicy }}"
         resources:
-          {{- toYaml .Values.manager.resources | nindent 12 }}
+{{- toYaml .Values.manager.resources | nindent 10 }}
+        readinessProbe:
+{{- toYaml .Values.manager.readinessProbe | nindent 10 }}
+        livenessProbe:
+{{- toYaml .Values.manager.livenessProbe | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
       nodeSelector:
-        {{- toYaml .Values.nodeSelector | nindent 8 }}
+{{- toYaml .Values.nodeSelector | nindent 8 }}
       tolerations:
-        {{- toYaml .Values.tolerations | nindent 8 }}
+{{- toYaml .Values.tolerations | nindent 8 }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: opensearch-operator-controller-manager

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -4,10 +4,10 @@ manager:
   resources:
     limits:
       cpu: 200m
-      memory: 300Mi
+      memory: 500Mi
     requests:
       cpu: 100m
-      memory: 150Mi
+      memory: 350Mi
 
   livenessProbe:
     failureThreshold: 3

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -3,10 +3,10 @@ tolerations: []
 manager:
   resources:
     limits:
-      cpu: 100m
+      cpu: 200m
       memory: 300Mi
     requests:
-      cpu: 20m
+      cpu: 100m
       memory: 150Mi
 
   livenessProbe:

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -3,11 +3,32 @@ tolerations: []
 manager:
   resources:
     limits:
-      cpu: 2
-      memory: 1Gi
+      cpu: 100m
+      memory: 300Mi
     requests:
-      cpu: 2
-      memory: 1Gi
+      cpu: 20m
+      memory: 150Mi
+
+  livenessProbe:
+    failureThreshold: 3
+    httpGet:
+      path: /healthz
+      port: 8081
+    periodSeconds: 15
+    successThreshold: 1
+    timeoutSeconds: 3
+    initialDelaySeconds: 10
+
+  readinessProbe:
+    failureThreshold: 3
+    httpGet:
+      path: /readyz
+      port: 8081
+    periodSeconds: 15
+    successThreshold: 1
+    timeoutSeconds: 3
+    initialDelaySeconds: 10
+
   image:
     repository: public.ecr.aws/opsterio/opensearch-operator
     ## tag default uses appVersion from Chart.yaml, to override specify tag tag: "v1.1"
@@ -16,3 +37,30 @@ manager:
   # If a watchNamespace is specified, the manager's cache will be restricted to
   # watch objects in the desired namespace. Defaults is to watch all namespaces.
   watchNamespace:
+
+kubeRbacProxy:
+  resources:
+    limits:
+      cpu: 50m
+      memory: 50Mi
+    requests:
+      cpu: 25m
+      memory: 25Mi
+
+  livenessProbe:
+    failureThreshold: 3
+    tcpSocket:
+      port: 8443
+    periodSeconds: 15
+    successThreshold: 1
+    timeoutSeconds: 3
+    initialDelaySeconds: 10
+
+  readinessProbe:
+    failureThreshold: 3
+    tcpSocket:
+      port: 8443
+    periodSeconds: 15
+    successThreshold: 1
+    timeoutSeconds: 3
+    initialDelaySeconds: 10


### PR DESCRIPTION
This pull requests adds default resource limits and health probes to the operator and kube-rbac-proxy containers.