### PR TITLE
Change "go get" to "go install"

### DIFF
--- a/opensearch-operator/Makefile
+++ b/opensearch-operator/Makefile
@@ -113,7 +113,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
Fixes: [#320](https://github.com/Opster/opensearch-k8s-operator/issues/320)
Due to "go get" is deprecated we have to use "go install"
More information:  [go-get-install-deprecation](https://go.dev/doc/go-get-install-deprecation)