### PR TITLE
Change "go get" to "go install"

### DIFF
--- a/opensearch-operator/Makefile
+++ b/opensearch-operator/Makefile
@@ -68,13 +68,13 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: test ## Build docker image with the manager.
-	go get opensearch.opster.io/pkg/builders
-	go get opensearch.opster.io/pkg/helpers
+	go install opensearch.opster.io/pkg/builders
+	go install opensearch.opster.io/pkg/helpers
 	DOCKER_BUILDKIT=1 docker build -t ${IMG} .
 
 docker-build-multiarch: ## Build docker image with the manager for all supported architectures
-	go get opensearch.opster.io/pkg/builders
-	go get opensearch.opster.io/pkg/helpers
+	go install opensearch.opster.io/pkg/builders
+	go install opensearch.opster.io/pkg/helpers
 	DOCKER_BUILDKIT=1 docker buildx build --platform="linux/amd64,linux/arm,linux/arm64" -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
@@ -102,11 +102,12 @@ controller-gen: ## Download controller-gen locally if necessary.
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-install-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
-define go-get-tool
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+define go-install-tool
 @[ -f $(1) ] || { \
 set -e ;\
 TMP_DIR=$$(mktemp -d) ;\
@@ -114,6 +115,6 @@ cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
 GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
-rm -rf $$TMP_DIR ;\
+rm -rf $$TMP_DIR2 ;\
 }
 endef

--- a/opensearch-operator/Makefile
+++ b/opensearch-operator/Makefile
@@ -113,7 +113,7 @@ TMP_DIR=$$(mktemp -d) ;\
 cd $$TMP_DIR ;\
 go mod init tmp ;\
 echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_DIR)/bin go get $(2) ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 rm -rf $$TMP_DIR ;\
 }
 endef


### PR DESCRIPTION
Fixes: [#320](https://github.com/Opster/opensearch-k8s-operator/issues/320)
Due to "go get" is deprecated we have to use "go install"
More information:  [go-get-install-deprecation](https://go.dev/doc/go-get-install-deprecation)