### PR TITLE
Bump controller-gen

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.17'
+          go-version: '1.19'
       - name: Test
         run: |
           cd opensearch-operator

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The Operator can be easily installed using Helm:
 - Run `make install` to create the CRD in the kubernetes cluster
 - Start the Operator by running `make run`
 
-**Note: use GO 1.17 version** 
+# **Note: use GO 1.19 version** 
 
 Now you can deploy an Opensearch cluster.
 

--- a/charts/opensearch-operator/templates/OpensearchRole-crd.yaml
+++ b/charts/opensearch-operator/templates/OpensearchRole-crd.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: opensearchroles.opensearch.opster.io
 spec:

--- a/charts/opensearch-operator/templates/OpensearchUser-crd.yaml
+++ b/charts/opensearch-operator/templates/OpensearchUser-crd.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: opensearchusers.opensearch.opster.io
 spec:

--- a/charts/opensearch-operator/templates/OpensearchUserRoleBinding-crd.yaml
+++ b/charts/opensearch-operator/templates/OpensearchUserRoleBinding-crd.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: opensearchuserrolebindings.opensearch.opster.io
 spec:

--- a/charts/opensearch-operator/templates/opensearchclusters.opensearch.opster.io-crd.yaml
+++ b/charts/opensearch-operator/templates/opensearchclusters.opensearch.opster.io-crd.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: opensearchclusters.opensearch.opster.io
 spec:

--- a/opensearch-operator/Dockerfile
+++ b/opensearch-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.17 as builder
+FROM --platform=$BUILDPLATFORM golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/opensearch-operator/Makefile
+++ b/opensearch-operator/Makefile
@@ -1,8 +1,6 @@
 
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 PROJECT_PATH=$(CURDIR)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
@@ -39,7 +37,7 @@ help: ## Display this help.
 ##@ Development
 
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
@@ -98,7 +96,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
+	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0)
 
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: opensearchclusters.opensearch.opster.io
 spec:

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchroles.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchroles.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: opensearchroles.opensearch.opster.io
 spec:

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchuserrolebindings.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchuserrolebindings.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: opensearchuserrolebindings.opensearch.opster.io
 spec:

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchusers.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchusers.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: opensearchusers.opensearch.opster.io
 spec:


### PR DESCRIPTION
Fixes [#330](https://github.com/Opster/opensearch-k8s-operator/issues/330)
- Bump controller-gen to v0.10.0 for supporting latest kubernetes version
- Remove crd options trivialVersions and preserveUnknownFields since they are no longer supported in later version of controller-gen after this commit https://github.com/kubernetes-sigs/controller-tools/commit/09f1952580d4e40a3aab8b1c4f6bfc8de3ae0b0b

Signed-off-by: Maksim Bazhin <factort@list.ru>