### PR TITLE
Add example config for v2.x of operator with new 'cluster_manager' flag

### DIFF
--- a/opensearch-operator/examples/opensearch-v2-cluster.yaml
+++ b/opensearch-operator/examples/opensearch-v2-cluster.yaml
@@ -1,0 +1,51 @@
+#Minimal configuration of a cluster with version 2.X of the operator.
+#Note the replacement of 'master' role with 'cluster_manager' on line 49
+apiVersion: opensearch.opster.io/v1
+kind: OpenSearchCluster
+metadata:
+  name: my-first-cluster
+  namespace: default
+spec:
+  security:
+    config:
+    tls:
+       http:
+         generate: true 
+       transport:
+         generate: true
+         perNode: true
+  general:
+    httpPort: 9200
+    serviceName: my-first-cluster
+    version: 2.3.0
+    pluginsList: ["repository-s3"]
+    drainDataNodes: true
+  dashboards:
+    tls:
+      enable: true
+      generate: true
+    version: 2.3.0
+    enable: true
+    replicas: 1
+    resources:
+      requests:
+         memory: "512Mi"
+         cpu: "200m"
+      limits:
+         memory: "512Mi"
+         cpu: "200m"
+  nodePools:
+    - component: masters
+      replicas: 3
+      resources:
+         requests:
+            memory: "4Gi"
+            cpu: "1000m"
+         limits:
+            memory: "4Gi"
+            cpu: "1000m"
+      roles:
+        - "data"
+        - "cluster_manager"
+      persistence:
+         emptyDir: {}


### PR DESCRIPTION
This addresses issue 267.

Signed-off-by: David O'Connor <davidon5@ie.ibm.com>