### PR TITLE
Add support for custom kubeRbacProxy image

### DIFF
--- a/charts/opensearch-operator/CHANGELOG.md
+++ b/charts/opensearch-operator/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ---
 ## [Unreleased]
 ### Added
+- Added support for custom image used by `kubeRbacProxy`.
 ### Changed
 ### Deprecated
 ### Removed

--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: "{{ .Values.kubeRbacProxy.image.repository }}:{{ .Values.kubeRbacProxy.image.tag}}"
         name: kube-rbac-proxy
         resources:
 {{- toYaml .Values.kubeRbacProxy.resources | nindent 10 }}

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -64,3 +64,7 @@ kubeRbacProxy:
     successThreshold: 1
     timeoutSeconds: 3
     initialDelaySeconds: 10
+
+  image: 
+    repository: "gcr.io/kubebuilder/kube-rbac-proxy"
+    tag: "v0.8.0"


### PR DESCRIPTION
This change allows users to configure the helm chart with a custom image for `kubeRbacProxy` as I suggested in #344.  Image can be configured using the chart values:
```yaml
kubeRbacProxy:
  image: 
    repository: mycustomrepository.cr/custom-kube-rbac-proxy
    tag: "v0.8.0-custom"
```

Default values are supplied and uses the original image `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0`. 