### PR TITLE
Implementing user password update on secret change

### DIFF
--- a/opensearch-operator/pkg/helpers/constants.go
+++ b/opensearch-operator/pkg/helpers/constants.go
@@ -1,6 +1,8 @@
 package helpers
 
 const (
-	DashboardConfigName   = "opensearch_dashboards.yml"
-	DashboardChecksumName = "checksum/dashboards.yml"
+	DashboardConfigName       = "opensearch_dashboards.yml"
+	DashboardChecksumName     = "checksum/dashboards.yml"
+	OsUserNameAnnotation      = "opensearchuser/name"
+	OsUserNamespaceAnnotation = "opensearchuser/namespace"
 )

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -139,7 +139,7 @@ func MapClusterRole(role string, ver string) string {
 	}
 }
 
-//Get leftSlice strings not in rightSlice
+// Get leftSlice strings not in rightSlice
 func DiffSlice(leftSlice, rightSlice []string) []string {
 	//diff := []string{}
 	var diff []string


### PR DESCRIPTION
Solves #335 with the solution being inspired by @swoehrl-mw 

Once a `OpenSearchUser`-CRD is discovered, the password secret is annotated with metadata (username and namespace of the user). Every time a secret event occurs, the annotations of the secret in question are checked. If the according annotations match the ones set in the first step, the OpenSearchUser resource is marked for reconciliation. 

Signed-off-by: Luis Schweigard <luis.schweigard@maibornwolff.de>