### PR TITLE
Fixing a bug where the opensearch image would overwrite the opensearc…

### DIFF
--- a/opensearch-operator/pkg/helpers/reconcile-helpers.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers.go
@@ -91,13 +91,6 @@ func ResolveDashboardsImage(cr *opsterv1.OpenSearchCluster) (result opsterv1.Ima
 		}
 	}
 
-	// If a general custom image is specified, use it.
-	if cr.Spec.General.ImageSpec != nil {
-		if useCustomImage(cr.Spec.General.ImageSpec, &result) {
-			return
-		}
-	}
-
 	// If a different image repo is requested, use that with the default image
 	// name and version tag.
 	if cr.Spec.General.DefaultRepo != nil {


### PR DESCRIPTION
As mentioned in #253 , setting a custom image for the OpenSearchCluster in the "General" part of the manifest also sets the image for OpenSearch Dashboards, which is unexpected behavior. This is due to a call to "useCustomImage". This PR is moving said code snippet.

Signed-off-by: Luis Schweigard <luis.schweigard@maibornwolff.de>