### PR TITLE
synchronize manager role

### DIFF
--- a/charts/opensearch-operator/templates/opensearch-operator-manager-role-cr.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-manager-role-cr.yaml
@@ -29,22 +29,9 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
+  - batch
   resources:
-  - persistentvolumeclaims
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  - pods
-  - persistentvolumeclaims
+  - jobs
   verbs:
   - create
   - delete
@@ -56,7 +43,39 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
   - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
   verbs:
   - create
   - delete
@@ -90,18 +109,6 @@ rules:
   - update
   - watch
 - apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - opensearch.opster.io
   resources:
   - events
@@ -112,9 +119,6 @@ rules:
   - opensearch.opster.io
   resources:
   - opensearchclusters
-  - opensearchuserrolebindings
-  - opensearchusers
-  - opensearchroles
   verbs:
   - create
   - delete
@@ -133,10 +137,97 @@ rules:
   - opensearch.opster.io
   resources:
   - opensearchclusters/status
-  - opensearchuserrolebindings/status
-  - opensearchusers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - opensearch.opster.io
+  resources:
+  - opensearchroles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - opensearch.opster.io
+  resources:
+  - opensearchroles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - opensearch.opster.io
+  resources:
   - opensearchroles/status
   verbs:
   - get
   - patch
   - update
+- apiGroups:
+  - opensearch.opster.io
+  resources:
+  - opensearchuserrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - opensearch.opster.io
+  resources:
+  - opensearchuserrolebindings/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - opensearch.opster.io
+  resources:
+  - opensearchuserrolebindings/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - opensearch.opster.io
+  resources:
+  - opensearchusers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - opensearch.opster.io
+  resources:
+  - opensearchusers/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - opensearch.opster.io
+  resources:
+  - opensearchusers/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch


### PR DESCRIPTION
This addresses #352 by fixing the "events" apiGroup, expanding out existing permissions on */status, and adding missing */finalizer permissions.
The commit reduces the differences between `charts/opensearch-operator/templates/opensearch-operator-manager-role-cr.yaml` and `opensearch-operator/config/rbac/role.yaml` to one permission on `persistentvolumeclaims`

Signed-off-by: Robert van Veelen <vanveele@users.noreply.github.com>