### PR TITLE
Allow changing admin password in running cluster

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -176,7 +176,8 @@ func NewSTSForNodePool(
 
 	// Because the http endpoint requires auth we need to do it as a curl script
 	httpPort := PortForCluster(cr)
-	curlCmd := "curl -k -u \"${OPENSEARCH_USER}:${OPENSEARCH_PASSWORD}\" --silent --fail https://localhost:" + fmt.Sprint(httpPort)
+
+	curlCmd := "curl -k -u \"$(cat /mnt/admin-credentials/username):$(cat /mnt/admin-credentials/password)\" --silent --fail https://localhost:" + fmt.Sprint(httpPort)
 	readinessProbe := corev1.Probe{
 		InitialDelaySeconds: 60,
 		PeriodSeconds:       30,
@@ -192,6 +193,17 @@ func NewSTSForNodePool(
 			},
 		},
 	}
+
+	volumes = append(volumes, corev1.Volume{
+		Name: "admin-credentials",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{SecretName: fmt.Sprintf("%s-admin-password", cr.Name)},
+		},
+	})
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      "admin-credentials",
+		MountPath: "/mnt/admin-credentials",
+	})
 
 	image := helpers.ResolveImage(cr, &node)
 	initHelperImage := helpers.ResolveInitHelperImage(cr)
@@ -380,21 +392,6 @@ func NewSTSForNodePool(
 								{
 									Name:  "http.port",
 									Value: fmt.Sprint(cr.Spec.General.HttpPort),
-								},
-								{
-									Name:  "OPENSEARCH_USER",
-									Value: username,
-								},
-								{
-									Name: "OPENSEARCH_PASSWORD",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: fmt.Sprintf("%s-admin-password", cr.Name),
-											},
-											Key: "password",
-										},
-									},
 								},
 							},
 							Name:            "opensearch",
@@ -801,13 +798,14 @@ func URLForCluster(cr *opsterv1.OpenSearchCluster) string {
 	return fmt.Sprintf("https://%s.svc.cluster.local:%d", DnsOfService(cr), httpPort)
 }
 
-func PasswordSecret(cr *opsterv1.OpenSearchCluster, password string) *corev1.Secret {
+func PasswordSecret(cr *opsterv1.OpenSearchCluster, username, password string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-admin-password", cr.Name),
 			Namespace: cr.Namespace,
 		},
 		StringData: map[string]string{
+			"username": username,
 			"password": password,
 		},
 	}

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -139,7 +139,7 @@ func MapClusterRole(role string, ver string) string {
 	}
 }
 
-//Get leftSlice strings not in rightSlice
+// Get leftSlice strings not in rightSlice
 func DiffSlice(leftSlice, rightSlice []string) []string {
 	//diff := []string{}
 	var diff []string

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -72,7 +72,7 @@ func (r *ClusterReconciler) Reconcile() (ctrl.Result, error) {
 	result.CombineErr(ctrl.SetControllerReference(r.instance, discoveryService, r.Scheme()))
 	result.Combine(r.ReconcileResource(discoveryService, reconciler.StatePresent))
 
-	passwordSecret := builders.PasswordSecret(r.instance, password)
+	passwordSecret := builders.PasswordSecret(r.instance, username, password)
 	result.CombineErr(ctrl.SetControllerReference(r.instance, passwordSecret, r.Scheme()))
 	result.Combine(r.ReconcileResource(passwordSecret, reconciler.StatePresent))
 


### PR DESCRIPTION
As discussed in #305 it is currently not possible to change the opensearch admin password after cluster creation because the operator will update the securityconfig but will not update the readiness probes in the opensearch pods which consequently fail and declare all pods unhealthy. 
This PR changes the probe to retrieve its credentials not via env var but from a file-mounted secret. That way changed credentials are automatically propagated to the pods by kubernetes and the probe will stay healthy and there is no need for a restart.
