### PR TITLE
Making cluster.local dns base configurable

### DIFF
--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -49,6 +49,9 @@ spec:
 {{- toYaml .Values.manager.readinessProbe | nindent 10 }}
         livenessProbe:
 {{- toYaml .Values.manager.livenessProbe | nindent 10 }}
+        env:
+        - name: DNS_BASE
+          value: {{ .Values.manager.dnsBase }}
         securityContext:
           allowPrivilegeEscalation: false
       nodeSelector:

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -34,6 +34,9 @@ manager:
     ## tag default uses appVersion from Chart.yaml, to override specify tag tag: "v1.1"
     tag: ""
     pullPolicy: "Always"
+
+  dnsBase: cluster.local
+
   # If a watchNamespace is specified, the manager's cache will be restricted to
   # watch objects in the desired namespace. Defaults is to watch all namespaces.
   watchNamespace:

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -492,6 +492,15 @@ spec:
         secretName: secret-name
 ```
 
+## Custom cluster domain name
+
+If your cluster is configured with a custom domain name (default is `cluster.local`) you need to configure the operator accordingly in order for internal routing to work properly. This can be achieved by setting `manager.dnsBase` in the helm chart.
+
+```yaml
+manager:
+  # ...
+  dnsBase: custom.domain
+```
 
 ## Custom Admin User
 

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -812,6 +812,7 @@ func PortForCluster(cr *opsterv1.OpenSearchCluster) int32 {
 	}
 	return httpPort
 }
+
 func URLForCluster(cr *opsterv1.OpenSearchCluster) string {
 	httpPort := PortForCluster(cr)
 	return fmt.Sprintf("https://%s.svc.%s:%d", DnsOfService(cr), helpers.ClusterDnsBase(), httpPort)

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -814,7 +814,7 @@ func PortForCluster(cr *opsterv1.OpenSearchCluster) int32 {
 }
 func URLForCluster(cr *opsterv1.OpenSearchCluster) string {
 	httpPort := PortForCluster(cr)
-	return fmt.Sprintf("https://%s.svc.cluster.local:%d", DnsOfService(cr), httpPort)
+	return fmt.Sprintf("https://%s.svc.%s:%d", DnsOfService(cr), helpers.ClusterDnsBase(), httpPort)
 }
 
 func PasswordSecret(cr *opsterv1.OpenSearchCluster, username, password string) *corev1.Secret {
@@ -897,11 +897,11 @@ func NewSecurityconfigUpdateJob(
 	// The following curl command is added to make sure cluster is full connected before .opendistro_security is created.
 	arg := "ADMIN=/usr/share/opensearch/plugins/opensearch-security/tools/securityadmin.sh;" +
 		"chmod +x $ADMIN;" +
-		fmt.Sprintf("until curl -k --silent https://%s.svc.cluster.local:%v; do", dns, instance.Spec.General.HttpPort) +
+		fmt.Sprintf("until curl -k --silent https://%s.svc.%s:%v; do", dns, helpers.ClusterDnsBase(), instance.Spec.General.HttpPort) +
 		" echo 'Waiting to connect to the cluster'; sleep 120; " +
 		"done; " +
 		"count=0;" +
-		fmt.Sprintf("until $ADMIN -cacert %s -cert %s -key %s -cd %s -icl -nhnv -h %s.svc.cluster.local -p %v || (( count++ >= 20 )); do", caCert, adminCert, adminKey, securityconfigPath, dns, httpPort) +
+		fmt.Sprintf("until $ADMIN -cacert %s -cert %s -key %s -cd %s -icl -nhnv -h %s.svc.%s -p %v || (( count++ >= 20 )); do", caCert, adminCert, adminKey, securityconfigPath, dns, helpers.ClusterDnsBase(), httpPort) +
 		"  sleep 20; " +
 		"done"
 	annotations := map[string]string{

--- a/opensearch-operator/pkg/helpers/constants.go
+++ b/opensearch-operator/pkg/helpers/constants.go
@@ -7,12 +7,13 @@ const (
 	DashboardChecksumName     = "checksum/dashboards.yml"
 	OsUserNameAnnotation      = "opensearchuser/name"
 	OsUserNamespaceAnnotation = "opensearchuser/namespace"
+	DnsBaseEnvVariable        = "DNS_BASE"
 )
 
 func ClusterDnsBase() string {
-	env, found := os.LookupEnv("DNS_BASE")
+	env, found := os.LookupEnv(DnsBaseEnvVariable)
 
-	if !found {
+	if !found || len(env) == 0 {
 		env = "cluster.local"
 	}
 

--- a/opensearch-operator/pkg/helpers/constants.go
+++ b/opensearch-operator/pkg/helpers/constants.go
@@ -1,8 +1,20 @@
 package helpers
 
+import "os"
+
 const (
 	DashboardConfigName       = "opensearch_dashboards.yml"
 	DashboardChecksumName     = "checksum/dashboards.yml"
 	OsUserNameAnnotation      = "opensearchuser/name"
 	OsUserNamespaceAnnotation = "opensearchuser/namespace"
 )
+
+func ClusterDnsBase() string {
+	env, found := os.LookupEnv("DNS_BASE")
+
+	if !found {
+		env = "cluster.local"
+	}
+
+	return env
+}

--- a/opensearch-operator/pkg/reconcilers/dashboards.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards.go
@@ -142,7 +142,7 @@ func (r *DashboardsReconciler) handleTls() ([]corev1.Volume, []corev1.VolumeMoun
 				fmt.Sprintf("%s-dashboards", clusterName),
 				fmt.Sprintf("%s-dashboards.%s", clusterName, namespace),
 				fmt.Sprintf("%s-dashboards.%s.svc", clusterName, namespace),
-				fmt.Sprintf("%s-dashboards.%s.svc.cluster.local", clusterName, namespace),
+				fmt.Sprintf("%s-dashboards.%s.svc.%s", clusterName, namespace, helpers.ClusterDnsBase()),
 			}
 			nodeCert, err := ca.CreateAndSignCertificate(clusterName+"-dashboards", clusterName, dnsNames)
 			if err != nil {

--- a/opensearch-operator/pkg/reconcilers/tls.go
+++ b/opensearch-operator/pkg/reconcilers/tls.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	opsterv1 "opensearch.opster.io/api/v1"
 	"opensearch.opster.io/pkg/builders"
+	"opensearch.opster.io/pkg/helpers"
 	"opensearch.opster.io/pkg/reconcilers/util"
 	"opensearch.opster.io/pkg/tls"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -172,7 +173,7 @@ func (r *TLSReconciler) handleTransportGenerateGlobal() error {
 			clusterName,
 			fmt.Sprintf("%s.%s", clusterName, namespace),
 			fmt.Sprintf("%s.%s.svc", clusterName, namespace),
-			fmt.Sprintf("%s.%s.svc.cluster.local", clusterName, namespace),
+			fmt.Sprintf("%s.%s.svc.%s", clusterName, namespace, helpers.ClusterDnsBase()),
 		}
 		nodeCert, err := ca.CreateAndSignCertificate(clusterName, clusterName, dnsNames)
 		if err != nil {
@@ -245,8 +246,8 @@ func (r *TLSReconciler) handleTransportGeneratePerNode() error {
 			fmt.Sprintf("%s.%s.%s", bootstrapPodName, clusterName, namespace),
 			fmt.Sprintf("%s.%s.svc", clusterName, namespace),
 			fmt.Sprintf("%s.%s.%s.svc", bootstrapPodName, clusterName, namespace),
-			fmt.Sprintf("%s.%s.svc.cluster.local", clusterName, namespace),
-			fmt.Sprintf("%s.%s.%s.svc.cluster.local", bootstrapPodName, clusterName, namespace),
+			fmt.Sprintf("%s.%s.svc.%s", clusterName, namespace, helpers.ClusterDnsBase()),
+			fmt.Sprintf("%s.%s.%s.svc.%s", bootstrapPodName, clusterName, namespace, helpers.ClusterDnsBase()),
 		}
 		nodeCert, err := ca.CreateAndSignCertificate(bootstrapPodName, clusterName, dnsNames)
 		if err != nil {
@@ -279,8 +280,8 @@ func (r *TLSReconciler) handleTransportGeneratePerNode() error {
 				fmt.Sprintf("%s.%s.%s", podName, clusterName, namespace),
 				fmt.Sprintf("%s.%s.svc", clusterName, namespace),
 				fmt.Sprintf("%s.%s.%s.svc", podName, clusterName, namespace),
-				fmt.Sprintf("%s.%s.svc.cluster.local", clusterName, namespace),
-				fmt.Sprintf("%s.%s.%s.svc.cluster.local", podName, clusterName, namespace),
+				fmt.Sprintf("%s.%s.svc.%s", clusterName, namespace, helpers.ClusterDnsBase()),
+				fmt.Sprintf("%s.%s.%s.svc.%s", podName, clusterName, namespace, helpers.ClusterDnsBase()),
 			}
 			nodeCert, err := ca.CreateAndSignCertificate(podName, clusterName, dnsNames)
 			if err != nil {
@@ -389,7 +390,7 @@ func (r *TLSReconciler) handleHttp() error {
 				builders.DiscoveryServiceName(r.instance),
 				fmt.Sprintf("%s.%s", clusterName, namespace),
 				fmt.Sprintf("%s.%s.svc", clusterName, namespace),
-				fmt.Sprintf("%s.%s.svc.cluster.local", clusterName, namespace),
+				fmt.Sprintf("%s.%s.svc.%s", clusterName, namespace, helpers.ClusterDnsBase()),
 			}
 			nodeCert, err := ca.CreateAndSignCertificate(clusterName, clusterName, dnsNames)
 			if err != nil {

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -182,9 +182,10 @@ func CreateAdditionalVolumes(
 
 func OpensearchClusterURL(cluster *opsterv1.OpenSearchCluster) string {
 	return fmt.Sprintf(
-		"https://%s.%s.svc.cluster.local:%v",
+		"https://%s.%s.svc.%s:%v",
 		cluster.Spec.General.ServiceName,
 		cluster.Namespace,
+		helpers.ClusterDnsBase(),
 		cluster.Spec.General.HttpPort,
 	)
 }


### PR DESCRIPTION
This PR makes the cluster.local dns base configurable in the helm chart and solves #156.
The helm chart exposes a variables manager.dnsBase that will later be set as an environment variable for the operator manager container. This env variable is read in the constants.go file, and used at all times when building a cluster domain url.

Signed-off-by: Luis Schweigard <luis.schweigard@maibornwolff.de>