### PR TITLE
Adding option for basePath for OS Dashboards in CRD

### DIFF
--- a/charts/opensearch-operator/templates/opensearchclusters.opensearch.opster.io-crd.yaml
+++ b/charts/opensearch-operator/templates/opensearchclusters.opensearch.opster.io-crd.yaml
@@ -2028,6 +2028,10 @@ spec:
                             type: array
                         type: object
                     type: object
+                  basePath:
+                    description: Base Path for Opensearch Clusters running behind
+                      a reverse proxy
+                    type: string
                   enable:
                     type: boolean
                   env:

--- a/docs/designs/crd.md
+++ b/docs/designs/crd.md
@@ -273,6 +273,12 @@ Dashboards defines Opensearch-Dashboard configuration and deployment
         <td>true</td>
         <td>1</td>
       </tr><tr>
+        <td><b>basePath</b></td>
+        <td>string</td>
+        <td>Defines the base path of opensearch dashboards (e.g. when using a reverse proxy)</td>
+        <td>false</td>
+        <td>-</td>
+      </tr><tr>
         <td><b>resources</b></td>
         <td>corev1.ResourceRequirements</td>
         <td> Define Opensearch-Dashboard resources </td>

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -162,6 +162,21 @@ This allows one to set up any of the [backend](https://opensearch.org/docs/lates
 
 *The configuration must be valid or the dashboard will fail to start.*
 
+## Configuring a basePath
+
+When using OpenSearch behind a reverse proxy you have to configure a base path. This can be achieved by setting the base path field in the configuraiton of OpenSearch Dashboards. Behind the scenes the according configuration fields are set automatically in the opensearch.yml file.
+
+```yaml
+apiVersion: opensearch.opster.io/v1
+kind: OpenSearchCluster
+...
+spec:
+  dashboards:
+    enable: true
+    basePath: "/logs"
+```
+
+
 ## TLS
 
 For security reasons, encryption is required for communication with the OpenSearch cluster and between cluster nodes. If you do not configure any encryption, OpenSearch will use the included demo TLS certificates, which are not ideal for most active deployments.

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -114,6 +114,8 @@ type DashboardsConfig struct {
 	Replicas   int32                       `json:"replicas"`
 	Tls        *DashboardsTlsConfig        `json:"tls,omitempty"`
 	Version    string                      `json:"version"`
+	// Base Path for Opensearch Clusters running behind a reverse proxy
+	BasePath string `json:"basePath,omitempty"`
 	// Additional properties for opensearch_dashboards.yaml
 	AdditionalConfig map[string]string `json:"additionalConfig,omitempty"`
 	// Secret that contains fields username and password for dashboards to use to login to opensearch, must only be supplied if a custom securityconfig is provided

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -2028,6 +2028,10 @@ spec:
                             type: array
                         type: object
                     type: object
+                  basePath:
+                    description: Base Path for Opensearch Clusters running behind
+                      a reverse proxy
+                    type: string
                   enable:
                     type: boolean
                   env:

--- a/opensearch-operator/pkg/builders/dashboards.go
+++ b/opensearch-operator/pkg/builders/dashboards.go
@@ -70,6 +70,14 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 		probeScheme = "HTTPS"
 	}
 
+	healthcheckPath := "/api/reporting/stats"
+
+	// Figure out if the opensearch cluster runs with a base path configured
+	if cr.Spec.Dashboards.BasePath != "" {
+		// If basePath is correctly setup, prefix healthcheck path
+		healthcheckPath = fmt.Sprintf("%s%s", cr.Spec.Dashboards.BasePath, healthcheckPath)
+	}
+
 	probe := corev1.Probe{
 		PeriodSeconds:       20,
 		TimeoutSeconds:      5,
@@ -83,7 +91,13 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 		  - name: Authorization
 		    value: Basic YWRtaW46YWRtaW4=*/
 
-		ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/api/reporting/stats", Port: intstr.IntOrString{IntVal: port}, Scheme: probeScheme}},
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path:   healthcheckPath,
+				Port:   intstr.IntOrString{IntVal: port},
+				Scheme: probeScheme,
+			},
+		},
 	}
 
 	return &appsv1.Deployment{
@@ -138,6 +152,11 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 func NewDashboardsConfigMapForCR(cr *opsterv1.OpenSearchCluster, name string, config map[string]string) *corev1.ConfigMap {
 	config["server.name"] = cr.Name + "-dashboards"
 	config["opensearch.ssl.verificationMode"] = "none"
+
+	if cr.Spec.Dashboards.BasePath != "" {
+		config["server.basePath"] = cr.Spec.Dashboards.BasePath
+		config["server.rewriteBasePath"] = "true"
+	}
 
 	keys := make([]string, 0, len(config))
 


### PR DESCRIPTION
This PR extends the CRD with an option `spec.dashboards.*basePath*` and allows for easy configuration of a basepath for OpenSearch Dashboards (in particular useful when running behind a reverse proxy).

This PR aims to fix #309 

Signed-off-by: Luis Schweigard <luis.schweigard@maibornwolff.de>