### PR TITLE
Added support to override the default command in general spec

### DIFF
--- a/charts/opensearch-operator/templates/opensearchclusters.opensearch.opster.io-crd.yaml
+++ b/charts/opensearch-operator/templates/opensearchclusters.opensearch.opster.io-crd.yaml
@@ -2480,6 +2480,8 @@ spec:
                       - path
                       type: object
                     type: array
+                  command:
+                    type: string
                   defaultRepo:
                     type: string
                   drainDataNodes:

--- a/docs/designs/crd.md
+++ b/docs/designs/crd.md
@@ -135,6 +135,12 @@ GeneralConfig defines global Opensearch cluster configuration
         <td>false</td>
         <td>opensearch</td>
       </tr><tr>
+        <td><b>command</b></td>
+        <td>string</td>
+        <td>Specify command in case you want to override the default command, useful if you have a custom image.</td>
+        <td>false</td>
+        <td>./opensearch-docker-entrypoint.sh</td>
+      </tr><tr>
         <td><b>version</b></td>
         <td>string</td>
         <td>Version of opensearch to deploy</td>

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -45,6 +45,7 @@ type GeneralConfig struct {
 	// Drain data nodes controls whether to drain data notes on rolling restart operations
 	DrainDataNodes bool     `json:"drainDataNodes,omitempty"`
 	PluginsList    []string `json:"pluginsList,omitempty"`
+	Command        string   `json:"command,omitempty"`
 	// Additional volumes to mount to all pods in the cluster
 	AdditionalVolumes []AdditionalVolume `json:"additionalVolumes,omitempty"`
 	// Populate opensearch keystore before startup

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -2480,6 +2480,8 @@ spec:
                       - path
                       type: object
                     type: array
+                  command:
+                    type: string
                   defaultRepo:
                     type: string
                   drainDataNodes:

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -214,7 +214,12 @@ func NewSTSForNodePool(
 	image := helpers.ResolveImage(cr, &node)
 	initHelperImage := helpers.ResolveInitHelperImage(cr)
 
-	mainCommand := helpers.BuildMainCommand("./bin/opensearch-plugin", cr.Spec.General.PluginsList, true, "./opensearch-docker-entrypoint.sh")
+	startUpCommand := "./opensearch-docker-entrypoint.sh"
+	// If a custom command is specified, use it.
+	if len(cr.Spec.General.Command) > 0 {
+		startUpCommand = cr.Spec.General.Command
+	}
+	mainCommand := helpers.BuildMainCommand("./bin/opensearch-plugin", cr.Spec.General.PluginsList, true, startUpCommand)
 
 	initContainers := []corev1.Container{
 		{

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -404,12 +404,12 @@ var _ = Describe("Builders", func() {
 
 			actualSts := appsv1.StatefulSet{}
 			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "foobar", Namespace: namespaceName}, &actualSts)
+				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: "foobar" + "-masters", Namespace: namespaceName}, &actualSts)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 
 			actualCommand := actualSts.Spec.Template.Spec.Containers[0].Command
-			Expect(actualCommand).To(Equal(customCommand))
+			Expect(actualCommand[2]).To(Equal(customCommand))
 		})
 	})
 })

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -18,6 +18,11 @@ const (
 	interval = time.Second * 1
 )
 
+const (
+	timeout  = time.Second * 30
+	interval = time.Second * 1
+)
+
 func ClusterDescWithVersion(version string) opsterv1.OpenSearchCluster {
 	return opsterv1.OpenSearchCluster{
 		Spec: opsterv1.ClusterSpec{

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -3,24 +3,12 @@ package builders
 import (
 	"context"
 	"fmt"
-	"os"
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	opsterv1 "opensearch.opster.io/api/v1"
 	"opensearch.opster.io/pkg/helpers"
-)
-
-const (
-	timeout  = time.Second * 30
-	interval = time.Second * 1
-)
-
-const (
-	timeout  = time.Second * 30
-	interval = time.Second * 1
+	"os"
 )
 
 func ClusterDescWithVersion(version string) opsterv1.OpenSearchCluster {


### PR DESCRIPTION
Currently we can override the default command used by OpenSearch image, this will help in case we have a custom image being used.