### PR TITLE
Fix plugin install for OSD

### DIFF
--- a/opensearch-operator/pkg/builders/dashboards.go
+++ b/opensearch-operator/pkg/builders/dashboards.go
@@ -116,7 +116,7 @@ func NewDashboardsDeploymentForCR(cr *opsterv1.OpenSearchCluster, volumes []core
 		},
 	}
 
-	mainCommand := helpers.BuildMainCommand("./bin/opensearch-dashboards-plugin", cr.Spec.Dashboards.PluginsList, false, "./opensearch-dashboards-docker-entrypoint.sh")
+	mainCommand := helpers.BuildMainCommandOSD("./bin/opensearch-dashboards-plugin", cr.Spec.Dashboards.PluginsList, "./opensearch-dashboards-docker-entrypoint.sh")
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/opensearch-operator/pkg/builders/dashboards_test.go
+++ b/opensearch-operator/pkg/builders/dashboards_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Builders", func() {
 
 			var result = NewDashboardsDeploymentForCR(&spec, nil, nil, nil)
 			installCmd := fmt.Sprintf(
-				"./bin/opensearch-dashboards-plugin install '%s' '%s' && ./opensearch-dashboards-docker-entrypoint.sh",
+				"./bin/opensearch-dashboards-plugin install '%s' && ./bin/opensearch-dashboards-plugin install '%s' && ./opensearch-dashboards-docker-entrypoint.sh",
 				pluginA,
 				pluginB,
 			)

--- a/opensearch-operator/pkg/helpers/reconcile-helpers.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers.go
@@ -163,3 +163,18 @@ func BuildMainCommand(installerBinary string, pluginsList []string, batchMode bo
 
 	return mainCommand
 }
+
+func BuildMainCommandOSD(installerBinary string, pluginsList []string, entrypoint string) []string {
+	var mainCommand []string
+	mainCommand = append(mainCommand, "/bin/bash", "-c")
+
+	var com string
+	for _, plugin := range pluginsList {
+		com = com + installerBinary + " install" + " '" + strings.Replace(plugin, "'", "\\'", -1) + "'"
+		com = com + " && "
+	}
+	com = com + entrypoint
+
+	mainCommand = append(mainCommand, com)
+	return mainCommand
+}


### PR DESCRIPTION
This fixes #433 

Currently the command is built as - 
`./bin/opensearch-dashboards-plugin install 'securityDashboards' 'reportsDashboards'`
Tried this same command in a standalone OSD pod and the plugin install basically ignores the second plugin. And OSD-plugin install doesn't support batch mode either. So, changed the command to built for each plugin and append the entrypoint at the end
`./bin/opensearch-dashboards-plugin install 'reportsDashboards' && ./bin/opensearch-dashboards-plugin install 'securityDashboards' && ./opensearch-dashboards-docker-entrypoint.sh`