### PR TITLE
Fix reconcilation logic for default disk size

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	ConfigurationChecksumAnnotation  = "opster.io/config"
+	DefaultDiskSize                  = "30Gi"
 	securityconfigChecksumAnnotation = "securityconfig/checksum"
 )
 
@@ -38,7 +39,7 @@ func NewSTSForNodePool(
 	//To make sure disksize is not passed as empty
 	var disksize string
 	if len(node.DiskSize) == 0 {
-		disksize = "30Gi"
+		disksize = DefaultDiskSize
 	} else {
 		disksize = node.DiskSize
 	}

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -218,6 +218,9 @@ func (r *ClusterReconciler) reconcileNodeStatefulSet(nodePool opsterv1.NodePool,
 		existingDisk := existing.Spec.VolumeClaimTemplates[0].Spec.Resources.Requests.Storage().String()
 		r.logger.Info("The existing statefulset VolumeClaimTemplate disk size is: " + existingDisk)
 		r.logger.Info("The cluster definition nodePool disk size is: " + nodePool.DiskSize)
+		if nodePool.DiskSize == "" { // Default case
+			nodePool.DiskSize = builders.DefaultDiskSize
+		}
 		if existingDisk == nodePool.DiskSize {
 			r.logger.Info("The existing disk size " + existingDisk + " is same as passed in disk size " + nodePool.DiskSize)
 		} else {


### PR DESCRIPTION
This fixes https://github.com/Opster/opensearch-k8s-operator/issues/432

If the diskSize and persistence are not defined in the CR, then the operator defaults to a PV of 30Gi but after the PV and the sts are created, the operator gets stuck in a reconcile loop and the master pod fails to come up.
This fix checks if the desired diskSize is not defined or empty which is the default case and sets the value to the default disk size. That solved the problem.