### PR TITLE
Match prometheus monitoring integration docs with CRD spec

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -1041,7 +1041,7 @@ spec:
     version: <YOUR_CLUSTER_VERSION>
     monitoring:
       enable: true
-      interval: 30s
+      scrapeInterval: 30s
       monitoringUserSecret: appUserSecret
       pluginUrl: https://github.com/aiven/prometheus-exporter-plugin-for-opensearch/releases/download/<YOUR_CLUSTER_VERSION>/prometheus-exporter-<YOUR_CLUSTER_VERSION>.zip
 ```


### PR DESCRIPTION
This matches the CRD here https://github.com/Opster/opensearch-k8s-operator/blob/main/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml#L2877
