### PR TITLE
Pod Security context for securityconfig-update job

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -934,6 +934,10 @@ func NewSnapshotRepoconfigUpdateJob(
 		Name:      "admin-credentials",
 		MountPath: "/mnt/admin-credentials",
 	})
+
+	podSecurityContext := instance.Spec.General.PodSecurityContext
+	securityContext := instance.Spec.General.SecurityContext
+
 	return batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: namespace, Annotations: annotations},
 		Spec: batchv1.JobSpec{
@@ -949,9 +953,11 @@ func NewSnapshotRepoconfigUpdateJob(
 						Command:         []string{"/bin/bash", "-c"},
 						Args:            []string{snapshotCmd},
 						VolumeMounts:    volumeMounts,
+						SecurityContext: securityContext,
 					}},
-					RestartPolicy: corev1.RestartPolicyNever,
-					Volumes:       volumes,
+					RestartPolicy:   corev1.RestartPolicyNever,
+					Volumes:         volumes,
+					SecurityContext: podSecurityContext,
 				},
 			},
 		},

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -1005,6 +1005,8 @@ func NewSecurityconfigUpdateJob(
 	backoffLimit := int32(0)
 
 	image := helpers.ResolveImage(instance, &node)
+	securityContext := instance.Spec.General.SecurityContext
+	podSecurityContext := instance.Spec.General.PodSecurityContext
 
 	return batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: namespace, Annotations: annotations},
@@ -1021,10 +1023,12 @@ func NewSecurityconfigUpdateJob(
 						Command:         []string{"/bin/bash", "-c"},
 						Args:            []string{arg},
 						VolumeMounts:    volumeMounts,
+						SecurityContext: securityContext,
 					}},
 					Volumes:          volumes,
 					RestartPolicy:    corev1.RestartPolicyNever,
 					ImagePullSecrets: image.ImagePullSecrets,
+					SecurityContext:  podSecurityContext,
 				},
 			},
 		},


### PR DESCRIPTION
This fixes #472 .

Changes:

- Use the same security-context provided for OS cluster pods when building the security-config job as well.

Also added security context for the new snapshot job