### PR TITLE
Use sorted keys for map iterations in keyMappings to have a stable order

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -3,7 +3,6 @@ package builders
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 
 	monitoring "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -301,11 +300,11 @@ func NewSTSForNodePool(
 					MountPath: "/tmp/keystoreSecrets/" + keystoreValue.Secret.Name,
 				})
 			} else {
-				// If renames are necessary, mount keys from secrets directly and rename from old to new
-				for oldKey, newKey := range keystoreValue.KeyMappings {
+				keys := helpers.SortedKeys(keystoreValue.KeyMappings)
+				for _, oldKey := range keys {
 					initContainerVolumeMounts = append(initContainerVolumeMounts, corev1.VolumeMount{
 						Name:      "keystore-" + keystoreValue.Secret.Name,
-						MountPath: "/tmp/keystoreSecrets/" + keystoreValue.Secret.Name + "/" + newKey,
+						MountPath: "/tmp/keystoreSecrets/" + keystoreValue.Secret.Name + "/" + keystoreValue.KeyMappings[oldKey],
 						SubPath:   oldKey,
 					})
 				}
@@ -448,11 +447,7 @@ func NewSTSForNodePool(
 	}
 
 	// Append additional config to env vars
-	keys := make([]string, 0, len(extraConfig))
-	for key := range extraConfig {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+	keys := helpers.SortedKeys(extraConfig)
 	for _, k := range keys {
 		sts.Spec.Template.Spec.Containers[0].Env = append(sts.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 			Name:  k,
@@ -734,11 +729,7 @@ func NewBootstrapPod(
 		extraConfig = cr.Spec.Bootstrap.AdditionalConfig
 	}
 
-	keys := make([]string, 0, len(extraConfig))
-	for key := range extraConfig {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
+	keys := helpers.SortedKeys(extraConfig)
 	for _, k := range keys {
 		env = append(env, corev1.EnvVar{
 			Name:  k,
@@ -901,12 +892,7 @@ func NewSnapshotRepoconfigUpdateJob(
 		var snapshotSettings string
 
 		// Sort keys to have a stable order
-		keys := make([]string, 0, len(repository.Settings))
-		for key := range repository.Settings {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-
+		keys := helpers.SortedKeys(repository.Settings)
 		for _, settingsKey := range keys {
 			snapshotSettings += fmt.Sprintf("\"%s\": \"%s\" , ", settingsKey, repository.Settings[settingsKey])
 		}

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"time"
 
 	"github.com/hashicorp/go-version"
@@ -119,6 +120,17 @@ func MergeConfigs(left map[string]string, right map[string]string) map[string]st
 		left[k] = v
 	}
 	return left
+}
+
+// Return the keys of the input map in sorted order
+// Can be used if you want to iterate over a map but have a stable order
+func SortedKeys(input map[string]string) []string {
+	keys := make([]string, 0, len(input))
+	for key := range input {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func ResolveClusterManagerRole(ver string) string {


### PR DESCRIPTION
Fixes #446 

Root cause of the problem from that issue is that the order of keys in a map is not stable, which leads to phantom diffs when maps from the CRD are converted by the operator to lists in the resulting kubernetes objects.
The solution (that we already employ in most places) is to sort the keys before doing an iteration.