### PR TITLE
Searchable snapshots GA

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -177,7 +177,7 @@ func NewSTSForNodePool(
 	}
 
 	// If node role `search` defined add required experimental flag if version less than 2.7
-	if helpers.ContainsString(selectedRoles, "search") && cr.Spec.General.Version < "2.7" {
+	if helpers.ContainsString(selectedRoles, "search") && helpers.CompareVersions(cr.Spec.General.Version, "2.7.0") {
 		jvm += " -Dopensearch.experimental.feature.searchable_snapshot.enabled=true"
 	}
 

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -176,8 +176,8 @@ func NewSTSForNodePool(
 		jvm = node.Jvm
 	}
 
-	// If node role `search` defined add required experimental flag
-	if helpers.ContainsString(selectedRoles, "search") {
+	// If node role `search` defined add required experimental flag if version less than 2.7
+	if helpers.ContainsString(selectedRoles, "search") && cr.Spec.General.Version < "2.7" {
 		jvm += " -Dopensearch.experimental.feature.searchable_snapshot.enabled=true"
 	}
 

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -208,7 +208,7 @@ var _ = Describe("Builders", func() {
 			Expect(expected).To(Equal(actual))
 		})
 
-		It("should properly add the required when the node.roles contains search", func() {
+		It("should add experimental flag when the node.roles contains search and the version is below 2.7", func() {
 			var clusterObject = ClusterDescWithVersion("2.2.1")
 			var nodePool = opsterv1.NodePool{
 				Component: "masters",
@@ -223,6 +223,24 @@ var _ = Describe("Builders", func() {
 			Expect(result.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
 				Name:  "OPENSEARCH_JAVA_OPTS",
 				Value: "-Xmx512M -Xms512M -Dopensearch.experimental.feature.searchable_snapshot.enabled=true -Dopensearch.transport.cname_in_publish_address=true",
+			}))
+		})
+
+		It("should not add experimental flag when the node.roles contains search and the version is 2.7 or above", func() {
+			var clusterObject = ClusterDescWithVersion("2.7.0")
+			var nodePool = opsterv1.NodePool{
+				Component: "masters",
+				Roles:     []string{"search"},
+			}
+			var result = NewSTSForNodePool("foobar", &clusterObject, nodePool, "foobar", nil, nil, nil)
+			Expect(result.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
+				Name:  "node.roles",
+				Value: "search",
+			}))
+
+			Expect(result.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
+				Name:  "OPENSEARCH_JAVA_OPTS",
+				Value: "-Xmx512M -Xms512M -Dopensearch.transport.cname_in_publish_address=true",
 			}))
 		})
 

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -244,3 +244,15 @@ func HasDataRole(nodePool *opsterv1.NodePool) bool {
 func HasManagerRole(nodePool *opsterv1.NodePool) bool {
 	return ContainsString(nodePool.Roles, "master") || ContainsString(nodePool.Roles, "cluster_manager")
 }
+
+// Compares whether v1 is LessThan v2
+func CompareVersions(v1 string, v2 string) bool {
+	lessThan := false
+	ver1, err := version.NewVersion(v1)
+
+	ver2, _ := version.NewVersion(v2)
+	if err == nil && ver1.LessThan(ver2) {
+		lessThan = true
+	}
+	return lessThan
+}

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -247,12 +247,7 @@ func HasManagerRole(nodePool *opsterv1.NodePool) bool {
 
 // Compares whether v1 is LessThan v2
 func CompareVersions(v1 string, v2 string) bool {
-	lessThan := false
 	ver1, err := version.NewVersion(v1)
-
 	ver2, _ := version.NewVersion(v2)
-	if err == nil && ver1.LessThan(ver2) {
-		lessThan = true
-	}
-	return lessThan
+	return err == nil && ver1.LessThan(ver2)
 }


### PR DESCRIPTION
This follows the announcement here https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-2.7.0.md This means the experimental flag only needs to be added if version is less than 2.7.0