### PR TITLE
Recreate emptyDir cluster on failure

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -813,6 +813,12 @@ In case the operator detects several crashed or missing pods (for a nodepool) at
 
 The recovery mode also kicks in if you deleted your cluster but kept the PVCs around and are then reinstalling the cluster.
 
+If the cluster is using emptyDir i.e. every node pool is using emptyDir, the operator starts recovery in case of these failure scenarios:
+1. More than half the master nodes are missing or crashed and thus, the quorum is broken.
+2. All data nodes are missing or crashed and thus, no data node is available.
+
+But since the cluster is using emptyDir, data is lost and not recoverable. So, it is impossible to restore the cluster to its old state. Therefore, the operator deletes and recreates the entire OpenSearch cluster.
+
 ### Rolling Upgrades
 
 The operator supports automatic rolling version upgrades. To do so simply change the `general.version` in your cluster spec and reapply it:


### PR DESCRIPTION
This fixes #443 

Changes:

- Add scaler component status while increasing or decreasing nodes
- Add code to check if the cluster is using only emptyDir
- Add code to recreate the emptyDir cluster in failure scenarios

The failure scenarios being checked are:

- If all the data nodes fail at once. 
- The quorum is broken i.e. more than half of master pods fail at once.

This scenarios causes to the cluster to completely break. So the operator deletes all the sts, the security job and sets the initialized flag in the OS CR to false. This causes the bootstrap pod and security job to be recreated and the cluster is again initialized.