### PR TITLE
Make kube-proxy container optional

### DIFF
--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -15,6 +15,7 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
+      {{- if or (.Values.kubeRbacProxy.enable) (eq (.Values.kubeRbacProxy.enable | toString) "<nil>") }}
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
@@ -31,6 +32,7 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+      {{- end}}
       - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -46,6 +46,7 @@ manager:
   watchNamespace:
 
 kubeRbacProxy:
+  enable: true
   resources:
     limits:
       cpu: 50m


### PR DESCRIPTION
This fixes #514 

Changes:

- Changed operator deployment to optionally create the proxy container based on the value kubeProxy.enable
- By default it will be enabled to maintain backwards compatibility.