### PR TITLE
Do not continue rolling restart while other pod is terminating

### DIFF
--- a/opensearch-operator/functionaltests/helmtests/helmcrinstall.go
+++ b/opensearch-operator/functionaltests/helmtests/helmcrinstall.go
@@ -24,7 +24,7 @@ var _ = Describe("DeployWithHelm", Ordered, func() {
 					return sts.Status.ReadyReplicas
 				}
 				return 0
-			}, time.Minute*8, time.Second*5).Should(Equal(int32(3)))
+			}, time.Minute*15, time.Second*5).Should(Equal(int32(3)))
 		})
 
 		It("should have a ready dashboards pod", func() {
@@ -35,7 +35,7 @@ var _ = Describe("DeployWithHelm", Ordered, func() {
 					return deployment.Status.ReadyReplicas
 				}
 				return 0
-			}, time.Minute*2, time.Second*5).Should(Equal(int32(1)))
+			}, time.Minute*5, time.Second*5).Should(Equal(int32(1)))
 		})
 	})
 })

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"reflect"
 	"sort"
 	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/hashicorp/go-version"
 	appsv1 "k8s.io/api/apps/v1"
@@ -182,6 +183,42 @@ func DiffSlice(leftSlice, rightSlice []string) []string {
 		}
 	}
 	return diff
+}
+
+// Count the number of pods running and ready and not terminating for a given nodePool
+func CountRunningPodsForNodePool(ctx context.Context, k8sClient client.Client, cr *opsterv1.OpenSearchCluster, nodePool *opsterv1.NodePool) (int, error) {
+	// Constrict selector from labels
+	clusterReq, err := labels.NewRequirement(ClusterLabel, selection.Equals, []string{cr.ObjectMeta.Name})
+	if err != nil {
+		return 0, err
+	}
+	componentReq, err := labels.NewRequirement(NodePoolLabel, selection.Equals, []string{nodePool.Component})
+	if err != nil {
+		return 0, err
+	}
+	selector := labels.NewSelector()
+	selector = selector.Add(*clusterReq, *componentReq)
+	// List pods matching selector
+	list := corev1.PodList{}
+	if err := k8sClient.List(ctx, &list, &client.ListOptions{LabelSelector: selector}); err != nil {
+		return 0, err
+	}
+	// Count pods that are ready
+	var numReadyPods = 0
+	for _, pod := range list.Items {
+		// If DeletionTimestamp is set the pod is terminating
+		var podReady = pod.ObjectMeta.DeletionTimestamp == nil
+		// Count the pod as not ready if one of its containers is not running or not ready
+		for _, container := range pod.Status.ContainerStatuses {
+			if !container.Ready || container.State.Running == nil {
+				podReady = false
+			}
+		}
+		if podReady {
+			numReadyPods += 1
+		}
+	}
+	return numReadyPods, nil
 }
 
 // Count the number of PVCs created for the given NodePool


### PR DESCRIPTION
Fixes #464 

If a rolling restart for a nodePool/STS is pending, first check if any of the pods are in a terminating state or otherwise not healthy. If so, wait with the restart to not get the cluster into a potentialy unavailable state.