### PR TITLE
Set JVM to half request memory in NodePools when jvm is not provided

### DIFF
--- a/docs/designs/crd.md
+++ b/docs/designs/crd.md
@@ -487,7 +487,7 @@ Every NodePool is defining different Opensearch Nodes StatefulSet
         <td>string</td>
         <td>JVM args. Use this to define heap size (recommendation: Set to half of memory request)</td>
         <td>false</td>
-        <td>-Xmx512M -Xms512M if `resources.requests.memory` is not set. It set to half of `resources.requests.memory` is not set.</td>
+        <td>Half of `resources.requests.memory` if jvm is not set. Fallback value is `-Xmx512M -Xms512M` if neither `resources.requests.memory` nor jvm are set.</td>
       </tr><tr>
       </tr><tr>
         <td><b>Affinity</b></td>

--- a/docs/designs/crd.md
+++ b/docs/designs/crd.md
@@ -487,7 +487,7 @@ Every NodePool is defining different Opensearch Nodes StatefulSet
         <td>string</td>
         <td>JVM args. Use this to define heap size (recommendation: Set to half of memory request)</td>
         <td>false</td>
-        <td>-Xmx512M -Xms512M</td>
+        <td>-Xmx512M -Xms512M if `resources.requests.memory` is not set. It set to half of `resources.requests.memory` is not set.</td>
       </tr><tr>
       </tr><tr>
         <td><b>Affinity</b></td>

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -343,7 +343,6 @@ spec:
         roles:
           - "data"
 ```
-### Dynamic Java heap size in nodePools
 
 If `jvm` is not provided then the java heap size will be set to half of
 `resources.requests.memory` which is the recommend value for data nodes

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -343,6 +343,15 @@ spec:
         roles:
           - "data"
 ```
+### Dynamic Java heap size in nodePools
+
+If `jvm` is not provided then the java heap size will be set to half of
+`resources.requests.memory` which is the recommend value for data nodes
+
+If `jvm` is not provided and `resources.requests.memory` does not exist
+then value will be `-Xmx512M -Xms512M`.
+
+We don't support dynamic values depending on the node type for now.
 
 ### Deal with `max virtual memory areas vm.max_map_count` errors
 

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -169,7 +169,7 @@ func NewSTSForNodePool(
 		//vendor ="elasticsearch"
 	}
 
-	jvm := helpers.GetJvmHeapSize(node)
+	jvm := helpers.GetJvmHeapSize(&node)
 
 	// If node role `search` defined add required experimental flag if version less than 2.7
 	if helpers.ContainsString(selectedRoles, "search") && helpers.CompareVersions(cr.Spec.General.Version, "2.7.0") {

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -169,12 +169,7 @@ func NewSTSForNodePool(
 		//vendor ="elasticsearch"
 	}
 
-	var jvm string
-	if node.Jvm == "" {
-		jvm = "-Xmx512M -Xms512M"
-	} else {
-		jvm = node.Jvm
-	}
+	jvm := helpers.GetJvmHeapSize(node)
 
 	// If node role `search` defined add required experimental flag if version less than 2.7
 	if helpers.ContainsString(selectedRoles, "search") && helpers.CompareVersions(cr.Spec.General.Version, "2.7.0") {

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -169,7 +169,7 @@ func NewSTSForNodePool(
 		//vendor ="elasticsearch"
 	}
 
-	jvm := helpers.GetJvmHeapSize(&node)
+	jvm := helpers.CalculateJvmHeapSize(&node)
 
 	// If node role `search` defined add required experimental flag if version less than 2.7
 	if helpers.ContainsString(selectedRoles, "search") && helpers.CompareVersions(cr.Spec.General.Version, "2.7.0") {

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -358,7 +358,7 @@ var _ = Describe("Builders", func() {
 				Jvm: "-Xmx1024M -Xms1024M",
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceMemory: resource.MustParse("2Gi"),
+						corev1.ResourceMemory: resource.MustParse("4Gi"),
 					},
 				},
 			}

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -361,11 +361,11 @@ func CompareVersions(v1 string, v2 string) bool {
 	return err == nil && ver1.LessThan(ver2)
 }
 
-func GetJvmHeapSize(node opsterv1.NodePool) string {
+func GetJvmHeapSize(nodePool *opsterv1.NodePool) string {
 	jvmHeapSizeTemplate := "-Xmx%s -Xms%s"
 
-	if node.Jvm == "" {
-		memoryLimit := node.Resources.Requests.Memory()
+	if nodePool.Jvm == "" {
+		memoryLimit := nodePool.Resources.Requests.Memory()
 		nodePoolMemorySize, _ := resource.ParseQuantity(memoryLimit.String())
 
 		// Memory request is not present
@@ -383,5 +383,5 @@ func GetJvmHeapSize(node opsterv1.NodePool) string {
 		return fmt.Sprintf(jvmHeapSizeTemplate, maximumJavaHeapSize, initialJavaHeapSize)
 	}
 
-	return node.Jvm
+	return nodePool.Jvm
 }

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -361,7 +361,7 @@ func CompareVersions(v1 string, v2 string) bool {
 	return err == nil && ver1.LessThan(ver2)
 }
 
-func GetJvmHeapSize(nodePool *opsterv1.NodePool) string {
+func CalculateJvmHeapSize(nodePool *opsterv1.NodePool) string {
 	jvmHeapSizeTemplate := "-Xmx%s -Xms%s"
 
 	if nodePool.Jvm == "" {


### PR DESCRIPTION
Set JVM to 50% of `resources.requests.memory` when jvm is not provided. This is recommended by [OpenSearch](https://opensearch.org/docs/1.0/opensearch/install/important-settings/).

Users don't have to update the jvm every time they change the requested memory of the node pools.

Refs: https://github.com/Opster/opensearch-k8s-operator/issues/426