### PR TITLE
Change OpenSearchClusterSpec to opensearchCluster

### DIFF
--- a/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
+++ b/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
@@ -1,175 +1,175 @@
-{{- if eq .Values.OpenSearchClusterSpec.enabled true }}
+{{- if eq .Values.opensearchCluster.enabled true }}
 apiVersion: opensearch.opster.io/v1
 kind: OpenSearchCluster
 metadata:
   name: {{ .Values.clusterName | default .Release.Name}}
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- if .Values.OpenSearchClusterSpec.bootstrap }}
+  {{- if .Values.opensearchCluster.bootstrap }}
   bootstrap:
-    {{- if .Values.OpenSearchClusterSpec.bootstrap.additionalConfig }}
+    {{- if .Values.opensearchCluster.bootstrap.additionalConfig }}
     additionalConfig:
-      {{ toYaml .Values.OpenSearchClusterSpec.bootstrap.additionalConfig | nindent 6 }}
+      {{ toYaml .Values.opensearchCluster.bootstrap.additionalConfig | nindent 6 }}
     {{- end }}
   {{- end }}
-  {{- if .Values.OpenSearchClusterSpec.initHelper }}
+  {{- if .Values.opensearchCluster.initHelper }}
   initHelper:
-    {{- if .Values.OpenSearchClusterSpec.initHelper.version }}
-    version: {{ .Values.OpenSearchClusterSpec.initHelper.version }}
+    {{- if .Values.opensearchCluster.initHelper.version }}
+    version: {{ .Values.opensearchCluster.initHelper.version }}
     {{ end }}
-    {{- if .Values.OpenSearchClusterSpec.initHelper.image }}
-    image: {{ .Values.OpenSearchClusterSpec.initHelper.image }}
+    {{- if .Values.opensearchCluster.initHelper.image }}
+    image: {{ .Values.opensearchCluster.initHelper.image }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.initHelper.imagePullPolicy }}
-    imagePullPolicy: {{ .Values.OpenSearchClusterSpec.initHelper.imagePullPolicy }}
+    {{- if .Values.opensearchCluster.initHelper.imagePullPolicy }}
+    imagePullPolicy: {{ .Values.opensearchCluster.initHelper.imagePullPolicy }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.initHelper.imagePullSecrets }}
+    {{- if .Values.opensearchCluster.initHelper.imagePullSecrets }}
     imagePullSecrets:
-      {{ toYaml .Values.OpenSearchClusterSpec.initHelper.imagePullSecrets | nindent 6 }}
+      {{ toYaml .Values.opensearchCluster.initHelper.imagePullSecrets | nindent 6 }}
     {{- end }}
   {{- end }}
   general:
-    {{- if .Values.OpenSearchClusterSpec.general.version }}
-    version: {{ .Values.OpenSearchClusterSpec.general.version }}
+    {{- if .Values.opensearchCluster.general.version }}
+    version: {{ .Values.opensearchCluster.general.version }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.general.image }}
-    image: {{ .Values.OpenSearchClusterSpec.general.image | quote }}
+    {{- if .Values.opensearchCluster.general.image }}
+    image: {{ .Values.opensearchCluster.general.image | quote }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.general.httpPort }}
-    httpPort: {{ .Values.OpenSearchClusterSpec.general.httpPort }}
+    {{- if .Values.opensearchCluster.general.httpPort }}
+    httpPort: {{ .Values.opensearchCluster.general.httpPort }}
     {{- end }}
     vendor: opensearch
-    serviceName: {{ .Values.OpenSearchClusterSpec.general.serviceName }}
-    {{- if .Values.OpenSearchClusterSpec.general.pluginsList }}
+    serviceName: {{ .Values.opensearchCluster.general.serviceName }}
+    {{- if .Values.opensearchCluster.general.pluginsList }}
     pluginsList:
-      {{ toYaml .Values.OpenSearchClusterSpec.general.pluginsList | nindent 6 }}
+      {{ toYaml .Values.opensearchCluster.general.pluginsList | nindent 6 }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.general.keystore }}
+    {{- if .Values.opensearchCluster.general.keystore }}
     keystore:
-      {{ toYaml .Values.OpenSearchClusterSpec.general.keystore |  nindent 6 }}
+      {{ toYaml .Values.opensearchCluster.general.keystore |  nindent 6 }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.general.securityContext }}
+    {{- if .Values.opensearchCluster.general.securityContext }}
     securityContext:
-      {{ toYaml .Values.OpenSearchClusterSpec.general.securityContext | nindent 6}}
+      {{ toYaml .Values.opensearchCluster.general.securityContext | nindent 6}}
     {{- end}}
-    {{- if .Values.OpenSearchClusterSpec.general.podSecurityContext }}
+    {{- if .Values.opensearchCluster.general.podSecurityContext }}
     podSecurityContext:
-      {{ toYaml .Values.OpenSearchClusterSpec.general.podSecurityContext | nindent 6 }}
+      {{ toYaml .Values.opensearchCluster.general.podSecurityContext | nindent 6 }}
     {{- end}}
-    {{- if .Values.OpenSearchClusterSpec.general.additionalVolumes }}
+    {{- if .Values.opensearchCluster.general.additionalVolumes }}
     additionalVolumes:
-  {{- range $key, $val := .Values.OpenSearchClusterSpec.general.additionalVolumes }}
+  {{- range $key, $val := .Values.opensearchCluster.general.additionalVolumes }}
       - name: {{ $val.name }}
         path: {{ $val.path }}
         secret:
           secretName: {{ $val.secret.secretName }}
   {{- end -}}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.general.additionalConfig }}
+    {{- if .Values.opensearchCluster.general.additionalConfig }}
     additionalConfig:
-      {{ toYaml .Values.OpenSearchClusterSpec.general.additionalConfig | nindent 6 }}
+      {{ toYaml .Values.opensearchCluster.general.additionalConfig | nindent 6 }}
     {{- end }}
-  {{- if .Values.OpenSearchClusterSpec.dashboards }}
+  {{- if .Values.opensearchCluster.dashboards }}
   dashboards:
-    {{- if .Values.OpenSearchClusterSpec.dashboards.image }}
-    image: {{ .Values.OpenSearchClusterSpec.dashboards.image | quote }}
+    {{- if .Values.opensearchCluster.dashboards.image }}
+    image: {{ .Values.opensearchCluster.dashboards.image | quote }}
     {{- end }}
-    version: {{ .Values.OpenSearchClusterSpec.dashboards.version }}
-    {{- if .Values.OpenSearchClusterSpec.dashboards.enable }}
-    enable: {{ .Values.OpenSearchClusterSpec.dashboards.enable }}
+    version: {{ .Values.opensearchCluster.dashboards.version }}
+    {{- if .Values.opensearchCluster.dashboards.enable }}
+    enable: {{ .Values.opensearchCluster.dashboards.enable }}
     {{- end }}
-    replicas: {{ .Values.OpenSearchClusterSpec.dashboards.replicas }}
-    {{- if .Values.OpenSearchClusterSpec.dashboards.pluginsList }}
+    replicas: {{ .Values.opensearchCluster.dashboards.replicas }}
+    {{- if .Values.opensearchCluster.dashboards.pluginsList }}
     pluginsList:
-      {{ toYaml .Values.OpenSearchClusterSpec.dashboards.pluginsList | nindent 6 }}
+      {{ toYaml .Values.opensearchCluster.dashboards.pluginsList | nindent 6 }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.dashboards.basePath }}
-    basePath: {{ .Values.OpenSearchClusterSpec.dashboards.basePath }}
+    {{- if .Values.opensearchCluster.dashboards.basePath }}
+    basePath: {{ .Values.opensearchCluster.dashboards.basePath }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.dashboards.labels }}
+    {{- if .Values.opensearchCluster.dashboards.labels }}
     labels: # Add any extra labels as key-value pairs here
-      {{ toYaml .Values.OpenSearchClusterSpec.dashboards.labels | nindent 6 }}
+      {{ toYaml .Values.opensearchCluster.dashboards.labels | nindent 6 }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.dashboards.annotations }}
+    {{- if .Values.opensearchCluster.dashboards.annotations }}
     annotations: # Add any extra annotations as key-value pairs here
-      {{ toYaml .Values.OpenSearchClusterSpec.dashboards.annotations | nindent 6 }}
+      {{ toYaml .Values.opensearchCluster.dashboards.annotations | nindent 6 }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.dashboards.opensearchCredentialsSecret }}
+    {{- if .Values.opensearchCluster.dashboards.opensearchCredentialsSecret }}
     opensearchCredentialsSecret:
-      name: {{ .Values.OpenSearchClusterSpec.dashboards.opensearchCredentialsSecret.name }}
+      name: {{ .Values.opensearchCluster.dashboards.opensearchCredentialsSecret.name }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.dashboards.env }}
+    {{- if .Values.opensearchCluster.dashboards.env }}
     env:
-      {{- toYaml .Values.OpenSearchClusterSpec.dashboards.env | nindent 8 }}
+      {{- toYaml .Values.opensearchCluster.dashboards.env | nindent 8 }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.dashboards.resources }}
+    {{- if .Values.opensearchCluster.dashboards.resources }}
     resources:
-      {{- if .Values.OpenSearchClusterSpec.dashboards.resources.requests }}
+      {{- if .Values.opensearchCluster.dashboards.resources.requests }}
       requests:
-        {{- if .Values.OpenSearchClusterSpec.dashboards.resources.requests.memory }}
-        memory: {{ .Values.OpenSearchClusterSpec.dashboards.resources.requests.memory }}
+        {{- if .Values.opensearchCluster.dashboards.resources.requests.memory }}
+        memory: {{ .Values.opensearchCluster.dashboards.resources.requests.memory }}
         {{- end }}
-        {{- if .Values.OpenSearchClusterSpec.dashboards.resources.requests.cpu }}
-        cpu: {{ .Values.OpenSearchClusterSpec.dashboards.resources.requests.cpu }}
+        {{- if .Values.opensearchCluster.dashboards.resources.requests.cpu }}
+        cpu: {{ .Values.opensearchCluster.dashboards.resources.requests.cpu }}
         {{- end }}
       {{- end }}
-      {{- if .Values.OpenSearchClusterSpec.dashboards.resources.limits }}
+      {{- if .Values.opensearchCluster.dashboards.resources.limits }}
       limits:
-        {{- if .Values.OpenSearchClusterSpec.dashboards.resources.limits.memory }}
-        memory: {{ .Values.OpenSearchClusterSpec.dashboards.resources.limits.memory }}
+        {{- if .Values.opensearchCluster.dashboards.resources.limits.memory }}
+        memory: {{ .Values.opensearchCluster.dashboards.resources.limits.memory }}
         {{- end }}
-        {{- if .Values.OpenSearchClusterSpec.dashboards.resources.limits.cpu }}
-        cpu: {{ .Values.OpenSearchClusterSpec.dashboards.resources.limits.cpu }}
+        {{- if .Values.opensearchCluster.dashboards.resources.limits.cpu }}
+        cpu: {{ .Values.opensearchCluster.dashboards.resources.limits.cpu }}
         {{- end }}
         {{- end }}
         {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.dashboards.tls }}
+    {{- if .Values.opensearchCluster.dashboards.tls }}
     tls:
-      {{- if .Values.OpenSearchClusterSpec.dashboards.tls.enable }}
-      enable: {{ .Values.OpenSearchClusterSpec.dashboards.tls.enable  }}  # Configure TLS
+      {{- if .Values.opensearchCluster.dashboards.tls.enable }}
+      enable: {{ .Values.opensearchCluster.dashboards.tls.enable  }}  # Configure TLS
       {{- end }}
-      {{- if .Values.OpenSearchClusterSpec.dashboards.tls.generate }}
-      generate: {{ .Values.OpenSearchClusterSpec.dashboards.tls.generate }}  # Have the Operator generate and sign a certificate
+      {{- if .Values.opensearchCluster.dashboards.tls.generate }}
+      generate: {{ .Values.opensearchCluster.dashboards.tls.generate }}  # Have the Operator generate and sign a certificate
       {{- end }}
-      {{- if .Values.OpenSearchClusterSpec.dashboards.tls.secret }}
+      {{- if .Values.opensearchCluster.dashboards.tls.secret }}
       secret:
-        name: {{ .Values.OpenSearchClusterSpec.dashboards.tls.secret.name }}
+        name: {{ .Values.opensearchCluster.dashboards.tls.secret.name }}
       {{- end }}
-      {{- if .Values.OpenSearchClusterSpec.dashboards.tls.casecret }}
+      {{- if .Values.opensearchCluster.dashboards.tls.casecret }}
       caSecret:
-        name: {{ .Values.OpenSearchClusterSpec.dashboards.tls.caSecret.name }}
+        name: {{ .Values.opensearchCluster.dashboards.tls.caSecret.name }}
       {{- end }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.dashboards.securityContext }}
+    {{- if .Values.opensearchCluster.dashboards.securityContext }}
     securityContext:
-      {{ toYaml .Values.OpenSearchClusterSpec.dashboards.securityContext | nindent 6 }}
+      {{ toYaml .Values.opensearchCluster.dashboards.securityContext | nindent 6 }}
     {{- end}}
-    {{- if .Values.OpenSearchClusterSpec.dashboards.podSecurityContext }}
+    {{- if .Values.opensearchCluster.dashboards.podSecurityContext }}
     podSecurityContext:
-      {{ toYaml .Values.OpenSearchClusterSpec.dashboards.podSecurityContext | nindent 6}}
+      {{ toYaml .Values.opensearchCluster.dashboards.podSecurityContext | nindent 6}}
     {{- end}}
-    {{- if .Values.OpenSearchClusterSpec.dashboards.additionalVolumes }}
+    {{- if .Values.opensearchCluster.dashboards.additionalVolumes }}
     additionalVolumes:
-    {{- range $key,$val := .Values.OpenSearchClusterSpec.dashboards.additionalVolumes }}
+    {{- range $key,$val := .Values.opensearchCluster.dashboards.additionalVolumes }}
     - name: {{ $val.name }}
       path: {{ $val.path }}
       secret:
         secretName: {{ $val.secretName.name }}
     {{- end }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.dashboards.additionalConfig }}
+    {{- if .Values.opensearchCluster.dashboards.additionalConfig }}
     additionalConfig:
-      {{ toYaml .Values.OpenSearchClusterSpec.dashboards.additionalConfig | nindent 6 }}
+      {{ toYaml .Values.opensearchCluster.dashboards.additionalConfig | nindent 6 }}
     {{- end }}
   {{- end }}
-  {{- if .Values.OpenSearchClusterSpec.confMgmt }}
+  {{- if .Values.opensearchCluster.confMgmt }}
   confMgmt:
-    {{- if .Values.OpenSearchClusterSpec.confMgmt.smartScaler }}
-    smartScaler: .Values.OpenSearchClusterSpec.confMgmt.smartScaler
+    {{- if .Values.opensearchCluster.confMgmt.smartScaler }}
+    smartScaler: .Values.opensearchCluster.confMgmt.smartScaler
     {{- end }}
   {{- end }}
   nodePools:
-  {{- range $key,$val := .Values.OpenSearchClusterSpec.nodePools }}
+  {{- range $key,$val := .Values.opensearchCluster.nodePools }}
     - component: {{ $val.component }}
       replicas: {{ $val.replicas }}
       diskSize: {{ $val.diskSize | quote }}
@@ -240,51 +240,51 @@ spec:
         {{ toYaml $val.additionalConfig | nindent 8 }}
       {{- end }}
   {{- end }}
-  {{- if .Values.OpenSearchClusterSpec.security }}
+  {{- if .Values.opensearchCluster.security }}
   security:
-    {{- if .Values.OpenSearchClusterSpec.security.config }}
+    {{- if .Values.opensearchCluster.security.config }}
     config:
-      {{- if .Values.OpenSearchClusterSpec.security.config.adminSecret }}
+      {{- if .Values.opensearchCluster.security.config.adminSecret }}
       adminSecret:
-        name: {{ .Values.OpenSearchClusterSpec.security.config.adminSecret.name }}
+        name: {{ .Values.opensearchCluster.security.config.adminSecret.name }}
       {{- end }}
-      {{- if .Values.OpenSearchClusterSpec.security.config.adminCredentialsSecret }}
+      {{- if .Values.opensearchCluster.security.config.adminCredentialsSecret }}
       adminCredentialsSecret:
-        name: {{ .Values.OpenSearchClusterSpec.security.config.adminCredentialsSecret.name }}
+        name: {{ .Values.opensearchCluster.security.config.adminCredentialsSecret.name }}
       {{- end }}
-      {{- if .Values.OpenSearchClusterSpec.security.config.securityConfigSecret }}
+      {{- if .Values.opensearchCluster.security.config.securityConfigSecret }}
       securityConfigSecret:
-        name: {{ .Values.OpenSearchClusterSpec.security.config.securityConfigSecret.name }}
+        name: {{ .Values.opensearchCluster.security.config.securityConfigSecret.name }}
       {{- end }}
     {{- end }}
-    {{- if .Values.OpenSearchClusterSpec.security.tls }}
+    {{- if .Values.opensearchCluster.security.tls }}
     tls:
-      {{- if .Values.OpenSearchClusterSpec.security.tls.transport }}
+      {{- if .Values.opensearchCluster.security.tls.transport }}
       transport:
-        {{- if .Values.OpenSearchClusterSpec.security.tls.http.generate }}
-        generate: {{ .Values.OpenSearchClusterSpec.security.tls.transport.generate }}
+        {{- if .Values.opensearchCluster.security.tls.http.generate }}
+        generate: {{ .Values.opensearchCluster.security.tls.transport.generate }}
         {{- end }}
-        {{- if .Values.OpenSearchClusterSpec.security.tls.transport.secret }}
+        {{- if .Values.opensearchCluster.security.tls.transport.secret }}
         secret:
-          name: {{ .Values.OpenSearchClusterSpec.security.tls.transport.secret.name }}
+          name: {{ .Values.opensearchCluster.security.tls.transport.secret.name }}
         {{- end }}
-        {{- if .Values.OpenSearchClusterSpec.security.tls.transport.adminDn }}
+        {{- if .Values.opensearchCluster.security.tls.transport.adminDn }}
         adminDn:
-          {{ toYaml .Values.OpenSearchClusterSpec.security.tls.transport.adminDn | nindent 10 }}
+          {{ toYaml .Values.opensearchCluster.security.tls.transport.adminDn | nindent 10 }}
         {{- end }}
-        {{- if .Values.OpenSearchClusterSpec.security.tls.transport.nodesDn }}
+        {{- if .Values.opensearchCluster.security.tls.transport.nodesDn }}
         nodesDn:
-          {{ toYaml .Values.OpenSearchClusterSpec.security.tls.transport.nodesDn | nindent 10 }}
+          {{ toYaml .Values.opensearchCluster.security.tls.transport.nodesDn | nindent 10 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.OpenSearchClusterSpec.security.tls.http }}
+      {{- if .Values.opensearchCluster.security.tls.http }}
       http:
-        {{- if .Values.OpenSearchClusterSpec.security.tls.http.generate }}
-        generate: {{ .Values.OpenSearchClusterSpec.security.tls.http.generate }}
+        {{- if .Values.opensearchCluster.security.tls.http.generate }}
+        generate: {{ .Values.opensearchCluster.security.tls.http.generate }}
         {{- end }}
-        {{- if .Values.OpenSearchClusterSpec.security.tls.http.secret }}
+        {{- if .Values.opensearchCluster.security.tls.http.secret }}
         secret:
-          name: {{ .Values.OpenSearchClusterSpec.security.tls.http.secret.name }}
+          name: {{ .Values.opensearchCluster.security.tls.http.secret.name }}
         {{- end }}
       {{- end }}
     {{- end }}

--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -1,4 +1,4 @@
-OpenSearchClusterSpec:
+opensearchCluster:
   enabled: true
   general:
     httpPort: "9200"


### PR DESCRIPTION
This PR aims to rename the OpenSearchClusterSpec to opensearchCluster in order to sync with other specs like manager.