### PR TITLE
Fix panic when changing from ephemeral storage to pvcs

### DIFF
--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -432,11 +432,11 @@ func WorkingPodForRollingRestart(ctx context.Context, k8sClient client.Client, s
 	replicas := lo.FromPtrOr(sts.Spec.Replicas, 1)
 	// Handle the simple case
 	if replicas == sts.Status.UpdatedReplicas+sts.Status.CurrentReplicas {
-		ordinal := replicas - 1 - sts.Status.UpdatedReplicas
+		ordinal := sts.Status.UpdatedReplicas
 		return ReplicaHostName(*sts, ordinal), nil
 	}
 	// If there are potentially mixed revisions we need to check each pod
-	for i := replicas - 1; i >= 0; i-- {
+	for i := int32(0); i < replicas; i++ {
 		podName := ReplicaHostName(*sts, i)
 		pod := &corev1.Pod{}
 		if err := k8sClient.Get(ctx, types.NamespacedName{Name: podName, Namespace: sts.Namespace}, pod); err != nil {


### PR DESCRIPTION
Fixes #600 

This PR makes the following changes:
- Separates the logic for resizing volumes to a separate function
- Adds a check for if the PVCs already exist and if not just deletes the statefulset (orphaning the pods)
- Inverts the order that we manually rollout pods in.  For the previous change the PVCs are created from lowest ordinal to highest so for this to work the manual rolling restart/upgrade needs to follow this order.