### PR TITLE
Enable monitoring config on the cluster definition

### DIFF
--- a/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
+++ b/charts/opensearch-cluster/templates/opensearch-cluster-cr.yaml
@@ -78,6 +78,10 @@ spec:
     additionalConfig:
       {{ toYaml .Values.opensearchCluster.general.additionalConfig | nindent 6 }}
     {{- end }}
+    {{- if .Values.opensearchCluster.general.monitoring }}
+    monitoring:
+      {{ toYaml .Values.opensearchCluster.general.monitoring | nindent 6 }}
+    {{- end }}
   {{- if .Values.opensearchCluster.dashboards }}
   dashboards:
     {{- if .Values.opensearchCluster.dashboards.image }}


### PR DESCRIPTION
Currently, the helm chart does not allow configuring the `monitor` section for the OpensearchCluster object. Even if it is defined in the values, it is ignored.

This PR is to address that.