### PR TITLE
fix rollingRestart reconciler to do the rolling restart for master 

### DIFF
--- a/charts/opensearch-operator/templates/opensearch-operator-manager-role-cr.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-manager-role-cr.yaml
@@ -20,6 +20,7 @@ rules:
   - apps
   resources:
   - statefulsets
+  - statefulsets/status
   verbs:
   - create
   - delete


### PR DESCRIPTION
As we have recently, made update strategy to OnDelete for all node pools, this PR fix the rolling restart reconciler to restart the pods of master and ingest nodes too in rolling restart fashion. Also There is one know issue in kubernetes https://github.com/kubernetes/kubernetes/issues/106055, where current version doesn't get updated with `OnDelete`  strategy. This PR includes WA for that too.
Changes: 

- Rolling Restart check for all nodes instead of just checking for data node pool only  if there is any pending update.
- Added check to enforce the update in case any pod got stuck in crashloopbackoff due to invalid config.
- Update the current version to updated version once all pods of the Sts are updated successfully.

It fixes Issue: https://github.com/Opster/opensearch-k8s-operator/issues/604, https://github.com/Opster/opensearch-k8s-operator/issues/605, https://github.com/Opster/opensearch-k8s-operator/issues/310