### PR TITLE
Add imagePullSecret for operator

### DIFF
--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -70,11 +70,9 @@ spec:
 {{- toYaml .Values.tolerations | nindent 8 }}
       securityContext:
 {{- toYaml .Values.securityContext | nindent 8}}
-      {{- if and .Values.manager.imagePullSecrets (not .Values.serviceAccount.create ) }}
+      {{- if .Values.manager.imagePullSecrets }}
       imagePullSecrets:
-      {{- range .Values.manager.imagePullSecrets }}
-        - name: {{ . }}
-      {{- end }}
+        {{- toYaml .Values.manager.imagePullSecrets | nindent 6 }}
       {{- end }}
       serviceAccountName: {{ include "opensearch-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10

--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -70,5 +70,11 @@ spec:
 {{- toYaml .Values.tolerations | nindent 8 }}
       securityContext:
 {{- toYaml .Values.securityContext | nindent 8}}
+      {{- if and .Values.manager.imagePullSecrets (not .Values.serviceAccount.create ) }}
+      imagePullSecrets:
+      {{- range .Values.manager.imagePullSecrets }}
+        - name: {{ . }}
+      {{- end }}
+      {{- end }}
       serviceAccountName: {{ include "opensearch-operator.serviceAccountName" . }}
       terminationGracePeriodSeconds: 10

--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-sa.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-sa.yaml
@@ -3,4 +3,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "opensearch-operator.serviceAccountName" . }}
+{{- if .Values.manager.imagePullSecrets }}
+imagePullSecrets:
+{{- range .Values.manager.imagePullSecrets }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-sa.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-sa.yaml
@@ -3,10 +3,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "opensearch-operator.serviceAccountName" . }}
-{{- if .Values.manager.imagePullSecrets }}
-imagePullSecrets:
-{{- range .Values.manager.imagePullSecrets }}
-  - name: {{ . }}
-{{- end }}
-{{- end }}
 {{- end -}}

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -48,7 +48,7 @@ manager:
 
   ## Optional array of imagePullSecrets containing private registry credentials
   imagePullSecrets: []
-  # - secretName
+  # - name: secretName
 
   dnsBase: cluster.local
 

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -46,6 +46,10 @@ manager:
     tag: ""
     pullPolicy: "Always"
 
+  ## Optional array of imagePullSecrets containing private registry credentials
+  imagePullSecrets: []
+  # - secretName
+
   dnsBase: cluster.local
 
   # Log level of the operator. Possible values: debug, info, warn, error


### PR DESCRIPTION
Fixes #618 

Changes:

- Add `imagePullSecrets` field to the values.yaml
- Populate the SA for the operator with the imagePullSecrets
- Populate the deployment for the operator incase the SA is not created