### PR TITLE
Ignore not found errors when deleting STS and Dashboards 

### DIFF
--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -318,6 +319,9 @@ func DeleteSTSForNodePool(ctx context.Context, k8sClient client.Client, nodePool
 
 	sts, err := GetSTSForNodePool(ctx, k8sClient, nodePool, clusterName, clusterNamespace)
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -349,6 +353,9 @@ func DeleteSecurityUpdateJob(ctx context.Context, k8sClient client.Client, clust
 	err := k8sClient.Get(ctx, client.ObjectKey{Name: jobName, Namespace: clusterNamespace}, &job)
 
 	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -493,18 +500,28 @@ func GetPodWithOlderRevision(ctx context.Context, k8sClient client.Client, sts *
 	return nil, nil
 }
 
+func GetDashboardsDeployment(ctx context.Context, k8sClient client.Client, clusterName, clusterNamespace string) (*appsv1.Deployment, error) {
+	deploy := appsv1.Deployment{}
+	err := k8sClient.Get(ctx, types.NamespacedName{Name: clusterName + "-dashboards", Namespace: clusterNamespace}, &deploy)
+
+	return &deploy, err
+}
+
 // DeleteDashboardsDeployment deletes the OSD deployment along with all its pods
 func DeleteDashboardsDeployment(ctx context.Context, k8sClient client.Client, clusterName, clusterNamespace string) error {
-	deploy := appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusterName + "-dashboards",
-			Namespace: clusterNamespace,
-		},
+	deploy, err := GetDashboardsDeployment(ctx, k8sClient, clusterName, clusterNamespace)
+
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return err
 	}
+
 	opts := client.DeleteOptions{}
 	// Add this so pods of the job are deleted as well, otherwise they would remain as orphaned pods
 	client.PropagationPolicy(metav1.DeletePropagationForeground).ApplyToDelete(&opts)
-	if err := k8sClient.Delete(ctx, &deploy, &opts); err != nil {
+	if err := k8sClient.Delete(ctx, deploy, &opts); err != nil {
 		return err
 	}
 
@@ -512,7 +529,7 @@ func DeleteDashboardsDeployment(ctx context.Context, k8sClient client.Client, cl
 	// We can use the same waiting time for sts as both have same termination grace period
 	for i := 1; i <= stsUpdateWaitTime/updateStepTime; i++ {
 		existing := appsv1.Deployment{}
-		err := k8sClient.Get(ctx, types.NamespacedName{Name: clusterName + "-dashboards", Namespace: clusterNamespace}, &existing)
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(deploy), &existing)
 		if err != nil {
 			return nil
 		}


### PR DESCRIPTION
I made a recent change where OSD deployment was deleted to recreate the .kibana index in case of emptyDir failure. This is a follow up change for that as we noticed some issues.

Changes:

- Ignore not found error
- Wait for OSD deployment to be deleted before resetting the status