### PR TITLE
Upgrade kube-rbac-proxy and update healthcheck

### DIFF
--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -19,6 +19,7 @@ spec:
       - args:
         - --secure-listen-address=0.0.0.0:8443
         - --upstream=http://127.0.0.1:8080/
+        - --proxy-endpoints-port=10443
         - --logtostderr=true
         - --v=10
         image: "{{ .Values.kubeRbacProxy.image.repository }}:{{ .Values.kubeRbacProxy.image.tag}}"
@@ -34,6 +35,9 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+        - containerPort: 10443
+          name: https-proxy
+          protocol: TCP
       {{- end}}
       - args:
         - --health-probe-bind-address=:8081

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -82,8 +82,10 @@ kubeRbacProxy:
 
   livenessProbe:
     failureThreshold: 3
-    tcpSocket:
-      port: 8443
+    httpGet:
+      path: /healthz
+      port: 10443
+      scheme: HTTPS
     periodSeconds: 15
     successThreshold: 1
     timeoutSeconds: 3
@@ -91,8 +93,10 @@ kubeRbacProxy:
 
   readinessProbe:
     failureThreshold: 3
-    tcpSocket:
-      port: 8443
+    httpGet:
+      path: /healthz
+      port: 10443
+      scheme: HTTPS
     periodSeconds: 15
     successThreshold: 1
     timeoutSeconds: 3
@@ -100,4 +104,4 @@ kubeRbacProxy:
 
   image:
     repository: "gcr.io/kubebuilder/kube-rbac-proxy"
-    tag: "v0.12.0"
+    tag: "v0.15.0"


### PR DESCRIPTION
With [0.14.0](https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.14.0) `kube-rbac-proxy` added a separate endpoint to check the readiness of the service. To get rid of messages like

```
2023/10/24 13:38:15 http: TLS handshake error from 10.100.160.5:46900: EOF
2023/10/24 13:38:15 http: TLS handshake error from 10.100.160.5:46902: EOF
2023/10/24 13:38:30 http: TLS handshake error from 10.100.160.5:59470: EOF
2023/10/24 13:38:30 http: TLS handshake error from 10.100.160.5:59458: EOF
2023/10/24 13:38:45 http: TLS handshake error from 10.100.160.5:43678: EOF
2023/10/24 13:38:45 http: TLS handshake error from 10.100.160.5:43684: EOF
```

I upgraded  `kube-rbac-proxy` to the latest version and added the needed argument. I updated the preconfigured checks in the helm-chart default as well.

fixes: #599