### PR TITLE
Separate http and config port in securityadmin.sh handling

### DIFF
--- a/opensearch-operator/examples/opensearch-cluster-custom-admin-user.yaml
+++ b/opensearch-operator/examples/opensearch-cluster-custom-admin-user.yaml
@@ -24,6 +24,8 @@ spec:
       http:
         generate: true
   dashboards:
+    opensearchCredentialsSecret:
+      name: admin-credentials-secret
     version: "2.2.1"
     enable: true
     replicas: 2

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -896,7 +896,7 @@ func NewSnapshotRepoconfigUpdateJob(
 	volumes []corev1.Volume,
 	volumeMounts []corev1.VolumeMount,
 ) batchv1.Job {
-	httpPort, _ := helpers.VersionCheck(instance)
+	httpPort, _, _ := helpers.VersionCheck(instance)
 	dns := DnsOfService(instance)
 	var snapshotCmd string
 	for _, repository := range instance.Spec.General.SnapshotRepositories {

--- a/opensearch-operator/pkg/helpers/helpers_suite_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_suite_test.go
@@ -1,0 +1,13 @@
+package helpers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHelpers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Helpers Suite")
+}

--- a/opensearch-operator/pkg/helpers/helpers_suite_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_suite_test.go
@@ -1,4 +1,4 @@
-package helpers_test
+package helpers
 
 import (
 	"testing"

--- a/opensearch-operator/pkg/helpers/reconcile-helpers.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers.go
@@ -107,20 +107,17 @@ func VersionCheck(instance *opsterv1.OpenSearchCluster) (int32, int32, string) {
 	var securityConfigPath string
 	versionPassed, _ := version.NewVersion(instance.Spec.General.Version)
 	constraints, _ := version.NewConstraint(">= 2.0")
+
+	if instance.Spec.General.HttpPort > 0 {
+		httpPort = instance.Spec.General.HttpPort
+	} else {
+		httpPort = 9200
+	}
+
 	if constraints.Check(versionPassed) {
-		if instance.Spec.General.HttpPort > 0 {
-			httpPort = instance.Spec.General.HttpPort
-		} else {
-			httpPort = 9200
-		}
 		securityConfigPort = httpPort
 		securityConfigPath = "/usr/share/opensearch/config/opensearch-security"
 	} else {
-		if instance.Spec.General.HttpPort > 0 {
-			httpPort = instance.Spec.General.HttpPort
-		} else {
-			httpPort = 9200
-		}
 		securityConfigPort = 9300
 		securityConfigPath = "/usr/share/opensearch/plugins/opensearch-security/securityconfig"
 	}

--- a/opensearch-operator/pkg/helpers/reconcile-helpers_test.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers_test.go
@@ -1,0 +1,31 @@
+package helpers_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	opsterv1 "opensearch.opster.io/api/v1"
+	"opensearch.opster.io/pkg/helpers"
+)
+
+var _ = DescribeTable("versionCheck reconciler",
+	func(version string, specifiedHttpPort int32, expectedHttpPort int32, expectedSecurityConfigPort int32, expectedSecurityConfigPath string) {
+		instance := &opsterv1.OpenSearchCluster{
+			Spec: opsterv1.ClusterSpec{
+				General: opsterv1.GeneralConfig{
+					Version:  version,
+					HttpPort: specifiedHttpPort,
+				},
+			},
+		}
+
+		actualHttpPort, actualSecurityConfigPort, actualConfigPath := helpers.VersionCheck(instance)
+
+		Expect(actualHttpPort).To(Equal(expectedHttpPort))
+		Expect(actualSecurityConfigPort).To(Equal(expectedSecurityConfigPort))
+		Expect(actualConfigPath).To(Equal(expectedSecurityConfigPath))
+	},
+	Entry("When no http port is specified and version 1.3.0 is used", "1.3.0", int32(0), int32(9200), int32(9300), "/usr/share/opensearch/plugins/opensearch-security/securityconfig"),
+	Entry("When no http port is specified and version 2.0 is used", "2.0", int32(0), int32(9200), int32(9200), "/usr/share/opensearch/config/opensearch-security"),
+	Entry("When an http port is specified and version 1.3.0 is used", "1.3.0", int32(6000), int32(6000), int32(9300), "/usr/share/opensearch/plugins/opensearch-security/securityconfig"),
+	Entry("When an http port is specified and version 2.0 is used", "2.0", int32(6000), int32(6000), int32(6000), "/usr/share/opensearch/config/opensearch-security"),
+)

--- a/opensearch-operator/pkg/helpers/reconcile-helpers_test.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers_test.go
@@ -1,10 +1,9 @@
-package helpers_test
+package helpers
 
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	opsterv1 "opensearch.opster.io/api/v1"
-	"opensearch.opster.io/pkg/helpers"
 )
 
 var _ = DescribeTable("versionCheck reconciler",
@@ -18,7 +17,7 @@ var _ = DescribeTable("versionCheck reconciler",
 			},
 		}
 
-		actualHttpPort, actualSecurityConfigPort, actualConfigPath := helpers.VersionCheck(instance)
+		actualHttpPort, actualSecurityConfigPort, actualConfigPath := VersionCheck(instance)
 
 		Expect(actualHttpPort).To(Equal(expectedHttpPort))
 		Expect(actualSecurityConfigPort).To(Equal(expectedSecurityConfigPort))


### PR DESCRIPTION
Fix #623. Use http port(default 9200) for curl and node communication port(9300) for securityadmin.sh for version 1.X.

There was a port change in securityadmin.sh from version 1 to 2.

In version 2, securityadmin.sh uses the http port for securityadmin.sh. Before running securityadmin.sh, we check if the service is ready using curl on the same port.

However, in version 1, securityadmin.sh uses a different port, port 9300, which is used for node communication with a binary protocol.  Since we use curl with the same port as securityadmin.sh, curl failed and the loop ran forever.

The solution was to use different ports for securityadmin.sh and curl. With this fix, curl always uses the http port and securityadmin.sh uses the http port or the binary port depending on the version.

More details about the port change can be found here:
- https://forum.opensearch.org/t/securityadmin-sh-uses-http-port-9200-and-not-transport-port-9300-in-opensearch-2-0-0/9760

- https://discuss.elastic.co/t/what-are-ports-9200-and-9300-used-for/238578