### PR TITLE
Feature #377 SubPath support for additional volumes

### DIFF
--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -1212,6 +1212,9 @@ spec:
                                 the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               type: string
                           type: object
+                        subPath:
+                          description: SubPath of the referenced volume to mount.
+                          type: string
                       required:
                       - name
                       - path
@@ -2922,11 +2925,19 @@ spec:
                                 the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               type: string
                           type: object
+                        subPath:
+                          description: SubPath of the referenced volume to mount.
+                          type: string
                       required:
                       - name
                       - path
                       type: object
                     type: array
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Adds support for annotations in services
+                    type: object
                   command:
                     type: string
                   defaultRepo:

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -44,7 +44,7 @@ type GeneralConfig struct {
 	// Extra items to add to the opensearch.yml
 	AdditionalConfig map[string]string `json:"additionalConfig,omitempty"`
 	// Adds support for annotations in services
-	Annotations      map[string]string `json:"annotations,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 	// Drain data nodes controls whether to drain data notes on rolling restart operations
 	DrainDataNodes bool     `json:"drainDataNodes,omitempty"`
 	PluginsList    []string `json:"pluginsList,omitempty"`
@@ -246,6 +246,8 @@ type AdditionalVolume struct {
 	Name string `json:"name"`
 	// Path in the container to mount the volume at. Required.
 	Path string `json:"path"`
+	// SubPath of the referenced volume to mount.
+	SubPath string `json:"subPath,omitempty"`
 	// Secret to use populate the volume
 	Secret *corev1.SecretVolumeSource `json:"secret,omitempty"`
 	// ConfigMap to use to populate the volume

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -1212,6 +1212,9 @@ spec:
                                 the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               type: string
                           type: object
+                        subPath:
+                          description: SubPath of the referenced volume to mount.
+                          type: string
                       required:
                       - name
                       - path
@@ -2922,11 +2925,19 @@ spec:
                                 the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               type: string
                           type: object
+                        subPath:
+                          description: SubPath of the referenced volume to mount.
+                          type: string
                       required:
                       - name
                       - path
                       type: object
                     type: array
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Adds support for annotations in services
+                    type: object
                   command:
                     type: string
                   defaultRepo:

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -5,15 +5,13 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
-	"net/http"
-	"sort"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kube-openapi/pkg/validation/errors"
+	"net/http"
 	opsterv1 "opensearch.opster.io/api/v1"
 	"opensearch.opster.io/opensearch-gateway/services"
 	"opensearch.opster.io/pkg/helpers"
@@ -21,6 +19,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sort"
+	"strings"
 )
 
 func CheckEquels(from_env *appsv1.StatefulSetSpec, from_crd *appsv1.StatefulSetSpec, text string) (int32, bool, error) {
@@ -128,10 +128,18 @@ func CreateAdditionalVolumes(
 			namesIndex[volumeConfig.Name] = i
 			names = append(names, volumeConfig.Name)
 		}
+
+		subPath := ""
+		// SubPaths are only supported for ConfigMaps and Secrets
+		if volumeConfig.ConfigMap != nil || volumeConfig.Secret != nil {
+			subPath = strings.TrimSpace(volumeConfig.SubPath)
+		}
+
 		retVolumeMounts = append(retVolumeMounts, corev1.VolumeMount{
 			Name:      volumeConfig.Name,
 			ReadOnly:  readOnly,
 			MountPath: volumeConfig.Path,
+			SubPath:   subPath,
 		})
 	}
 	sort.Strings(names)

--- a/opensearch-operator/pkg/reconcilers/util/util_suite_test.go
+++ b/opensearch-operator/pkg/reconcilers/util/util_suite_test.go
@@ -1,0 +1,106 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"github.com/cisco-open/operator-tools/pkg/prometheus"
+	"github.com/phayes/freeport"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
+	"path/filepath"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var ctx context.Context
+var k8sClient client.Client
+
+var testEnv *envtest.Environment
+var cancel context.CancelFunc
+
+func TestUtil(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Util Suite")
+}
+
+var _ = BeforeSuite(func() {
+	var cfg *rest.Config
+	ctx, cancel = context.WithCancel(context.TODO())
+	ports, err := freeport.GetFreePorts(2)
+	Expect(err).NotTo(HaveOccurred())
+
+	serviceMonitorCRD := apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: prometheus.ServiceMonitorName + "." + prometheus.GroupVersion.Group,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: prometheus.GroupVersion.Group,
+			Scope: apiextensionsv1.NamespaceScoped,
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:   prometheus.ServiceMonitorName,
+				Singular: prometheus.ServiceMonitorKindKey,
+				Kind:     prometheus.ServiceMonitorsKind,
+			},
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{
+					Name:    prometheus.GroupVersion.Version,
+					Storage: true,
+					Served:  true,
+					Schema: &apiextensionsv1.CustomResourceValidation{
+						OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+							Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
+							XPreserveUnknownFields: pointer.Bool(true),
+							Type:                   "object",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDs:                  []*apiextensionsv1.CustomResourceDefinition{&serviceMonitorCRD},
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 scheme.Scheme,
+		MetricsBindAddress:     fmt.Sprintf(":%d", ports[0]),
+		HealthProbeBindAddress: fmt.Sprintf(":%d", ports[1]),
+	})
+	Expect(err).ToNot(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = k8sManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
+	}()
+
+	k8sClient = k8sManager.GetClient()
+	Expect(k8sClient).ToNot(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/opensearch-operator/pkg/reconcilers/util/util_test.go
+++ b/opensearch-operator/pkg/reconcilers/util/util_test.go
@@ -1,0 +1,85 @@
+package util
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	opsterv1 "opensearch.opster.io/api/v1"
+)
+
+var _ = Describe("Additional volumes", func() {
+	var namespace = "Additional volume test"
+	var volumeConfigs []opsterv1.AdditionalVolume
+
+	BeforeEach(func() {
+		volumeConfigs = []opsterv1.AdditionalVolume{
+			{
+				Name: "myVolume",
+				Path: "myPath/a/b",
+			},
+		}
+	})
+
+	When("configmap is added with subPath", func() {
+		It("subPath is set", func() {
+			volumeConfigs[0].ConfigMap = &v1.ConfigMapVolumeSource{}
+			volumeConfigs[0].SubPath = "c"
+
+			var _, volumeMount, _, _ = CreateAdditionalVolumes(ctx, k8sClient, namespace, volumeConfigs)
+			Expect(volumeMount[0].MountPath).To(Equal("myPath/a/b"))
+			Expect(volumeMount[0].SubPath).To(Equal("c"))
+		})
+	})
+
+	When("configmap is added without subPath", func() {
+		It("subPath is not set", func() {
+			volumeConfigs[0].ConfigMap = &v1.ConfigMapVolumeSource{}
+
+			var _, volumeMount, _, _ = CreateAdditionalVolumes(ctx, k8sClient, namespace, volumeConfigs)
+			Expect(volumeMount[0].MountPath).To(Equal("myPath/a/b"))
+			Expect(volumeMount[0].SubPath).To(BeEmpty())
+		})
+	})
+
+	When("secret is added with subPath", func() {
+		It("subPath is set", func() {
+			volumeConfigs[0].Secret = &v1.SecretVolumeSource{}
+			volumeConfigs[0].SubPath = "c"
+
+			var _, volumeMount, _, _ = CreateAdditionalVolumes(ctx, k8sClient, namespace, volumeConfigs)
+			Expect(volumeMount[0].MountPath).To(Equal("myPath/a/b"))
+			Expect(volumeMount[0].SubPath).To(Equal("c"))
+		})
+	})
+
+	When("secret is added without subPath", func() {
+		It("subPath is not set", func() {
+			volumeConfigs[0].Secret = &v1.SecretVolumeSource{}
+
+			var _, volumeMount, _, _ = CreateAdditionalVolumes(ctx, k8sClient, namespace, volumeConfigs)
+			Expect(volumeMount[0].MountPath).To(Equal("myPath/a/b"))
+			Expect(volumeMount[0].SubPath).To(BeEmpty())
+		})
+	})
+
+	When("emptyDir is added with subPath", func() {
+		It("subPath is not set", func() {
+			volumeConfigs[0].EmptyDir = &v1.EmptyDirVolumeSource{}
+			volumeConfigs[0].SubPath = "c"
+
+			var _, volumeMount, _, _ = CreateAdditionalVolumes(ctx, k8sClient, namespace, volumeConfigs)
+			Expect(volumeMount[0].MountPath).To(Equal("myPath/a/b"))
+			Expect(volumeMount[0].SubPath).To(BeEmpty())
+		})
+	})
+
+	When("emptyDir is added without subPath", func() {
+		It("subPath is not set", func() {
+			volumeConfigs[0].EmptyDir = &v1.EmptyDirVolumeSource{}
+
+			var _, volumeMount, _, _ = CreateAdditionalVolumes(ctx, k8sClient, namespace, volumeConfigs)
+			Expect(volumeMount[0].MountPath).To(Equal("myPath/a/b"))
+			Expect(volumeMount[0].SubPath).To(BeEmpty())
+		})
+	})
+})


### PR DESCRIPTION
With this change you can also specify subPaths for additional volumes.
This will help if you want to mount just a specific file into an already mounted directory. This is often required for configuration files. 

E.g.
      - name: log4j2-properties
        path: /usr/share/opensearch/config/log4j2.properties
        subPath: log4j2.properties

Because subPaths are not reasonable for hostPaths and emptyDirs, in this feature, only ConfigMaps and Secrets support subPaths. But not hostPaths and emptyDirs.