### PR TITLE
Add health and availableNodes in the OpenSearchCluster status

### DIFF
--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -19,6 +19,13 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.health
+      name: health
+      type: string
+    - description: Available nodes
+      jsonPath: .status.availableNodes
+      name: nodes
+      type: integer
     - description: Opensearch version
       jsonPath: .status.version
       name: version
@@ -4978,6 +4985,10 @@ spec:
           status:
             description: ClusterStatus defines the observed state of Es
             properties:
+              availableNodes:
+                description: AvailableNodes is the number of available instances.
+                format: int32
+                type: integer
               componentsStatus:
                 items:
                   properties:
@@ -4993,6 +5004,10 @@ spec:
                       type: string
                   type: object
                 type: array
+              health:
+                description: OpenSearchHealth is the health of the cluster as returned
+                  by the health API.
+                type: string
               initialized:
                 type: boolean
               phase:

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -27,6 +27,17 @@ const (
 	PhaseRunning = "RUNNING"
 )
 
+// OpenSearchHealth is the health of the cluster as returned by the health API.
+type OpenSearchHealth string
+
+// Possible traffic light states OpenSearch health can have.
+const (
+	OpenSearchRedHealth     OpenSearchHealth = "red"
+	OpenSearchYellowHealth  OpenSearchHealth = "yellow"
+	OpenSearchGreenHealth   OpenSearchHealth = "green"
+	OpenSearchUnknownHealth OpenSearchHealth = "unknown"
+)
+
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
@@ -292,12 +303,17 @@ type ClusterStatus struct {
 	ComponentsStatus []ComponentStatus `json:"componentsStatus"`
 	Version          string            `json:"version,omitempty"`
 	Initialized      bool              `json:"initialized,omitempty"`
+	// AvailableNodes is the number of available instances.
+	AvailableNodes int32            `json:"availableNodes,omitempty"`
+	Health         OpenSearchHealth `json:"health,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=os;opensearch
 // Es is the Schema for the es API
+// +kubebuilder:printcolumn:name="health",type="string",JSONPath=".status.health"
+// +kubebuilder:printcolumn:name="nodes",type="integer",JSONPath=".status.availableNodes",description="Available nodes"
 // +kubebuilder:printcolumn:name="version",type="string",JSONPath=".status.version",description="Opensearch version"
 // +kubebuilder:printcolumn:name="phase",type="string",JSONPath=".status.phase"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -19,6 +19,13 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.health
+      name: health
+      type: string
+    - description: Available nodes
+      jsonPath: .status.availableNodes
+      name: nodes
+      type: integer
     - description: Opensearch version
       jsonPath: .status.version
       name: version
@@ -4978,6 +4985,10 @@ spec:
           status:
             description: ClusterStatus defines the observed state of Es
             properties:
+              availableNodes:
+                description: AvailableNodes is the number of available instances.
+                format: int32
+                type: integer
               componentsStatus:
                 items:
                   properties:
@@ -4993,6 +5004,10 @@ spec:
                       type: string
                   type: object
                 type: array
+              health:
+                description: OpenSearchHealth is the health of the cluster as returned
+                  by the health API.
+                type: string
               initialized:
                 type: boolean
               phase:


### PR DESCRIPTION
Feat #553 


Changes - 

1. Add `Health` and `NODES` field in OpensearchCluster Status to indicate cluster health and available nodes respectively.


Example Output
```
sakmahto@kind-managed1 ~ $ k get os
NAME         HEALTH   NODES   VERSION   PHASE     AGE
opensearch   green    8       2.3.0     RUNNING   14m
```