### PR TITLE
Restrict selector for ServiceMonitor to avoid double scraping

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -1049,6 +1049,13 @@ func NewServiceMonitor(cr *opsterv1.OpenSearchCluster) *monitoring.ServiceMonito
 	}
 	selector := metav1.LabelSelector{
 		MatchLabels: labels,
+		// Needed so only the pool-specific service is matched, otherwise there would be double scraping
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      helpers.NodePoolLabel,
+				Operator: metav1.LabelSelectorOpExists,
+			},
+		},
 	}
 
 	namespaceSelector := monitoring.NamespaceSelector{


### PR DESCRIPTION
Fixes #602

Adds a second expression to the `selector` of the `ServiceMonitor`. Without it both the per-nodepool headless service and the per-cluster service match and lead to Prometheus scraping every pod twice.
