### PR TITLE
Fix reconcile bug that prevents nodepool cleanup

### DIFF
--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -298,7 +298,7 @@ func (r *ScalerReconciler) drainNode(currentStatus opsterv1.ComponentStatus, cur
 }
 
 func (r *ScalerReconciler) cleanupStatefulSets(result *reconciler.CombinedResult) {
-	stsList, err := r.client.ListStatefulSets(client.InNamespace(r.instance.Name),
+	stsList, err := r.client.ListStatefulSets(client.InNamespace(r.instance.Namespace),
 		client.MatchingLabels{helpers.ClusterLabel: r.instance.Name})
 	if err != nil {
 		result.Combine(&ctrl.Result{}, err)
@@ -375,6 +375,6 @@ func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Resu
 	if err != nil {
 		lg.Error(err, fmt.Sprintf("failed to remove node exclusion for %s", lastReplicaNodeName))
 	}
-	r.recorder.AnnotatedEventf(r.instance, annotations, "Noraml", "Scaler", "Finished scaling")
+	r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Finished scaling")
 	return result, err
 }


### PR DESCRIPTION
### Description
Reintroduces change from https://github.com/opensearch-project/opensearch-k8s-operator/pull/637 which got reverted in https://github.com/opensearch-project/opensearch-k8s-operator/pull/592 at https://github.com/opensearch-project/opensearch-k8s-operator/commit/4174371137ad53f416c0fa6bff65bd72f99fa626#diff-190387233823a104ed9004f0cba248cf0aa504090c923cad3be1a901bd01e99fR308

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-k8s-operator/issues/386 again

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
