### PR TITLE
Fix: securityconfig wrong ca.crt

### DIFF
--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -27,7 +27,7 @@ const (
 
 	adminCert = "/certs/tls.crt"
 	adminKey  = "/certs/tls.key"
-	caCert    = "/certs/ca.crt"
+	caCert    = "/usr/share/opensearch/config/tls-http/ca.crt"
 
 	SecurityAdminBaseCmdTmpl = `ADMIN=/usr/share/opensearch/plugins/opensearch-security/tools/securityadmin.sh;
 chmod +x $ADMIN;

--- a/opensearch-operator/pkg/reconcilers/securityconfig_test.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig_test.go
@@ -290,7 +290,7 @@ until curl -k --silent https://no-securityconfig-tls-configured.no-securityconfi
 do
 echo 'Waiting to connect to the cluster'; sleep 120;
 done;count=0;
-until $ADMIN -cacert /certs/ca.crt -cert /certs/tls.crt -key /certs/tls.key -cd /usr/share/opensearch/config/opensearch-security -icl -nhnv -h no-securityconfig-tls-configured.no-securityconfig-tls-configured.svc.cluster.local -p 9200 || (( count++ >= 20 ));
+until $ADMIN -cacert /usr/share/opensearch/config/tls-http/ca.crt -cert /certs/tls.crt -key /certs/tls.key -cd /usr/share/opensearch/config/opensearch-security -icl -nhnv -h no-securityconfig-tls-configured.no-securityconfig-tls-configured.svc.cluster.local -p 9200 || (( count++ >= 20 ));
 do
 sleep 20;
 done;`


### PR DESCRIPTION
### Description
To fix a problem when we want to specify custom http certificate and leave transport and admin certificates generated

### Issues Resolved
https://github.com/opensearch-project/opensearch-k8s-operator/issues/690

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).