### PR TITLE
Add TLS certificate hot reloading support (fixes #1021)

### DIFF
--- a/charts/opensearch-cluster/README.md
+++ b/charts/opensearch-cluster/README.md
@@ -90,12 +90,14 @@ The following table lists the configurable parameters of the Helm chart.
 | `cluster.security.tls.http.customFQDN` | string | `""` | Optional custom FQDN to use for the HTTP certificate. If provided, this FQDN will be used as the primary DNS name in the certificate's Subject Alternative Names (SAN), along with the default cluster DNS names. This allows you to use a single certificate that works with both your custom domain and the internal Kubernetes DNS names. |
 | `cluster.security.tls.http.secret` | object | `{}` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
 | `cluster.security.tls.http.duration` | string | `"8760h"` | Duration controls the validity period of generated certificates (e.g. "8760h", "720h"). This is used only when generate is true. |
+| `cluster.security.tls.http.enableHotReload` | bool | `false` | Enable hot reloading of TLS certificates. |
 | `cluster.security.tls.transport.caSecret` | object | `{}` | Optional, secret that contains the ca certificate as ca.crt. If this and generate=true is set the existing CA cert from that secret is used to generate the node certs. In this case must contain ca.crt and ca.key fields |
 | `cluster.security.tls.transport.generate` | bool | `true` | If set to true the operator will generate a CA and certificates for the cluster to use, if false secrets with existing certificates must be supplied |
 | `cluster.security.tls.transport.nodesDn` | list | `[]` | Allowed Certificate DNs for nodes, only used when existing certificates are provided |
 | `cluster.security.tls.transport.perNode` | bool | `true` | Separate certificate per node |
 | `cluster.security.tls.transport.secret` | object | `{}` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
 | `cluster.security.tls.transport.duration` | string | `"8760h"` | Duration controls the validity period of generated certificates (e.g. "8760h", "720h"). This is used only when generate is true. |
+| `cluster.security.tls.transport.enableHotReload` | bool | `false` | Enable hot reloading of TLS certificates. |
 | `cluster.ingress.opensearch.enabled` | bool | `false` | Enable ingress for Opensearch service |
 | `cluster.ingress.opensearch.annotations` | object | `{}` | Opensearch ingress annotations |
 | `cluster.ingress.opensearch.className` | string | `""` | Opensearch Ingress class name |

--- a/charts/opensearch-cluster/templates/cluster.yaml
+++ b/charts/opensearch-cluster/templates/cluster.yaml
@@ -54,7 +54,7 @@ spec:
         secret: {{ . | toYaml | nindent 10 }}
         {{- end }}
         {{- if .tls.transport.duration }}
-        duration: {{ .tls.transport.duration | nindent 10 }}
+        duration: {{ .tls.transport.duration }}
         {{- end }}
         {{- if .tls.transport.enableHotReload }}
         enableHotReload: {{ .tls.transport.enableHotReload }}
@@ -73,7 +73,7 @@ spec:
         caSecret: {{ . | toYaml | nindent 10 }}
         {{- end }}
         {{- if .tls.http.duration }}
-        duration: {{ .tls.http.duration | nindent 10 }}
+        duration: {{ .tls.http.duration }}
         {{- end }}
         {{- if .tls.http.enableHotReload }}
         enableHotReload: {{ .tls.http.enableHotReload }}

--- a/charts/opensearch-cluster/templates/cluster.yaml
+++ b/charts/opensearch-cluster/templates/cluster.yaml
@@ -56,6 +56,9 @@ spec:
         {{- if .tls.transport.duration }}
         duration: {{ .tls.transport.duration | nindent 10 }}
         {{- end }}
+        {{- if .tls.transport.enableHotReload }}
+        enableHotReload: {{ .tls.transport.enableHotReload }}
+        {{- end }}
       http:
         {{- with .tls.http.adminDn }}
         adminDn: {{ . | toYaml | nindent 10 }}
@@ -71,6 +74,9 @@ spec:
         {{- end }}
         {{- if .tls.http.duration }}
         duration: {{ .tls.http.duration | nindent 10 }}
+        {{- end }}
+        {{- if .tls.http.enableHotReload }}
+        enableHotReload: {{ .tls.http.enableHotReload }}
         {{- end }}
     {{- with .config }}
     config: {{ . | toYaml | nindent 6 }}

--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -352,6 +352,9 @@ cluster:
         # This is used only when generate is true.
         duration: "8760h"
 
+        # -- Enable hot reloading of TLS certificates.
+        enableHotReload: false
+
       transport:
         # -- Optional, secret that contains the ca certificate as ca.crt. If this and generate=true is set the existing
         # CA cert from that secret is used to generate the node certs. In this case must contain ca.crt and ca.key fields
@@ -376,6 +379,9 @@ cluster:
         # -- Duration controls the validity period of generated certificates (e.g. "8760h", "720h").
         # This is used only when generate is true.
         duration: "8760h"
+
+        # -- Enable hot reloading of TLS certificates.
+        enableHotReload: false
 
   # Opensearch Ingress configuration
   ingress:

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -3346,6 +3346,12 @@ spec:
                       enable:
                         description: Enable HTTPS for Dashboards
                         type: boolean
+                      enableHotReload:
+                        description: Enable hot reloading of TLS certificates. When
+                          enabled, certificates are mounted as directories instead
+                          of using subPath, allowing Kubernetes to update certificate
+                          files when secrets are updated.
+                        type: boolean
                       generate:
                         description: Generate certificate, if false secret must be
                           provided
@@ -6293,6 +6299,12 @@ spec:
                             description: Duration controls the validity period of
                               generated certificates (e.g. "8760h", "720h").
                             type: string
+                          enableHotReload:
+                            description: Enable hot reloading of TLS certificates.
+                              When enabled, certificates are mounted as directories
+                              instead of using subPath, allowing Kubernetes to update
+                              certificate files when secrets are updated.
+                            type: boolean
                           generate:
                             description: If set to true the operator will generate
                               a CA and certificates for the cluster to use, if false
@@ -6344,6 +6356,12 @@ spec:
                             description: Duration controls the validity period of
                               generated certificates (e.g. "8760h", "720h").
                             type: string
+                          enableHotReload:
+                            description: Enable hot reloading of TLS certificates.
+                              When enabled, certificates are mounted as directories
+                              instead of using subPath, allowing Kubernetes to update
+                              certificate files when secrets are updated.
+                            type: boolean
                           generate:
                             description: If set to true the operator will generate
                               a CA and certificates for the cluster to use, if false

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -289,6 +289,8 @@ type TlsCertificateConfig struct {
 	// Duration controls the validity period of generated certificates (e.g. "8760h", "720h").
 	//+kubebuilder:default:="8760h"
 	Duration *metav1.Duration `json:"duration,omitempty"`
+	// Enable hot reloading of TLS certificates. When enabled, certificates are mounted as directories instead of using subPath, allowing Kubernetes to update certificate files when secrets are updated.
+	EnableHotReload bool `json:"enableHotReload,omitempty"`
 }
 
 // Reference to a secret

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -3346,6 +3346,12 @@ spec:
                       enable:
                         description: Enable HTTPS for Dashboards
                         type: boolean
+                      enableHotReload:
+                        description: Enable hot reloading of TLS certificates. When
+                          enabled, certificates are mounted as directories instead
+                          of using subPath, allowing Kubernetes to update certificate
+                          files when secrets are updated.
+                        type: boolean
                       generate:
                         description: Generate certificate, if false secret must be
                           provided
@@ -6303,6 +6309,12 @@ spec:
                             description: Duration controls the validity period of
                               generated certificates (e.g. "8760h", "720h").
                             type: string
+                          enableHotReload:
+                            description: Enable hot reloading of TLS certificates.
+                              When enabled, certificates are mounted as directories
+                              instead of using subPath, allowing Kubernetes to update
+                              certificate files when secrets are updated.
+                            type: boolean
                           generate:
                             description: If set to true the operator will generate
                               a CA and certificates for the cluster to use, if false
@@ -6354,6 +6366,12 @@ spec:
                             description: Duration controls the validity period of
                               generated certificates (e.g. "8760h", "720h").
                             type: string
+                          enableHotReload:
+                            description: Enable hot reloading of TLS certificates.
+                              When enabled, certificates are mounted as directories
+                              instead of using subPath, allowing Kubernetes to update
+                              certificate files when secrets are updated.
+                            type: boolean
                           generate:
                             description: If set to true the operator will generate
                               a CA and certificates for the cluster to use, if false

--- a/opensearch-operator/pkg/reconcilers/tls_test.go
+++ b/opensearch-operator/pkg/reconcilers/tls_test.go
@@ -178,14 +178,13 @@ var _ = Describe("TLS Controller", func() {
 			_, err := underTest.Reconcile()
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(reconcilerContext.Volumes).Should(HaveLen(6))
-			Expect(reconcilerContext.VolumeMounts).Should(HaveLen(6))
+			Expect(reconcilerContext.Volumes).Should(HaveLen(4))
+			Expect(reconcilerContext.VolumeMounts).Should(HaveLen(4))
+			// With new mounting logic: CaSecret.Name != Secret.Name, so we mount both as directories
 			Expect(helpers.CheckVolumeExists(reconcilerContext.Volumes, reconcilerContext.VolumeMounts, "casecret-transport", "transport-ca")).Should((BeTrue()))
-			Expect(helpers.CheckVolumeExists(reconcilerContext.Volumes, reconcilerContext.VolumeMounts, "cert-transport", "transport-key")).Should((BeTrue()))
-			Expect(helpers.CheckVolumeExists(reconcilerContext.Volumes, reconcilerContext.VolumeMounts, "cert-transport", "transport-cert")).Should((BeTrue()))
+			Expect(helpers.CheckVolumeExists(reconcilerContext.Volumes, reconcilerContext.VolumeMounts, "cert-transport", "transport-certs")).Should((BeTrue()))
 			Expect(helpers.CheckVolumeExists(reconcilerContext.Volumes, reconcilerContext.VolumeMounts, "casecret-http", "http-ca")).Should((BeTrue()))
-			Expect(helpers.CheckVolumeExists(reconcilerContext.Volumes, reconcilerContext.VolumeMounts, "cert-http", "http-key")).Should((BeTrue()))
-			Expect(helpers.CheckVolumeExists(reconcilerContext.Volumes, reconcilerContext.VolumeMounts, "cert-http", "http-cert")).Should((BeTrue()))
+			Expect(helpers.CheckVolumeExists(reconcilerContext.Volumes, reconcilerContext.VolumeMounts, "cert-http", "http-certs")).Should((BeTrue()))
 
 			value, exists := reconcilerContext.OpenSearchConfig["plugins.security.nodes_dn"]
 			Expect(exists).To(BeTrue())
@@ -287,6 +286,122 @@ var _ = Describe("TLS Controller", func() {
 			value, exists := reconcilerContext.OpenSearchConfig["plugins.security.nodes_dn"]
 			Expect(exists).To(BeTrue())
 			Expect(value).To(Equal("[\"CN=tls-withca-*,OU=tls-withca\"]"))
+		})
+	})
+
+	Context("When Reconciling the TLS configuration with same CaSecret and Secret names", func() {
+		It("Should mount only one secret as directory", func() {
+			clusterName := "tls-same-secrets"
+			spec := opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
+				Spec: opsterv1.ClusterSpec{
+					General: opsterv1.GeneralConfig{Version: "2.8.0"},
+					Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
+						Transport: &opsterv1.TlsConfigTransport{
+							Generate: false,
+							TlsCertificateConfig: opsterv1.TlsCertificateConfig{
+								Secret:   corev1.LocalObjectReference{Name: "same-secret"},
+								CaSecret: corev1.LocalObjectReference{Name: "same-secret"}, // Same name
+							},
+							NodesDn: []string{"CN=mycn"},
+						},
+						Http: &opsterv1.TlsConfigHttp{
+							Generate: false,
+							TlsCertificateConfig: opsterv1.TlsCertificateConfig{
+								Secret:   corev1.LocalObjectReference{Name: "same-secret"},
+								CaSecret: corev1.LocalObjectReference{Name: "same-secret"}, // Same name
+							},
+						},
+					},
+					},
+				}}
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			reconcilerContext, underTest := newTLSReconciler(mockClient, &spec)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Should have only 2 volumes/mounts (one for transport, one for http)
+			Expect(reconcilerContext.Volumes).Should(HaveLen(2))
+			Expect(reconcilerContext.VolumeMounts).Should(HaveLen(2))
+			Expect(helpers.CheckVolumeExists(reconcilerContext.Volumes, reconcilerContext.VolumeMounts, "same-secret", "transport-certs")).Should((BeTrue()))
+			Expect(helpers.CheckVolumeExists(reconcilerContext.Volumes, reconcilerContext.VolumeMounts, "same-secret", "http-certs")).Should((BeTrue()))
+		})
+	})
+
+	Context("When Reconciling the TLS configuration with hot reload enabled", func() {
+		It("Should enable hot reload configuration for supported versions", func() {
+			clusterName := "tls-hotreload"
+			spec := opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
+				Spec: opsterv1.ClusterSpec{
+					General: opsterv1.GeneralConfig{Version: "2.19.1"}, // Version that supports hot reload
+					Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
+						Transport: &opsterv1.TlsConfigTransport{
+							Generate: false,
+							TlsCertificateConfig: opsterv1.TlsCertificateConfig{
+								Secret:          corev1.LocalObjectReference{Name: "cert-transport"},
+								CaSecret:        corev1.LocalObjectReference{Name: "casecret-transport"},
+								EnableHotReload: true,
+							},
+							NodesDn: []string{"CN=mycn"},
+						},
+						Http: &opsterv1.TlsConfigHttp{
+							Generate: false,
+							TlsCertificateConfig: opsterv1.TlsCertificateConfig{
+								Secret:          corev1.LocalObjectReference{Name: "cert-http"},
+								CaSecret:        corev1.LocalObjectReference{Name: "casecret-http"},
+								EnableHotReload: true,
+							},
+						},
+					},
+					},
+				}}
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			reconcilerContext, underTest := newTLSReconciler(mockClient, &spec)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check that hot reload is enabled
+			value, exists := reconcilerContext.OpenSearchConfig["plugins.security.ssl.certificates_hot_reload.enabled"]
+			Expect(exists).To(BeTrue())
+			Expect(value).To(Equal("true"))
+		})
+
+		It("Should not enable hot reload configuration for unsupported versions", func() {
+			clusterName := "tls-hotreload-unsupported"
+			spec := opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
+				Spec: opsterv1.ClusterSpec{
+					General: opsterv1.GeneralConfig{Version: "2.18.0"}, // Version that doesn't support hot reload
+					Security: &opsterv1.Security{Tls: &opsterv1.TlsConfig{
+						Transport: &opsterv1.TlsConfigTransport{
+							Generate: false,
+							TlsCertificateConfig: opsterv1.TlsCertificateConfig{
+								Secret:          corev1.LocalObjectReference{Name: "cert-transport"},
+								CaSecret:        corev1.LocalObjectReference{Name: "casecret-transport"},
+								EnableHotReload: true,
+							},
+							NodesDn: []string{"CN=mycn"},
+						},
+						Http: &opsterv1.TlsConfigHttp{
+							Generate: false,
+							TlsCertificateConfig: opsterv1.TlsCertificateConfig{
+								Secret:          corev1.LocalObjectReference{Name: "cert-http"},
+								CaSecret:        corev1.LocalObjectReference{Name: "casecret-http"},
+								EnableHotReload: true,
+							},
+						},
+					},
+					},
+				}}
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			reconcilerContext, underTest := newTLSReconciler(mockClient, &spec)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Check that hot reload is not enabled for unsupported version
+			_, exists := reconcilerContext.OpenSearchConfig["plugins.security.ssl.certificates_hot_reload.enabled"]
+			Expect(exists).To(BeFalse())
 		})
 	})
 
@@ -397,5 +512,4 @@ var _ = Describe("TLS Controller", func() {
 			Expect(value).To(Equal("[\"CN=admin,OU=tls-empty-fqdn\"]"))
 		})
 	})
-
 })


### PR DESCRIPTION
Fix hot reloading TLS certificates feature that doesn't work due to certificates being mounted using subPath function.

Fixes https://github.com/opensearch-project/opensearch-k8s-operator/issues/1021

- OpenSearch operator uses Kubernetes subPath volume mounts for TLS certificates
- subPath prevents Kubernetes from updating files when underlying Secret is updated
- Certificate renewals from cert-manager require manual pod restarts
- Affects users with externally managed certificates (cert-manager, etc.)

Solution:
- Add new `enableHotReload` configuration option to TlsCertificateConfig
- When enabled, mount certificates as directories instead of using subPath
- Maintains full backward compatibility with existing configurations
- Allows selective enabling per TLS interface (transport/HTTP)

Changes:
- api/v1/opensearch_types.go: Add EnableHotReload field to TlsCertificateConfig
- pkg/reconcilers/tls.go: Add mountWithHotReload() function with conditional subPath usage
- pkg/reconcilers/tls.go: Update transport & HTTP certificate mounting logic
- pkg/reconcilers/tls.go: Update OpenSearch config paths for hot reload mode
- config/crd/bases/: Regenerate CRD with new enableHotReload field
- pkg/reconcilers/tls_hotreload_test.go: Add comprehensive unit tests

Benefits:
- Zero downtime certificate renewals
- Automatic cert-manager integration
- Backward compatible (default: enableHotReload=false)
- Per-interface configuration granularity

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
