### PR TITLE
fix: prevent unnecessary rolling restarts during node draining

### DIFF
--- a/opensearch-operator/pkg/reconcilers/rollingRestart.go
+++ b/opensearch-operator/pkg/reconcilers/rollingRestart.go
@@ -74,7 +74,7 @@ func (r *RollingRestartReconciler) Reconcile() (ctrl.Result, error) {
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		
+
 		// Skip rolling restart if revisions are the same (no actual spec changes)
 		// This prevents unnecessary rolling restarts during node draining/pod recreation
 		if sts.Status.UpdateRevision != "" && sts.Status.CurrentRevision == sts.Status.UpdateRevision {
@@ -82,7 +82,7 @@ func (r *RollingRestartReconciler) Reconcile() (ctrl.Result, error) {
 			lg.V(1).Info(fmt.Sprintf("StatefulSet %s has matching current and update revisions, skipping rolling restart", sts.Name))
 			continue
 		}
-		
+
 		if sts.Status.UpdateRevision != "" &&
 			sts.Status.UpdatedReplicas != ptr.Deref(sts.Spec.Replicas, int32(1)) {
 			pendingUpdate = true
@@ -156,14 +156,14 @@ func (r *RollingRestartReconciler) Reconcile() (ctrl.Result, error) {
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		
+
 		// Skip rolling restart if revisions are the same (no actual spec changes)
 		// This prevents unnecessary rolling restarts during node draining/pod recreation
 		if sts.Status.UpdateRevision != "" && sts.Status.CurrentRevision == sts.Status.UpdateRevision {
 			lg.V(1).Info(fmt.Sprintf("StatefulSet %s has matching current and update revisions, skipping rolling restart", sts.Name))
 			continue
 		}
-		
+
 		if sts.Status.UpdateRevision != "" &&
 			sts.Status.UpdatedReplicas != ptr.Deref(sts.Spec.Replicas, 1) {
 			// Only restart pods if not all pods are updated and the sts is healthy with no pods terminating
@@ -206,6 +206,10 @@ func (r *RollingRestartReconciler) restartStatefulSetPod(sts *appsv1.StatefulSet
 	workingPod, err := helpers.WorkingPodForRollingRestart(r.client, sts)
 	if err != nil {
 		return ctrl.Result{}, err
+	}
+	if workingPod == "" {
+		// Nothing to restart right now; do not requeue due to this condition
+		return ctrl.Result{}, nil
 	}
 
 	lg.Info(fmt.Sprintf("Preparing to restart pod %s", workingPod))

--- a/opensearch-operator/pkg/reconcilers/upgrade.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade.go
@@ -348,6 +348,11 @@ func (r *UpgradeReconciler) doNodePoolUpgrade(pool opsterv1.NodePool) error {
 		r.setComponentConditions(conditions, pool.Component)
 		return err
 	}
+	if workingPod == "" {
+		// No pod to restart right now; this is a non-error state
+		r.setComponentConditions(conditions, pool.Component)
+		return nil
+	}
 
 	ready, err = services.PreparePodForDelete(r.osClient, r.logger, workingPod, r.instance.Spec.General.DrainDataNodes, dataCount)
 	if err != nil {


### PR DESCRIPTION
When nodes are drained during K8S or OS upgrades, pods get deleted and recreated, but the StatefulSet revision doesn't change. The existing logic incorrectly triggered rolling restarts in these scenarios, causing all pods with lower ordinal numbers to be terminated simultaneously.

This change adds revision comparison checks to prevent rolling restarts when StatefulSet current and update revisions match, indicating no actual spec changes occurred. Rolling restarts now only happen when there are legitimate configuration updates requiring pod recreation.

Changes:
- Add revision match checks in RollingRestartReconciler.Reconcile()
- Enhance WorkingPodForRollingRestart() to skip when revisions match
- Add debug logging to indicate when rolling restarts are skipped

Fixes issues during node upgrades and other node draining scenarios where pods are recreated without spec changes. Fixes https://github.com/opensearch-project/opensearch-k8s-operator/issues/312.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
