### PR TITLE
Allow the opensearch operator to watch multiple namespaces

### DIFF
--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -51,7 +51,11 @@ spec:
         - --metrics-bind-address={{ .Values.manager.metricsBindAddress }}
         - --leader-elect
         {{- if .Values.manager.watchNamespace }}
+        {{- if kindIs "slice" .Values.manager.watchNamespace }}
+        - --watch-namespace={{ .Values.manager.watchNamespace | join "," }}
+        {{- else }}
         - --watch-namespace={{ .Values.manager.watchNamespace }}
+        {{- end }}
         {{- end }}
         - --loglevel={{ .Values.manager.loglevel }}
         command:

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -63,6 +63,10 @@ manager:
 
   # If a watchNamespace is specified, the manager's cache will be restricted to
   # watch objects in the desired namespace. Defaults is to watch all namespaces.
+  # To watch multiple namespaces, separate them by commas, or define it as a list.
+  # Examples:
+  # watchNamespace: ns1,ns2
+  # watchNamespace: [ns1, ns2]
   watchNamespace:
 
   metricsBindAddress: 127.0.0.1:8080

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -92,6 +92,10 @@ manager:
   loglevel: info
 
   # If specified, the operator will be restricted to watch objects only in the desired namespace. Defaults is to watch all namespaces.
+  # To watch multiple namespaces, either separate their name via commas or define it as a list.
+  # Examples:
+  # watchNamespaces: 'ns1,ns2'
+  # watchNamespace: [ns1, ns2]
   watchNamespace:
 
   # Configure extra environment variables for the operator. You can also pull them from secrets or configmaps

--- a/opensearch-operator/main.go
+++ b/opensearch-operator/main.go
@@ -22,7 +22,10 @@ import (
 	"os"
 	"strconv"
 
+	"strings"
+
 	"github.com/Opster/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
+
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -71,7 +74,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&watchNamespace, "watch-namespace", "",
-		"The namespace that controller manager is restricted to watch. If not set, default is to watch all namespaces.")
+		"The comma-separated list of namespaces that the controller manager is restricted to watch. If not set, default is to watch all namespaces.")
 	flag.StringVar(&logLevel, "loglevel", "info", "The log level to use for the operator logs. Possible values: debug,info,warn,error")
 
 	opts := zap.Options{
@@ -93,6 +96,9 @@ func main() {
 	if watchNamespace != "" {
 		cacheOpts.DefaultNamespaces = map[string]cache.Config{
 			watchNamespace: {},
+		}
+		for watchNs := range strings.SplitSeq(watchNamespace, ",") {
+			cacheOpts.DefaultNamespaces[watchNs] = cache.Config{}
 		}
 	}
 


### PR DESCRIPTION
### Description

We allow the opensearch-operator to watch multiple namespaces.

We keep the original `-watch-namespace` flag, to ensure backwards compatibility. We simply split the value over any comma, and populate the cache for each namespace in the csv.

**Note**: Because the `watchNamespace` variable was being tested for emptiness _before_ `flag.Parse()` was being called, it was always empty, causing the operator to _always_ watch all namespaces in the cluster. This is no longer the case.

I have added documentation in the user guide as well as in the chart values.

Because this change occurs in `main.go`, for which we don't have unit tests, I'll enclose my manual test  notes.

### Testing

We first rebuild the operator binary.

```console
~/code/opensearch-k8s-operator/opensearch-operator watch-multiple-ns ?1 ❯ make build
test -s /Users/brouberol/code/opensearch-k8s-operator/opensearch-operator/bin/controller-gen || GOBIN=/Users/brouberol/code/opensearch-k8s-operator/opensearch-operator/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.0
/Users/brouberol/code/opensearch-k8s-operator/opensearch-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
go build -o bin/manager main.go
```

We ensure that the new behavior is now available.
```console
~/code/opensearch-k8s-operator/opensearch-operator watch-multiple-ns ?1 ❯ ./bin/manager --help 2>&1 | grep -A 1 watch-namespace
  -watch-namespace string
    	The comma-separated list of namespaces that the controller manager is restricted to watch. If not set, default is to watch all namespaces.
```

We run the operator alongside a local minikube.
```console
~/code/opensearch-k8s-operator/opensearch-operator watch-multiple-ns ?1 ❯ ./bin/manager -watch-namespace ns1,ns2 
{"level":"info","ts":"2025-09-17T16:34:39.456+0200","logger":"setup","msg":"Starting manager"}
{"level":"info","ts":"2025-09-17T16:34:39.457+0200","msg":"starting server","name":"health probe","addr":"[::]:8081"}
{"level":"info","ts":"2025-09-17T16:34:39.457+0200","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
...
```

We define a namespace-less cluster resource
```console
~/c/opensearch-k8s-operator/opensearch-operator watch-multiple-ns ?1 ❯ cat cluster.yaml
```

```yaml
apiVersion: opensearch.opster.io/v1
kind: OpenSearchCluster
metadata:
  name: opensearch-cluster
spec:
  general:
    serviceName: opensearch-cluster
    version: '3'
  dashboards:
    enable: true
    version: '3'
    replicas: 1
    resources:
      requests:
        memory: "512Mi"
        cpu: "200m"
      limits:
        memory: "512Mi"
        cpu: "200m"
  nodePools:
    - component: nodes
      replicas: 3
      diskSize: "5Gi"
      nodeSelector:
      resources:
        requests:
          memory: "2Gi"
          cpu: "500m"
        limits:
          memory: "2Gi"
          cpu: "500m"
      roles:
        - "cluster_manager"
        - "data"
```

We create 3 namespaces
```console
~/c/opensearch-k8s-operator/opensearch-operator watch-multiple-ns ?1 ❯ kubectl create namespace ns1
namespace/ns1 created
~/c/opensearch-k8s-operator/opensearch-operator watch-multiple-ns ?1 ❯ kubectl create namespace ns2
namespace/ns2 created
~/c/opensearch-k8s-operator/opensearch-operator watch-multiple-ns ?1 ❯ kubectl create namespace ns3
namespace/ns3 created
```

We now create an opensearch cluster in `ns1` 
```console
~/c/opensearch-k8s-operator/opensearch-operator watch-multiple-ns ?1 ❯ kubectl create -n ns1 -f cluster.yaml
opensearchcluster.opensearch.opster.io/opensearch-cluster created
```

We start seeing activity in the operator logs
```console
{"level":"info","ts":"2025-09-17T16:38:19.560+0200","msg":"Reconciling OpenSearchCluster","controller":"opensearchcluster","controllerGroup":"opensearch.opster.io","controllerKind":"OpenSearchCluster","OpenSearchCluster":{"name":"opensearch-cluster","namespace":"ns1"},"namespace":"ns1","name":"opensearch-cluster","reconcileID":"4e9e94b2-8f25-4832-92bf-3a8e23349e3b","cluster":{"name":"opensearch-cluster","namespace":"ns1"}}
{"level":"info","ts":"2025-09-17T16:38:19.566+0200","msg":"Start reconcile - Phase: PENDING","controller":"opensearchcluster","controllerGroup":"opensearch.opster.io","controllerKind":"OpenSearchCluster","OpenSearchCluster":{"name":"opensearch-cluster","namespace":"ns1"},"namespace":"ns1","name":"opensearch-cluster","reconcileID":"4e9e94b2-8f25-4832-92bf-3a8e23349e3b","cluster":{"name":"opensearch-cluster","namespace":"ns1"}}
...
```

We now create an opensearch cluster in `ns2`:
```console
~/c/opensearch-k8s-operator/opensearch-operator watch-multiple-ns ?1 ❯ kubectl create -n ns2 -f cluster.yaml
opensearchcluster.opensearch.opster.io/opensearch-cluster created
```
We start seeing activity in the operator logs, this time related to the cluster in `ns2` 
```console
{"level":"info","ts":"2025-09-17T16:41:40.313+0200","msg":"Reconciling OpenSearchCluster","controller":"opensearchcluster","controllerGroup":"opensearch.opster.io","controllerKind":"OpenSearchCluster","OpenSearchCluster":{"name":"opensearch-cluster","namespace":"ns2"},"namespace":"ns2","name":"opensearch-cluster","reconcileID":"2b0e1d2a-9d9b-4cff-b52c-d3b32789b556","cluster":{"name":"opensearch-cluster","namespace":"ns2"}}
{"level":"info","ts":"2025-09-17T16:41:40.324+0200","msg":"Start reconcile - Phase: PENDING","controller":"opensearchcluster","controllerGroup":"opensearch.opster.io","controllerKind":"OpenSearchCluster","OpenSearchCluster":{"name":"opensearch-cluster","namespace":"ns2"},"namespace":"ns2","name":"opensearch-cluster","reconcileID":"2b0e1d2a-9d9b-4cff-b52c-d3b32789b556","cluster":{"name":"opensearch-cluster","namespace":"ns2"}}
...
```

We finally create a cluster in `ns3`:

```
~/c/opensearch-k8s-operator/opensearch-operator watch-multiple-ns ?1 ❯ kubectl create -n ns3 -f cluster.yaml
opensearchcluster.opensearch.opster.io/opensearch-cluster created
```

This time, no log related to the cluster in `ns3` is observed in the controller logs.

### Chart changes

I render the chart using the default values. The output does not contain the `-watch-namespace` flag.
```console
~/c/opensearch-k8s-operator/c/opensearch-operator watch-multiple-ns ?1 ❯ helm template  . | grep watch-namespace
~/c/opensearch-k8s-operator/c/opensearch-operator watch-multiple-ns ?1 ❯
```
I then inject either a single or multiple namespaces to watch, either in a csv or in a list, to ensure that the rendering is correct:

```console
~/c/opensearch-k8s-operator/c/opensearch-operator watch-multiple-ns ?1 ❯ helm template  . --set-json='manager.watchNamespace="ns1"' | grep watch-namespace
        - --watch-namespace=ns1
~/c/opensearch-k8s-operator/c/opensearch-operator watch-multiple-ns ?1 ❯ helm template  . --set-json='manager.watchNamespace="ns1,ns2"' | grep watch-namespace
        - --watch-namespace=ns1,ns2
~/c/opensearch-k8s-operator/c/opensearch-operator watch-multiple-ns ?1 ❯ helm template  . --set-json='manager.watchNamespace=["ns1"]' | grep watch-namespace
        - --watch-namespace=ns1
~/c/opensearch-k8s-operator/c/opensearch-operator watch-multiple-ns ?1 ❯ helm template  . --set-json='manager.watchNamespace=["ns1", "ns2"]' | grep watch-namespace
        - --watch-namespace=ns1,ns2
```

### Issues Resolved
Closes #374

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
