### PR TITLE
[WIP] Use docker image's default startup command and install plugins via init container

### DIFF
--- a/opensearch-operator/controllers/cluster_test.go
+++ b/opensearch-operator/controllers/cluster_test.go
@@ -446,20 +446,6 @@ var _ = Describe("Cluster Reconciler", func() {
 				return sts.Spec.Template.Spec.Containers[0].Image == "docker.io/opensearchproject/opensearch:1.1.0"
 			}, timeout, interval).Should(BeTrue())
 		})
-		It("should update any plugin URLs", func() {
-			Eventually(func() bool {
-				sts := &appsv1.StatefulSet{}
-				if err := k8sClient.Get(
-					context.Background(),
-					client.ObjectKey{
-						Namespace: OpensearchCluster.Namespace,
-						Name:      clusterName + "-nodes",
-					}, sts); err != nil {
-					return false
-				}
-				return ArrayElementContains(sts.Spec.Template.Spec.Containers[0].Command, "http://foo-plugin-1.1.0")
-			}, timeout, interval).Should(BeTrue())
-		})
 	})
 	When("a cluster is upgraded", func() {
 		Specify("updating the status should succeed", func() {

--- a/opensearch-operator/pkg/helpers/reconcile-helpers.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers.go
@@ -124,27 +124,19 @@ func VersionCheck(instance *opsterv1.OpenSearchCluster) (int32, int32, string) {
 	return httpPort, securityConfigPort, securityConfigPath
 }
 
-func BuildMainCommand(installerBinary string, pluginsList []string, batchMode bool, entrypoint string) []string {
-	var mainCommand []string
-	com := installerBinary + " install"
-
-	if batchMode {
-		com = com + " --batch"
+// BuildPluginInstallCommand builds a command for installing plugins in an init container
+func BuildPluginInstallCommand(installerBinary string, pluginsList []string) []string {
+	if len(pluginsList) == 0 {
+		return []string{"/bin/bash", "-c", "echo 'No plugins to install'"}
 	}
-
-	if len(pluginsList) > 0 {
-		mainCommand = append(mainCommand, "/bin/bash", "-c")
-		for _, plugin := range pluginsList {
-			com = com + " '" + strings.ReplaceAll(plugin, "'", "\\'") + "'"
-		}
-
-		com = com + " && " + entrypoint
-		mainCommand = append(mainCommand, com)
-	} else {
-		mainCommand = []string{"/bin/bash", "-c", entrypoint}
+	var command []string
+	command = append(command, "/bin/bash", "-c")
+	com := installerBinary + " install --batch"
+	for _, plugin := range pluginsList {
+		com = com + " '" + strings.ReplaceAll(plugin, "'", "\\'") + "'"
 	}
-
-	return mainCommand
+	command = append(command, com)
+	return command
 }
 
 func BuildMainCommandOSD(installerBinary string, pluginsList []string, entrypoint string) []string {


### PR DESCRIPTION
### Issues Resolved
#1111

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
