### PR TITLE
Feat: Allow disabling SSL in OpenSearchCluster CRD with DisableSSL

### DIFF
--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -3993,6 +3993,9 @@ spec:
                     type: string
                   defaultRepo:
                     type: string
+                  disableSSL:
+                    description: Disable SSL for the cluster
+                    type: boolean
                   drainDataNodes:
                     description: Drain data nodes controls whether to drain data notes
                       on rolling restart operations

--- a/docs/designs/crd.md
+++ b/docs/designs/crd.md
@@ -200,6 +200,12 @@ GeneralConfig defines global Opensearch cluster configuration
         <td></td>
         <td></td>
       </tr><tr>
+        <td><b>DisableSSL</b></td>
+        <td>bool</td>
+        <td>Disable SSL for the cluster (uses HTTP instead of HTTPS)</td>
+        <td>false</td>
+        <td>false</td>
+      </tr><tr>
         <td><b>keystore</b></td>
         <td>[]opsterv1.KeystoreValue</td>
         <td>List of objects that define secret values that will populate the opensearch keystore.</td>

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -52,6 +52,8 @@ type GeneralConfig struct {
 	ServiceName      string  `json:"serviceName"`
 	SetVMMaxMapCount bool    `json:"setVMMaxMapCount,omitempty"`
 	DefaultRepo      *string `json:"defaultRepo,omitempty"`
+	// Disable SSL for the cluster
+	DisableSSL bool `json:"disableSSL,omitempty"`
 	// Extra items to add to the opensearch.yml
 	AdditionalConfig map[string]string `json:"additionalConfig,omitempty"`
 	// Adds support for annotations in services

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -3993,6 +3993,9 @@ spec:
                     type: string
                   defaultRepo:
                     type: string
+                  disableSSL:
+                    description: Disable SSL for the cluster
+                    type: boolean
                   drainDataNodes:
                     description: Drain data nodes controls whether to drain data notes
                       on rolling restart operations

--- a/opensearch-operator/pkg/reconcilers/tls.go
+++ b/opensearch-operator/pkg/reconcilers/tls.go
@@ -56,6 +56,12 @@ const (
 )
 
 func (r *TLSReconciler) Reconcile() (ctrl.Result, error) {
+	if r.instance.Spec.General.DisableSSL {
+		r.logger.Info("HTTP TLS is disabled. Disabling SSL for HTTP layer")
+		r.reconcilerContext.AddConfig("plugins.security.ssl.http.enabled", "false")
+		return ctrl.Result{}, nil
+	}
+
 	if r.instance.Spec.Security == nil || r.instance.Spec.Security.Tls == nil {
 		r.logger.Info("No security specified. Not doing anything")
 		return ctrl.Result{}, nil

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -215,8 +215,13 @@ func CreateAdditionalVolumes(
 }
 
 func OpensearchClusterURL(cluster *opsterv1.OpenSearchCluster) string {
+	protocol := "https"
+	if cluster.Spec.General.DisableSSL {
+		protocol = "http"
+	}
 	return fmt.Sprintf(
-		"https://%s.%s.svc.%s:%v",
+		"%s://%s.%s.svc.%s:%v",
+		protocol,
 		cluster.Spec.General.ServiceName,
 		cluster.Namespace,
 		helpers.ClusterDnsBase(),

--- a/opensearch-operator/pkg/reconcilers/util/util_test.go
+++ b/opensearch-operator/pkg/reconcilers/util/util_test.go
@@ -201,3 +201,50 @@ var _ = Describe("Additional volumes", func() {
 		})
 	})
 })
+
+var _ = Describe("OpensearchClusterURL", func() {
+	When("DisableSSL is false", func() {
+		It("should return https URL", func() {
+			cluster := &opsterv1.OpenSearchCluster{
+				Spec: opsterv1.ClusterSpec{
+					General: opsterv1.GeneralConfig{
+						ServiceName: "test-service",
+						HttpPort:    9200,
+						DisableSSL:  false,
+					},
+				},
+			}
+			cluster.Name = "test-cluster"
+			cluster.Namespace = "test-namespace"
+
+			url := OpensearchClusterURL(cluster)
+			Expect(url).To(ContainSubstring("https://"))
+			Expect(url).To(ContainSubstring("test-service"))
+			Expect(url).To(ContainSubstring("test-namespace"))
+			Expect(url).To(ContainSubstring(":9200"))
+		})
+	})
+
+	When("DisableSSL is true", func() {
+		It("should return http URL", func() {
+			cluster := &opsterv1.OpenSearchCluster{
+				Spec: opsterv1.ClusterSpec{
+					General: opsterv1.GeneralConfig{
+						ServiceName: "test-service",
+						HttpPort:    9200,
+						DisableSSL:  true,
+					},
+				},
+			}
+			cluster.Name = "test-cluster"
+			cluster.Namespace = "test-namespace"
+
+			url := OpensearchClusterURL(cluster)
+			Expect(url).To(ContainSubstring("http://"))
+			Expect(url).NotTo(ContainSubstring("https://"))
+			Expect(url).To(ContainSubstring("test-service"))
+			Expect(url).To(ContainSubstring("test-namespace"))
+			Expect(url).To(ContainSubstring(":9200"))
+		})
+	})
+})


### PR DESCRIPTION


### Description
This PR adds the ability to disable SSL/TLS in the OpenSearch cluster by introducing a new configuration option DisableSSL in the OpenSearchCluster CRD. When enabled, this option configures the cluster to operate without SSL encryption, which can be useful for development environments or in secure, isolated networks.

based on pr: #966
### Issues Resolved
Fix: #967

### Check List
- [X] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [ ] No linter warnings (`make lint`)
linter shows errors, but they appear to be pre-existing
  infrastructure issues unrelated to the DisableSSL changes
If CRDs are changed:
- [x] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [x] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
