### PR TITLE
fix: correct typos in cleanupStatefulSets func

### DIFF
--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -298,7 +298,7 @@ func (r *ScalerReconciler) drainNode(currentStatus opsterv1.ComponentStatus, cur
 }
 
 func (r *ScalerReconciler) cleanupStatefulSets(result *reconciler.CombinedResult) {
-	stsList, err := r.client.ListStatefulSets(client.InNamespace(r.instance.Name),
+	stsList, err := r.client.ListStatefulSets(client.InNamespace(r.instance.Namespace),
 		client.MatchingLabels{helpers.ClusterLabel: r.instance.Name})
 	if err != nil {
 		result.Combine(&ctrl.Result{}, err)
@@ -375,6 +375,6 @@ func (r *ScalerReconciler) removeStatefulSet(sts appsv1.StatefulSet) (*ctrl.Resu
 	if err != nil {
 		lg.Error(err, fmt.Sprintf("failed to remove node exclusion for %s", lastReplicaNodeName))
 	}
-	r.recorder.AnnotatedEventf(r.instance, annotations, "Noraml", "Scaler", "Finished scaling")
+	r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Finished scaling")
 	return result, err
 }

--- a/opensearch-operator/pkg/reconcilers/scaler_test.go
+++ b/opensearch-operator/pkg/reconcilers/scaler_test.go
@@ -1,0 +1,117 @@
+package reconcilers
+
+import (
+	"context"
+
+	opsterv1 "github.com/Opster/opensearch-k8s-operator/opensearch-operator/api/v1"
+	"github.com/Opster/opensearch-k8s-operator/opensearch-operator/mocks/github.com/Opster/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
+	"github.com/Opster/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
+	"github.com/cisco-open/operator-tools/pkg/reconciler"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func newScalerReconciler(client *k8s.MockK8sClient, spec *opsterv1.OpenSearchCluster) *ScalerReconciler {
+	reconcilerContext := NewReconcilerContext(&helpers.MockEventRecorder{}, spec, spec.Spec.NodePools)
+	underTest := &ScalerReconciler{
+		client:            client,
+		ctx:               context.Background(),
+		recorder:          &record.FakeRecorder{},
+		reconcilerContext: &reconcilerContext,
+		instance:          spec,
+	}
+	return underTest
+}
+
+var _ = Describe("Scaler Controller", func() {
+
+	Context("When cleaning up StatefulSets", func() {
+		It("Should use the correct namespace when listing StatefulSets", func() {
+			clusterName := "test-cluster"
+			clusterNamespace := "test-namespace"
+
+			spec := opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: clusterNamespace,
+					UID:       "dummyuid",
+				},
+				Spec: opsterv1.ClusterSpec{
+					General: opsterv1.GeneralConfig{},
+					NodePools: []opsterv1.NodePool{
+						{
+							Component: "masters",
+							Replicas:  3,
+						},
+					},
+				},
+			}
+
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			// Mock the ListStatefulSets call to verify it uses the correct namespace
+			mockClient.On("ListStatefulSets",
+				client.InNamespace(clusterNamespace),
+				client.MatchingLabels{helpers.ClusterLabel: clusterName}).Return(appsv1.StatefulSetList{
+				Items: []appsv1.StatefulSet{},
+			}, nil)
+
+			underTest := newScalerReconciler(mockClient, &spec)
+			result := &reconciler.CombinedResult{}
+			underTest.cleanupStatefulSets(result)
+			Expect(result.Err).To(BeNil())
+			mockClient.AssertExpectations(GinkgoT())
+		})
+
+		It("Should fail if wrong namespace is used (regression test)", func() {
+			clusterName := "test-cluster"
+			clusterNamespace := "test-namespace"
+			wrongNamespace := clusterName // This would be the bug: using cluster name as namespace
+
+			spec := opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: clusterNamespace,
+					UID:       "dummyuid",
+				},
+				Spec: opsterv1.ClusterSpec{
+					General: opsterv1.GeneralConfig{},
+					NodePools: []opsterv1.NodePool{
+						{
+							Component: "masters",
+							Replicas:  3,
+						},
+					},
+				},
+			}
+
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			// Mock the ListStatefulSets call with the WRONG namespace (the bug scenario)
+			// This should NOT be called if the fix is working correctly
+			mockClient.On("ListStatefulSets",
+				client.InNamespace(wrongNamespace),
+				client.MatchingLabels{helpers.ClusterLabel: clusterName}).Return(appsv1.StatefulSetList{
+				Items: []appsv1.StatefulSet{},
+			}, nil).Maybe() // Maybe() means this call might not happen
+
+			// Mock the ListStatefulSets call with the CORRECT namespace
+			mockClient.On("ListStatefulSets",
+				client.InNamespace(clusterNamespace),
+				client.MatchingLabels{helpers.ClusterLabel: clusterName}).Return(appsv1.StatefulSetList{
+				Items: []appsv1.StatefulSet{},
+			}, nil)
+
+			underTest := newScalerReconciler(mockClient, &spec)
+			result := &reconciler.CombinedResult{}
+			underTest.cleanupStatefulSets(result)
+			Expect(result.Err).To(BeNil())
+
+			// Verify that the correct namespace was used, not the wrong one
+			// This test ensures the bug is fixed
+			mockClient.AssertExpectations(GinkgoT())
+		})
+	})
+})


### PR DESCRIPTION
### Description
Same as https://github.com/opensearch-project/opensearch-k8s-operator/pull/1049. I added test codes.
@ThisIsQasim I opened a new PR with your fix since I don't have w+ perm to your forked repo. 
You can add test codes in your PR and close mine as duplicated one. I don't mind.

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-k8s-operator/issues/386 again

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
