### PR TITLE
Fix: SnapshotPolicy deletion schedule incorrectly uses creation schedule

### DIFF
--- a/opensearch-operator/pkg/reconcilers/snapshotpolicy.go
+++ b/opensearch-operator/pkg/reconcilers/snapshotpolicy.go
@@ -306,13 +306,16 @@ func (r *SnapshotPolicyReconciler) CreateSnapshotPolicy() (*requests.SnapshotPol
 
 	if r.instance.Spec.Deletion != nil {
 		del := &requests.SnapshotDeletion{
-			Schedule: &requests.CronSchedule{
-				Cron: requests.CronExpression{
-					Expression: r.instance.Spec.Creation.Schedule.Cron.Expression,
-					Timezone:   r.instance.Spec.Creation.Schedule.Cron.Timezone,
-				},
-			},
 			TimeLimit: r.instance.Spec.Deletion.TimeLimit,
+		}
+
+		if r.instance.Spec.Deletion.Schedule != nil {
+			del.Schedule = &requests.CronSchedule{
+				Cron: requests.CronExpression{
+					Expression: r.instance.Spec.Deletion.Schedule.Cron.Expression,
+					Timezone:   r.instance.Spec.Deletion.Schedule.Cron.Timezone,
+				},
+			}
 		}
 
 		if r.instance.Spec.Deletion.DeleteCondition != nil {


### PR DESCRIPTION
### Description
Fix bug in SnapshotPolicy where deletion schedule incorrectly uses creation schedule values instead of deletion schedule values.

**Changes:**
- Fix deletion schedule to use `r.instance.Spec.Deletion.Schedule` instead of `r.instance.Spec.Creation.Schedule`
- Add nil check for `r.instance.Spec.Deletion.Schedule` to prevent panic
- Add unit tests to verify deletion schedule is used correctly
- Add unit test for nil deletion schedule case

### Issues Resolved
Closes #1121 - Bug: SnapshotPolicy deletion schedule incorrectly uses creation schedule

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

