### PR TITLE
fix: correct namespace restriction for reconcile watch

### DIFF
--- a/opensearch-operator/main.go
+++ b/opensearch-operator/main.go
@@ -71,18 +71,19 @@ func main() {
 		"The namespace that controller manager is restricted to watch. If not set, default is to watch all namespaces.")
 	flag.StringVar(&logLevel, "loglevel", "info", "The log level to use for the operator logs. Possible values: debug,info,warn,error")
 
-	var cacheOpts cache.Options
-	if watchNamespace != "" {
-		cacheOpts.DefaultNamespaces = map[string]cache.Config{
-			watchNamespace: {},
-		}
-	}
 	opts := zap.Options{
 		Development: false,
 		TimeEncoder: zapcore.ISO8601TimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	var cacheOpts cache.Options
+	if watchNamespace != "" {
+		cacheOpts.DefaultNamespaces = map[string]cache.Config{
+			watchNamespace: {},
+		}
+	}
 
 	level, err := zapcore.ParseLevel(logLevel)
 	if err != nil {


### PR DESCRIPTION
### Description
Fix cache namespace configuration.
The cacheOpts configuration was being set before flag.Parse() was called. This meant that when the cache options were configured, the watchNamespace variable was still empty (its default value), so the namespace restriction was never applied.

### Issues Resolved
Fix https://github.com/opensearch-project/opensearch-k8s-operator/issues/1062

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
