### PR TITLE
Fix useRoleBindings to properly use Role instead of ClusterRole

### DIFF
--- a/charts/opensearch-operator/templates/opensearch-operator-manager-role-cr.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-manager-role-cr.yaml
@@ -1,5 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.useRoleBindings }}
+kind: Role
+{{- else }}
 kind: ClusterRole
+{{- end }}
 metadata:
   creationTimestamp: null
   name: {{ include "opensearch-operator.fullname" . }}-{{ .Release.Namespace }}-manager-role

--- a/charts/opensearch-operator/templates/opensearch-operator-manager-rolebinding.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-manager-rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "opensearch-operator.fullname" . }}-{{ .Release.Namespace }}-manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ include "opensearch-operator.fullname" . }}-{{ .Release.Namespace }}-manager-role
 subjects:
 - kind: ServiceAccount

--- a/charts/opensearch-operator/templates/opensearch-operator-metrics-reader-cr.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-metrics-reader-cr.yaml
@@ -1,4 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.useRoleBindings }}
+kind: Role
+metadata:
+  name: {{ include "opensearch-operator.fullname" . }}-{{ .Release.Namespace }}-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+{{- else }}
 kind: ClusterRole
 metadata:
   name: {{ include "opensearch-operator.fullname" . }}-{{ .Release.Namespace }}-metrics-reader
@@ -7,3 +17,4 @@ rules:
   - /metrics
   verbs:
   - get
+{{- end }}

--- a/charts/opensearch-operator/templates/opensearch-operator-proxy-role-cr.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-proxy-role-cr.yaml
@@ -1,5 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.useRoleBindings }}
+kind: Role
+{{- else }}
 kind: ClusterRole
+{{- end }}
 metadata:
   name: {{ include "opensearch-operator.fullname" . }}-{{ .Release.Namespace }}-proxy-role
 rules:

--- a/charts/opensearch-operator/templates/opensearch-operator-proxy-rolebinding.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-proxy-rolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "opensearch-operator.fullname" . }}-{{ .Release.Namespace }}-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: {{ include "opensearch-operator.fullname" . }}-{{ .Release.Namespace }}-proxy-role
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
Fixes #1130

When useRoleBindings is set to true, the operator should create Role and RoleBinding resources instead of ClusterRole and ClusterRoleBinding to allow installation with namespace-level privileges.

This fix updates the following templates to conditionally use Role when useRoleBindings is true:

- opensearch-operator-manager-role-cr.yaml: Now creates Role when useRoleBindings is true, otherwise creates ClusterRole
- opensearch-operator-manager-rolebinding.yaml: Now references Role when useRoleBindings is true
- opensearch-operator-metrics-reader-cr.yaml: Now creates Role when useRoleBindings is true, otherwise creates ClusterRole
- opensearch-operator-proxy-role-cr.yaml: Now creates Role when useRoleBindings is true, otherwise creates ClusterRole
- opensearch-operator-proxy-rolebinding.yaml: Now references Role when useRoleBindings is true

This enables users with only namespace admin privileges to install the operator successfully.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
