### PR TITLE
feat: quorum-safe rolling restarts across nodepools

### DIFF
--- a/opensearch-operator/pkg/reconcilers/rollingRestart.go
+++ b/opensearch-operator/pkg/reconcilers/rollingRestart.go
@@ -361,34 +361,6 @@ func (r *RollingRestartReconciler) restartSpecificPod(cand interface{}) (ctrl.Re
 	return ctrl.Result{}, nil
 }
 
-// groupNodePoolsByRole groups node pools by their role configuration
-func (r *RollingRestartReconciler) groupNodePoolsByRole() map[string][]opsterv1.NodePool {
-	groups := map[string][]opsterv1.NodePool{
-		"dataOnly":      {},
-		"dataAndMaster": {},
-		"masterOnly":    {},
-		"other":         {},
-	}
-
-	for _, nodePool := range r.instance.Spec.NodePools {
-		hasData := helpers.HasDataRole(&nodePool)
-		hasMaster := helpers.HasManagerRole(&nodePool)
-
-		switch {
-		case hasData && hasMaster:
-			groups["dataAndMaster"] = append(groups["dataAndMaster"], nodePool)
-		case hasData && !hasMaster:
-			groups["dataOnly"] = append(groups["dataOnly"], nodePool)
-		case !hasData && hasMaster:
-			groups["masterOnly"] = append(groups["masterOnly"], nodePool)
-		default:
-			groups["other"] = append(groups["other"], nodePool)
-		}
-	}
-
-	return groups
-}
-
 func (r *RollingRestartReconciler) updateStatus(status string) error {
 	return UpdateComponentStatus(r.client, r.instance, &opsterv1.ComponentStatus{
 		Component:   componentName,

--- a/opensearch-operator/pkg/reconcilers/rollingRestart_test.go
+++ b/opensearch-operator/pkg/reconcilers/rollingRestart_test.go
@@ -1,110 +1,13 @@
 package reconcilers
 
 import (
-	"context"
-
 	opsterv1 "github.com/Opster/opensearch-k8s-operator/opensearch-operator/api/v1"
-	"github.com/Opster/opensearch-k8s-operator/opensearch-operator/mocks/github.com/Opster/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
 	"github.com/Opster/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("RollingRestart Reconciler", func() {
-	var (
-		mockClient *k8s.MockK8sClient
-		instance   *opsterv1.OpenSearchCluster
-		reconciler *RollingRestartReconciler
-	)
-
-	BeforeEach(func() {
-		mockClient = k8s.NewMockK8sClient(GinkgoT())
-		instance = &opsterv1.OpenSearchCluster{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-cluster",
-				Namespace: "default",
-			},
-			Spec: opsterv1.ClusterSpec{
-				General: opsterv1.GeneralConfig{
-					ServiceName: "test-cluster",
-					Version:     "2.14.0",
-				},
-			},
-			Status: opsterv1.ClusterStatus{
-				Initialized: true,
-			},
-		}
-		reconciler = &RollingRestartReconciler{
-			client:   mockClient,
-			ctx:      context.Background(),
-			instance: instance,
-		}
-	})
-
-	Describe("groupNodePoolsByRole", func() {
-		Context("with mixed roles across availability zones", func() {
-			BeforeEach(func() {
-				instance.Spec.NodePools = []opsterv1.NodePool{
-					{
-						Component: "master-a",
-						Replicas:  1,
-						Roles:     []string{"cluster_manager"},
-					},
-					{
-						Component: "master-b",
-						Replicas:  1,
-						Roles:     []string{"cluster_manager"},
-					},
-					{
-						Component: "master-c",
-						Replicas:  1,
-						Roles:     []string{"cluster_manager"},
-					},
-					{
-						Component: "data-a",
-						Replicas:  2,
-						Roles:     []string{"data"},
-					},
-					{
-						Component: "data-b",
-						Replicas:  2,
-						Roles:     []string{"data"},
-					},
-					{
-						Component: "coordinating",
-						Replicas:  2,
-						Roles:     []string{"data", "ingest"},
-					},
-				}
-			})
-
-			It("should correctly group node pools by role", func() {
-				groups := reconciler.groupNodePoolsByRole()
-
-				Expect(groups).NotTo(BeNil())
-				Expect(groups).To(HaveKey("masterOnly"))
-				Expect(groups).To(HaveKey("dataOnly"))
-				Expect(groups).To(HaveKey("dataAndMaster"))
-				Expect(groups).To(HaveKey("other"))
-
-				// Check master-only pools
-				Expect(groups["masterOnly"]).To(HaveLen(3))
-				Expect(groups["masterOnly"][0].Component).To(Equal("master-a"))
-				Expect(groups["masterOnly"][1].Component).To(Equal("master-b"))
-				Expect(groups["masterOnly"][2].Component).To(Equal("master-c"))
-
-				// Check data-only pools
-				Expect(groups["dataOnly"]).To(HaveLen(3))
-				Expect(groups["dataOnly"][0].Component).To(Equal("data-a"))
-				Expect(groups["dataOnly"][1].Component).To(Equal("data-b"))
-
-				// Check data+master pools
-				Expect(groups["dataAndMaster"]).To(HaveLen(0))
-			})
-		})
-	})
-
 	Describe("hasManagerRole", func() {
 		Context("with cluster_manager role", func() {
 			It("should return true", func() {


### PR DESCRIPTION
### Description
Quorum-safe rolling restarts across nodepools

- implement global candidate selection for restart beyond one sts scope
- enforce one deletion per reconcile (maxUnavailable=1)
- guarantee one master at a time with cluster-wide quorum checks
- keep role-aware path as fallback if no global candidate selected

### Issues Resolved
https://github.com/opensearch-project/opensearch-k8s-operator/issues/650
https://github.com/opensearch-project/opensearch-k8s-operator/issues/738

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
