### PR TITLE
feat: add support for single-node cluster

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -78,8 +78,6 @@ If you'd like to delete your cluster, run: `kubectl delete -f cluster.yaml`. The
 
 The minimal cluster you deployed in this section is only intended for demo purposes. Please see the next sections on how to configure and manage the different aspects of your cluster.
 
-**Single-Node clusters are currently not supported**. Your cluster must have at least 3 nodes with the `master/cluster_manager` role configured.
-
 ## Configuring the operator
 
 The majority of this guide deals with configuring and managing OpenSearch clusters. But there are some general options that can be configured for the operator itself. All of this is done using helm values your provide during installation: `helm install opensearch-operator opensearch-operator/opensearch-operator -f values.yaml`.
@@ -118,6 +116,10 @@ The main job of the operator is to deploy and manage OpenSearch clusters. As suc
 ### Nodepools and Scaling
 
 OpenSearch clusters are composed of one or more node pools, with each representing a logical group of nodes that have the same [role](https://opensearch.org/docs/latest/opensearch/cluster/). Each node pool can have its own resources. For each configured nodepool the operator will create a Kubernetes StatefulSet. It also creates a Kubernetes service object for each nodepool so you can communicate with a specfic nodepool if you want.
+
+In a regular setup, your cluster must have at least 3 nodes with the `master/cluster_manager` role configured.  
+A cluster with just 2 `master/cluster_manager` nodes is not supported, as it won't be able to elect a cluster manager.  
+Single-node clusters are supported, but shall only be used for development and testing purposes.
 
 ```yaml
 spec:

--- a/opensearch-operator/controllers/cluster_test.go
+++ b/opensearch-operator/controllers/cluster_test.go
@@ -17,6 +17,7 @@ import (
 	monitoring "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,16 +30,15 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var _ = Describe("Cluster Reconciler", func() {
+var _ = DescribeTableSubtree("Cluster Reconciler", func(clusterName string, isSingleNode bool) {
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
-		clusterName = "cluster-test-cluster"
-		namespace   = clusterName
-		timeout     = time.Second * 30
-		interval    = time.Second * 1
+		timeout  = time.Second * 30
+		interval = time.Second * 1
 	)
 	var (
-		OpensearchCluster      = ComposeOpensearchCrd(clusterName, namespace)
+		namespace              = clusterName
+		OpensearchCluster      = ComposeOpensearchCrd(clusterName, namespace, isSingleNode)
 		service                = corev1.Service{}
 		preUpgradeStatusLength int
 	)
@@ -213,6 +213,9 @@ var _ = Describe("Cluster Reconciler", func() {
 		})
 
 		It("should set nodepool specific config", func() {
+			if isSingleNode {
+				Skip("No client nodepool in single-node config")
+			}
 			sts := &appsv1.StatefulSet{}
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), types.NamespacedName{
@@ -227,6 +230,9 @@ var _ = Describe("Cluster Reconciler", func() {
 		})
 
 		It("should set nodepool additional user defined env vars", func() {
+			if isSingleNode {
+				Skip("No client nodepool in single-node cluster")
+			}
 			sts := &appsv1.StatefulSet{}
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), types.NamespacedName{
@@ -247,6 +253,9 @@ var _ = Describe("Cluster Reconciler", func() {
 		})
 
 		It("should set nodepool additional user defined labels", func() {
+			if isSingleNode {
+				Skip("No client nodepool in single-node cluster")
+			}
 			sts := &appsv1.StatefulSet{}
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), types.NamespacedName{
@@ -268,7 +277,10 @@ var _ = Describe("Cluster Reconciler", func() {
 			Expect(sts.Spec.Template.Spec.TopologySpreadConstraints[0].TopologyKey).To(Equal("zone"))
 		})
 
-		It("should create a bootstrap pod", func() {
+		It("should create a bootstrap pod in multi-node cluster", func() {
+			if isSingleNode {
+				Skip("Not valid for single-node cluster")
+			}
 			bootstrapName := fmt.Sprintf("%s-bootstrap-0", OpensearchCluster.Name)
 			Eventually(func() error {
 				return k8sClient.Get(context.Background(), types.NamespacedName{
@@ -300,7 +312,56 @@ var _ = Describe("Cluster Reconciler", func() {
 			}
 			wg.Wait()
 		})
+		It("should not create a bootstrap pod in single-node cluster", func() {
+			if !isSingleNode {
+				Skip("Not valid for multi-node cluster")
+			}
+			bootstrapName := fmt.Sprintf("%s-bootstrap-0", OpensearchCluster.Name)
+			nodePool := OpensearchCluster.Spec.NodePools[0]
+			By(fmt.Sprintf("retrieving %s nodepool", nodePool.Component))
+			sts := &appsv1.StatefulSet{}
+			Eventually(func() error {
+				return k8sClient.Get(context.Background(), types.NamespacedName{
+					Name:      clusterName + "-" + nodePool.Component,
+					Namespace: OpensearchCluster.Namespace,
+				}, sts)
+			}, timeout, interval).Should(Succeed())
+
+			By("checkin that the bootstrap pod doesn't exist")
+			Eventually(func() bool {
+				pod := &corev1.Pod{}
+				err := k8sClient.Get(context.Background(), types.NamespacedName{
+					Name:      bootstrapName,
+					Namespace: OpensearchCluster.Namespace,
+				}, pod)
+				if err != nil {
+					return apierrors.IsNotFound(err)
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By(fmt.Sprintf("checking %s nodepool initial master is not set", nodePool.Component))
+			Eventually(func() []corev1.EnvVar {
+				sts := &appsv1.StatefulSet{}
+				if err := k8sClient.Get(context.Background(), types.NamespacedName{
+					Namespace: OpensearchCluster.Namespace,
+					Name:      clusterName + "-" + nodePool.Component,
+				}, sts); err != nil {
+					return []corev1.EnvVar{}
+				}
+				return sts.Spec.Template.Spec.Containers[0].Env
+			}, timeout, interval).Should(Or(
+				ContainElement(corev1.EnvVar{
+					Name:  "cluster.initial_master_nodes",
+					Value: "",
+				}),
+				Not(ContainElement(HaveField("Name", "cluster.initial_master_nodes"))),
+			))
+		})
 		It("should configure bootstrap pod correctly", func() {
+			if isSingleNode {
+				Skip("Not valid for single-node cluster")
+			}
 			bootstrapName := fmt.Sprintf("%s-bootstrap-0", OpensearchCluster.Name)
 			pod := &corev1.Pod{}
 			Eventually(func() error {
@@ -371,6 +432,9 @@ var _ = Describe("Cluster Reconciler", func() {
 			}, timeout, interval).Should(BeTrue())
 		})
 		It("should create a pdb resource", func() {
+			if isSingleNode {
+				Skip("Not valid for single-node cluster")
+			}
 			pdb := policyv1.PodDisruptionBudget{}
 			Eventually(func() bool {
 				if err := k8sClient.Get(context.Background(), types.NamespacedName{Name: clusterName + "-master-pdb", Namespace: OpensearchCluster.Namespace}, &pdb); err != nil {
@@ -389,7 +453,10 @@ var _ = Describe("Cluster Reconciler", func() {
 			Expect(k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&OpensearchCluster), &OpensearchCluster)).Should(Succeed())
 
 			// Update the opensearch object
-			OpensearchCluster.Spec.NodePools = OpensearchCluster.Spec.NodePools[:2]
+			if !isSingleNode {
+				// We can't add/remove nodes in single-node cluster
+				OpensearchCluster.Spec.NodePools = OpensearchCluster.Spec.NodePools[:2]
+			}
 			OpensearchCluster.Spec.General.Version = "1.1.0"
 			OpensearchCluster.Spec.General.PluginsList[0] = "http://foo-plugin-1.1.0"
 			Expect(k8sClient.Update(context.Background(), &OpensearchCluster)).Should(Succeed())
@@ -401,7 +468,7 @@ var _ = Describe("Cluster Reconciler", func() {
 					return false
 				}
 
-				return len(stsList.Items) == 2
+				return len(stsList.Items) == len(OpensearchCluster.Spec.NodePools)
 			})
 		})
 		It("should update the node pool image version", func() {
@@ -419,10 +486,17 @@ var _ = Describe("Cluster Reconciler", func() {
 	})
 
 	When("A node pool is upgrading", func() {
+		var selectedComponent string
+		if !isSingleNode {
+			selectedComponent = "nodes"
+		} else {
+			selectedComponent = "master"
+		}
+
 		Specify("updating the status should succeed", func() {
 			status := opsterv1.ComponentStatus{
 				Component:   "Upgrader",
-				Description: "nodes",
+				Description: selectedComponent,
 				Status:      "Upgrading",
 			}
 			Eventually(func() error {
@@ -441,7 +515,7 @@ var _ = Describe("Cluster Reconciler", func() {
 					context.Background(),
 					client.ObjectKey{
 						Namespace: OpensearchCluster.Namespace,
-						Name:      clusterName + "-nodes",
+						Name:      clusterName + "-" + selectedComponent,
 					}, sts); err != nil {
 					return false
 				}
@@ -455,7 +529,7 @@ var _ = Describe("Cluster Reconciler", func() {
 					context.Background(),
 					client.ObjectKey{
 						Namespace: OpensearchCluster.Namespace,
-						Name:      clusterName + "-nodes",
+						Name:      clusterName + "-" + selectedComponent,
 					}, sts); err != nil {
 					return false
 				}
@@ -464,16 +538,23 @@ var _ = Describe("Cluster Reconciler", func() {
 		})
 	})
 	When("a cluster is upgraded", func() {
+		var selectedComponent string
+		if !isSingleNode {
+			selectedComponent = "nodes"
+		} else {
+			selectedComponent = "master"
+		}
+
 		Specify("updating the status should succeed", func() {
 			currentStatus := opsterv1.ComponentStatus{
 				Component:   "Upgrader",
 				Status:      "Upgrading",
-				Description: "nodes",
+				Description: selectedComponent,
 			}
 			componentStatus := opsterv1.ComponentStatus{
 				Component:   "Upgrader",
 				Status:      "Upgraded",
-				Description: "nodes",
+				Description: selectedComponent,
 			}
 			masterComponentStatus := opsterv1.ComponentStatus{
 				Component:   "Upgrader",
@@ -548,4 +629,7 @@ var _ = Describe("Cluster Reconciler", func() {
 			// that the method doesn't error and returns the expected result
 		})
 	})
-})
+},
+	Entry("Multi-node cluster", "multi-node-cluster", false),
+	Entry("Single-node cluster", "single-node-cluster", true),
+)

--- a/opensearch-operator/controllers/dashboard_test.go
+++ b/opensearch-operator/controllers/dashboard_test.go
@@ -3,9 +3,10 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
+
 	sts "k8s.io/api/apps/v1"
 	"k8s.io/utils/ptr"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,7 +30,7 @@ var _ = Describe("Dashboards Reconciler", func() {
 		interval    = time.Second * 1
 	)
 	var (
-		OpensearchCluster = ComposeOpensearchCrd(clusterName, namespace)
+		OpensearchCluster = ComposeOpensearchCrd(clusterName, namespace, false)
 		cm                = corev1.ConfigMap{}
 		service           = corev1.Service{}
 		deploy            = sts.Deployment{}

--- a/opensearch-operator/controllers/scaler_test.go
+++ b/opensearch-operator/controllers/scaler_test.go
@@ -2,8 +2,9 @@ package controllers
 
 import (
 	"context"
-	"k8s.io/utils/ptr"
 	"time"
+
+	"k8s.io/utils/ptr"
 
 	opsterv1 "github.com/Opster/opensearch-k8s-operator/opensearch-operator/api/v1"
 	. "github.com/onsi/ginkgo/v2"
@@ -29,7 +30,7 @@ var _ = Describe("Scaler Reconciler", func() {
 		interval    = time.Second * 1
 	)
 	var (
-		OpensearchCluster = ComposeOpensearchCrd(clusterName, namespace)
+		OpensearchCluster = ComposeOpensearchCrd(clusterName, namespace, false)
 		nodePool          = appsv1.StatefulSet{}
 		cluster2          = opsterv1.OpenSearchCluster{}
 	)

--- a/opensearch-operator/functionaltests/operatortests/deploy-and-upgrade-single-node.yaml
+++ b/opensearch-operator/functionaltests/operatortests/deploy-and-upgrade-single-node.yaml
@@ -1,0 +1,43 @@
+apiVersion: opensearch.opster.io/v1
+kind: OpenSearchCluster
+metadata:
+  name: deploy-and-upgrade-single-node
+  namespace: default
+spec:
+  general:
+    version: 1.3.0
+    httpPort: 9200
+    vendor: opensearch
+    serviceName: deploy-and-upgrade-single-node
+    additionalConfig: 
+      cluster.routing.allocation.disk.watermark.low: 500m
+      cluster.routing.allocation.disk.watermark.high: 300m
+      cluster.routing.allocation.disk.watermark.flood_stage: 100m
+  confMgmt:
+    smartScaler: true
+  dashboards:
+    version: 1.3.0
+    enable: true
+    replicas: 1
+    resources:
+      requests:
+         memory: "1Gi"
+         cpu: "500m"
+      limits:
+         memory: "1Gi"
+         cpu: "500m"
+  nodePools:
+    - component: masters
+      replicas: 1
+      diskSize: "5Gi"
+      NodeSelector:
+      resources:
+         requests:
+            memory: "1Gi"
+            cpu: "500m"
+         limits:
+            memory: "2Gi"
+            cpu: "500m"
+      roles:
+        - "master"
+        - "data"

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -406,6 +406,11 @@ func HasManagerRole(nodePool *opsterv1.NodePool) bool {
 	return ContainsString(nodePool.Roles, "master") || ContainsString(nodePool.Roles, "cluster_manager")
 }
 
+func IsSingleNodeCluster(cr *opsterv1.OpenSearchCluster) bool {
+	return len(cr.Spec.NodePools) == 1 &&
+		cr.Spec.NodePools[0].Replicas == 1
+}
+
 func RemoveDuplicateStrings(strSlice []string) []string {
 	allKeys := make(map[string]bool)
 	list := []string{}

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -162,6 +162,64 @@ var _ = Describe("Helper Functions", func() {
 		})
 	})
 
+	Describe("IsSingleNodeCluster", func() {
+		Context("when checking for single node configuration", func() {
+			It("should return true for a single node cluster", func() {
+				cluster := &opsterv1.OpenSearchCluster{
+					Spec: opsterv1.ClusterSpec{
+						NodePools: []opsterv1.NodePool{
+							{
+								Component: "node",
+								Replicas:  1,
+							},
+						},
+					},
+				}
+				Expect(IsSingleNodeCluster(cluster)).To(BeTrue())
+			})
+
+			It("should return false for a cluster with multiple nodepools", func() {
+				cluster := &opsterv1.OpenSearchCluster{
+					Spec: opsterv1.ClusterSpec{
+						NodePools: []opsterv1.NodePool{
+							{
+								Component: "master",
+								Replicas:  1,
+							},
+							{
+								Component: "data",
+								Replicas:  1,
+							},
+						},
+					},
+				}
+				Expect(IsSingleNodeCluster(cluster)).To(BeFalse())
+			})
+
+			It("should return false for a cluster with single nodepool but multiple replicas", func() {
+				cluster := &opsterv1.OpenSearchCluster{
+					Spec: opsterv1.ClusterSpec{
+						NodePools: []opsterv1.NodePool{
+							{
+								Component: "node",
+								Replicas:  3,
+							},
+						},
+					},
+				}
+				Expect(IsSingleNodeCluster(cluster)).To(BeFalse())
+			})
+
+			It("should return false for a cluster with no nodepools", func() {
+				cluster := &opsterv1.OpenSearchCluster{
+					Spec: opsterv1.ClusterSpec{
+						NodePools: []opsterv1.NodePool{},
+					},
+				}
+				Expect(IsSingleNodeCluster(cluster)).To(BeFalse())
+			})
+		})
+	})
 })
 
 var _ = Describe("JVM Heap Size Functions", func() {

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -95,21 +95,24 @@ func (r *ClusterReconciler) Reconcile() (ctrl.Result, error) {
 	result.CombineErr(ctrl.SetControllerReference(r.instance, passwordSecret, r.client.Scheme()))
 	result.Combine(r.client.ReconcileResource(passwordSecret, reconciler.StatePresent))
 
-	// Create bootstrap PVC for persistent storage
-	bootstrapPVC := builders.NewBootstrapPVC(r.instance)
-	result.CombineErr(ctrl.SetControllerReference(r.instance, bootstrapPVC, r.client.Scheme()))
-	if r.instance.Status.Initialized {
-		result.Combine(r.client.ReconcileResource(bootstrapPVC, reconciler.StateAbsent))
-	} else {
-		result.Combine(r.client.ReconcileResource(bootstrapPVC, reconciler.StatePresent))
-	}
+	// Single node clusters do not use bootstrap pod, which acts as a temporary master
+	if !helpers.IsSingleNodeCluster(r.instance) {
+		// Create bootstrap PVC for persistent storage
+		bootstrapPVC := builders.NewBootstrapPVC(r.instance)
+		result.CombineErr(ctrl.SetControllerReference(r.instance, bootstrapPVC, r.client.Scheme()))
+		if r.instance.Status.Initialized {
+			result.Combine(r.client.ReconcileResource(bootstrapPVC, reconciler.StateAbsent))
+		} else {
+			result.Combine(r.client.ReconcileResource(bootstrapPVC, reconciler.StatePresent))
+		}
 
-	bootstrapPod := builders.NewBootstrapPod(r.instance, r.reconcilerContext.Volumes, r.reconcilerContext.VolumeMounts)
-	result.CombineErr(ctrl.SetControllerReference(r.instance, bootstrapPod, r.client.Scheme()))
-	if r.instance.Status.Initialized {
-		result.Combine(r.client.ReconcileResource(bootstrapPod, reconciler.StateAbsent))
-	} else {
-		result.Combine(r.client.ReconcileResource(bootstrapPod, reconciler.StatePresent))
+		bootstrapPod := builders.NewBootstrapPod(r.instance, r.reconcilerContext.Volumes, r.reconcilerContext.VolumeMounts)
+		result.CombineErr(ctrl.SetControllerReference(r.instance, bootstrapPod, r.client.Scheme()))
+		if r.instance.Status.Initialized {
+			result.Combine(r.client.ReconcileResource(bootstrapPod, reconciler.StateAbsent))
+		} else {
+			result.Combine(r.client.ReconcileResource(bootstrapPod, reconciler.StatePresent))
+		}
 	}
 
 	for _, nodePool := range r.instance.Spec.NodePools {


### PR DESCRIPTION
### Description
Introduces support for single-node clusters.
Continues the work of #989.

#### Changes needed during the bootstrap process

The bootstrap process of a regular multi-node cluser roughly looks like this:
1. A _bootstrap_ pod is created to act as an _initial_ cluster manager
2. As soon as the bootstrap pod is ready (i.e. listening on port 9200), the _security config update_ pod reaches the bootstrap pod via the _HTTP service_ and applies the security config, which is of course propagated to the rest of the cluster
3. The cluster nodes are created in sequence and join the cluster via the bootstrap pod (as specified by `cluster.initial_master_nodes`)
4. The cluster nodes are considered ready only when the _admin_ user can successfully contact the HTTP service, i.e. the security config has been applied.

To bootstrap a single-node cluster, OpenSearch mandates that:
1. `discovery.type = "single-node"`
2. `cluster.initial_master_nodes` must be empty (or not set)

Therefore:
1. We cannot set up a bootstrap pod
=> removed it in the single-node case
2. The _security config update_ pod needs to contact the node directly, so the probe for the node cannot wait for the _admin_ user to be able to log in, which happens after security config is applied.
=> In the single-node case I have removed the `--fail` flag from the node probe, which makes it fail on HTTP error codes. In this way the probe behaves as it would for the bootstrap pod.

#### Tests

I have added unit, integration and functional tests.

To avoid duplicating test code, I have adopted a _tabular_ strategy with two entries:
- multi-node cluster, which retains the previous test behavior
- single-node cluster, which tests the corner case of a single-node cluster

**Comment required from maintainers**
In `opensearch-operator/controllers/cluster_test.go`, I have set up some tests to be _skipped_ in the single-node case, as they don't make sense in that context.
To do this, I have used the `Skip()` primitive, which effectively shows the tests as skipped in the ginkgo report. Let me know if this is ok, or if you want me to refactor them in some other way.
For example instead of:
```go
It("...", func () {
  if isSingleNode {
    Skip("makes no sense in single node case")
  }
  // Test code
}
```

I could do this, so the test is considered as passed
```go
It("...", func () {
  if isSingleNode {
    By("skipping it as it makes no sense in single node case")
    return
  }
  // Test code
}
```

### Issues Resolved
Closes #233.

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
