### PR TITLE
fix: remove kubeRbacProxy from helm docs

### DIFF
--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -81,32 +81,6 @@ The following table lists the configurable parameters of the Helm chart.
 | `installCRDs` | bool | `true` |  |
 | `serviceAccount.create` | bool | `true` |  |
 | `serviceAccount.name` | string | `""` |  |
-| `kubeRbacProxy.enable` | bool | `true` |  |
-| `kubeRbacProxy.securityContext.allowPrivilegeEscalation` | bool | `false` |  |
-| `kubeRbacProxy.securityContext.readOnlyRootFilesystem` | bool | `true` |  |
-| `kubeRbacProxy.securityContext.capabilities.drop[0]` | string | `"ALL"` |  |
-| `kubeRbacProxy.resources.limits.cpu` | string | `"50m"` |  |
-| `kubeRbacProxy.resources.limits.memory` | string | `"50Mi"` |  |
-| `kubeRbacProxy.resources.requests.cpu` | string | `"25m"` |  |
-| `kubeRbacProxy.resources.requests.memory` | string | `"25Mi"` |  |
-| `kubeRbacProxy.livenessProbe.failureThreshold` | int | `3` |  |
-| `kubeRbacProxy.livenessProbe.httpGet.path` | string | `"/healthz"` |  |
-| `kubeRbacProxy.livenessProbe.httpGet.port` | int | `10443` |  |
-| `kubeRbacProxy.livenessProbe.httpGet.scheme` | string | `"HTTPS"` |  |
-| `kubeRbacProxy.livenessProbe.periodSeconds` | int | `15` |  |
-| `kubeRbacProxy.livenessProbe.successThreshold` | int | `1` |  |
-| `kubeRbacProxy.livenessProbe.timeoutSeconds` | int | `3` |  |
-| `kubeRbacProxy.livenessProbe.initialDelaySeconds` | int | `10` |  |
-| `kubeRbacProxy.readinessProbe.failureThreshold` | int | `3` |  |
-| `kubeRbacProxy.readinessProbe.httpGet.path` | string | `"/healthz"` |  |
-| `kubeRbacProxy.readinessProbe.httpGet.port` | int | `10443` |  |
-| `kubeRbacProxy.readinessProbe.httpGet.scheme` | string | `"HTTPS"` |  |
-| `kubeRbacProxy.readinessProbe.periodSeconds` | int | `15` |  |
-| `kubeRbacProxy.readinessProbe.successThreshold` | int | `1` |  |
-| `kubeRbacProxy.readinessProbe.timeoutSeconds` | int | `3` |  |
-| `kubeRbacProxy.readinessProbe.initialDelaySeconds` | int | `10` |  |
-| `kubeRbacProxy.image.repository` | string | `"gcr.io/kubebuilder/kube-rbac-proxy"` |  |
-| `kubeRbacProxy.image.tag` | string | `"v0.15.0"` |  |
 | `useRoleBindings` | bool | `false` |  |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.


### PR DESCRIPTION
### Description
remove kubeRbacProxy related parts from chart doc

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
