### PR TITLE
chore: update versions in upgrade test

### DIFF
--- a/opensearch-operator/functionaltests/operatortests/deploy-and-upgrade.yaml
+++ b/opensearch-operator/functionaltests/operatortests/deploy-and-upgrade.yaml
@@ -4,40 +4,85 @@ metadata:
   name: deploy-and-upgrade
   namespace: default
 spec:
-  general:
-    version: 1.3.0
-    httpPort: 9200
-    vendor: opensearch
-    serviceName: deploy-and-upgrade
-    additionalConfig: 
-      cluster.routing.allocation.disk.watermark.low: 500m
-      cluster.routing.allocation.disk.watermark.high: 300m
-      cluster.routing.allocation.disk.watermark.flood_stage: 100m
-  confMgmt:
-    smartScaler: true
+  bootstrap:
+    affinity: {}
+    resources: {}
+  confMgmt: {}
   dashboards:
-    version: 1.3.0
+    affinity: {}
     enable: true
+    opensearchCredentialsSecret:
+      name: ""
+    podSecurityContext: {}
     replicas: 1
-    resources:
-      requests:
-         memory: "1Gi"
-         cpu: "500m"
-      limits:
-         memory: "1Gi"
-         cpu: "500m"
+    resources: {}
+    securityContext: {}
+    service:
+      type: ClusterIP
+    tls:
+      caSecret:
+        name: ""
+      duration: 8760h0m0s
+      generate: true
+      secret:
+        name: ""
+    version: 2.19.4
+  general:
+    drainDataNodes: true
+    httpPort: 9200
+    monitoring:
+      scrapeInterval: 30s
+      tlsConfig: {}
+    podSecurityContext: {}
+    securityContext: {}
+    serviceName: opensearch-cluster
+    setVMMaxMapCount: true
+    vendor: Opensearch
+    version: 2.19.4
+  initHelper:
+    image: docker.io/busybox:1.36
+    imagePullPolicy: IfNotPresent
+    resources: {}
+    version: "1.36"
   nodePools:
-    - component: masters
-      replicas: 3
-      diskSize: "5Gi"
-      NodeSelector:
-      resources:
-         requests:
-            memory: "1Gi"
-            cpu: "500m"
-         limits:
-            memory: "2Gi"
-            cpu: "500m"
-      roles:
-        - "master"
-        - "data"
+  - component: masters
+    diskSize: 30Gi
+    replicas: 3
+    resources:
+      limits:
+        cpu: 500m
+        memory: 2Gi
+      requests:
+        cpu: 500m
+        memory: 2Gi
+    roles:
+    - master
+    - data
+  security:
+    config:
+      adminCredentialsSecret:
+        name: ""
+      adminSecret:
+        name: ""
+      securityConfigSecret:
+        name: ""
+      updateJob:
+        resources: {}
+    tls:
+      http:
+        caSecret:
+          name: ""
+        duration: 8760h0m0s
+        generate: true
+        rotateDaysBeforeExpiry: -1
+        secret:
+          name: ""
+      transport:
+        caSecret:
+          name: ""
+        duration: 8760h0m0s
+        generate: true
+        perNode: true
+        rotateDaysBeforeExpiry: -1
+        secret:
+          name: ""

--- a/opensearch-operator/functionaltests/operatortests/deploy_and_upgrade_test.go
+++ b/opensearch-operator/functionaltests/operatortests/deploy_and_upgrade_test.go
@@ -52,8 +52,8 @@ var _ = Describe("DeployAndUpgrade", Ordered, func() {
 			cluster.SetGroupVersionKind(schema.GroupVersionKind{Group: "opensearch.opster.io", Version: "v1", Kind: "OpenSearchCluster"})
 			Get(&cluster, client.ObjectKey{Name: name, Namespace: namespace}, time.Second*5)
 
-			SetNestedKey(cluster.Object, "2.3.0", "spec", "general", "version")
-			SetNestedKey(cluster.Object, "2.3.0", "spec", "dashboards", "version")
+			SetNestedKey(cluster.Object, "3.3.0", "spec", "general", "version")
+			SetNestedKey(cluster.Object, "3.3.0", "spec", "dashboards", "version")
 
 			Expect(k8sClient.Update(context.Background(), &cluster)).ToNot(HaveOccurred())
 		})
@@ -66,7 +66,7 @@ var _ = Describe("DeployAndUpgrade", Ordered, func() {
 					return sts.Spec.Template.Spec.Containers[0].Image
 				}
 				return ""
-			}, time.Minute*3, time.Second*5).Should(Equal("docker.io/opensearchproject/opensearch:2.3.0"))
+			}, time.Minute*3, time.Second*5).Should(Equal("docker.io/opensearchproject/opensearch:3.3.0"))
 
 			Eventually(func() int32 {
 				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: name + "-masters", Namespace: namespace}, &sts)
@@ -105,7 +105,7 @@ var _ = Describe("DeployAndUpgrade", Ordered, func() {
 					return deployment.Spec.Template.Spec.Containers[0].Image
 				}
 				return ""
-			}, time.Minute*1, time.Second*5).Should(Equal("docker.io/opensearchproject/opensearch-dashboards:2.3.0"))
+			}, time.Minute*1, time.Second*5).Should(Equal("docker.io/opensearchproject/opensearch-dashboards:3.3.0"))
 
 			Eventually(func() int32 {
 				err := k8sClient.Get(context.Background(), client.ObjectKey{Name: name + "-dashboards", Namespace: namespace}, &deployment)


### PR DESCRIPTION
### Description
The upgrade functional test was originally implemented 3 years ago in commit [db237e9](https://github.com/opensearch-project/opensearch-k8s-operator/commit/db237e907effa86b550f87110b2e42e8c75ba037) and only covered the upgrade path from 1.3.0 to 2.3.0. With OpenSearch now at version 3.x, we need to ensure upgrade testing from 2.x to 3.x. 
This PR 
- sets before and after versions as 2.19.x and 3.3.0
- enable tls in the test cluster

### Issues Resolved
fix https://github.com/opensearch-project/opensearch-k8s-operator/issues/1164

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
