### PR TITLE
replace readyReplicas with direct pod counts

### DIFF
--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -318,6 +318,15 @@ func CountRunningPodsForNodePool(k8sClient k8s.K8sClient, cr *opsterv1.OpenSearc
 	return numReadyPods, nil
 }
 
+// ReadyReplicasForNodePool returns the number of ready replicas derived from the actual running pods.
+func ReadyReplicasForNodePool(k8sClient k8s.K8sClient, cr *opsterv1.OpenSearchCluster, nodePool *opsterv1.NodePool) (int32, error) {
+	numReadyPods, err := CountRunningPodsForNodePool(k8sClient, cr, nodePool)
+	if err != nil {
+		return 0, err
+	}
+	return int32(numReadyPods), nil
+}
+
 // Count the number of PVCs created for the given NodePool
 func CountPVCsForNodePool(k8sClient k8s.K8sClient, cr *opsterv1.OpenSearchCluster, nodePool *opsterv1.NodePool) (int, error) {
 	clusterReq, err := labels.NewRequirement(ClusterLabel, selection.Equals, []string{cr.Name})

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -202,6 +202,11 @@ func (r *ClusterReconciler) reconcileNodeStatefulSet(nodePool opsterv1.NodePool,
 			}
 			existing = *new
 		}
+		readyReplicas, err := helpers.ReadyReplicasForNodePool(r.client, r.instance, &nodePool)
+		if err != nil {
+			return result, err
+		}
+		existing.Status.ReadyReplicas = readyReplicas
 		// Check number of PVCs for nodepool
 		pvcCount, err := helpers.CountPVCsForNodePool(r.client, r.instance, &nodePool)
 		if err != nil {
@@ -334,6 +339,11 @@ func (r *ClusterReconciler) checkForEmptyDirRecovery() (*ctrl.Result, error) {
 			if err != nil {
 				return &ctrl.Result{Requeue: true}, err
 			}
+			readyReplicas, err := helpers.ReadyReplicasForNodePool(r.client, r.instance, &nodePool)
+			if err != nil {
+				return &ctrl.Result{Requeue: true}, err
+			}
+			sts.Status.ReadyReplicas = readyReplicas
 		}
 
 		if helpers.HasDataRole(&nodePool) {

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -77,6 +77,12 @@ func (r *ScalerReconciler) reconcileNodePool(nodePool *opsterv1.NodePool) (bool,
 		return false, err
 	}
 
+	readyReplicas, err := helpers.ReadyReplicasForNodePool(r.client, r.instance, nodePool)
+	if err != nil {
+		return false, err
+	}
+	currentSts.Status.ReadyReplicas = readyReplicas
+
 	componentStatus := opsterv1.ComponentStatus{
 		Component:   "Scaler",
 		Status:      "Running",

--- a/opensearch-operator/pkg/reconcilers/upgrade.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade.go
@@ -309,6 +309,12 @@ func (r *UpgradeReconciler) doNodePoolUpgrade(pool opsterv1.NodePool) error {
 		return err
 	}
 
+	readyReplicas, err := helpers.ReadyReplicasForNodePool(r.client, r.instance, &pool)
+	if err != nil {
+		return err
+	}
+	sts.Status.ReadyReplicas = readyReplicas
+
 	dataCount := util.DataNodesCount(r.client, r.instance)
 	if dataCount == 2 && r.instance.Spec.General.DrainDataNodes {
 		r.logger.Info("Only 2 data nodes and drain is set, some shards may not drain")

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -338,6 +338,12 @@ func GetAvailableOpenSearchNodes(k8sClient k8s.K8sClient, ctx context.Context, c
 		}
 
 		if sts != nil {
+			readyReplicas, err := helpers.ReadyReplicasForNodePool(k8sClient, cluster, &nodePool)
+			if err != nil {
+				lg.V(1).Info(fmt.Sprintf("Failed to count ready pods for nodepool %s: %v", nodePool.Component, err))
+				return previousAvailableNodes
+			}
+			sts.Status.ReadyReplicas = readyReplicas
 			availableNodes += sts.Status.ReadyReplicas
 		}
 	}


### PR DESCRIPTION
### Description
Avoid stale `status.ReadyReplicas` by recomputing from pods to support strict ready pod accounting.

Originated from https://github.com/opensearch-project/opensearch-k8s-operator/pull/694

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
