### PR TITLE
Enable coordinator nodes

### DIFF
--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -1294,18 +1294,21 @@ spec:
                             Required.
                           type: string
                         persistentVolumeClaim:
-                          description: PersistentVolumeClaim object to use to populate the volume
+                          description: PersistentVolumeClaim object to use to populate
+                            the volume
                           properties:
                             claimName:
                               description: |-
-                                The name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                 More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               type: string
                             readOnly:
                               description: |-
-                                Will force the ReadOnly setting in VolumeMounts.
+                                readOnly Will force the ReadOnly setting in VolumeMounts.
                                 Default false.
                               type: boolean
+                          required:
+                          - claimName
                           type: object
                         projected:
                           description: Projected object to use to populate the volume
@@ -3059,6 +3062,7 @@ spec:
                         type: object
                     type: object
                   replicas:
+                    default: 1
                     format: int32
                     type: integer
                   resources:
@@ -3427,9 +3431,6 @@ spec:
                     type: array
                   version:
                     type: string
-                required:
-                - replicas
-                - version
                 type: object
               general:
                 description: |-
@@ -3593,18 +3594,21 @@ spec:
                             Required.
                           type: string
                         persistentVolumeClaim:
-                          description: PersistentVolumeClaim object to use to populate the volume
+                          description: PersistentVolumeClaim object to use to populate
+                            the volume
                           properties:
                             claimName:
                               description: |-
-                                The name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
                                 More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                               type: string
                             readOnly:
                               description: |-
-                                Will force the ReadOnly setting in VolumeMounts.
+                                readOnly Will force the ReadOnly setting in VolumeMounts.
                                 Default false.
                               type: boolean
+                          required:
+                          - claimName
                           type: object
                         projected:
                           description: Projected object to use to populate the volume
@@ -4116,6 +4120,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  operatorClusterURL:
+                    description: |-
+                      Operator cluster URL. If set, the operator will use this URL to communicate with OpenSearch
+                      instead of the default internal Kubernetes service DNS name.
+                    type: string
                   pluginsList:
                     items:
                       type: string
@@ -6322,6 +6331,11 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
+                          customFQDN:
+                            description: Custom FQDN to use for the HTTP certificate.
+                              If not set, the operator will use the default cluster
+                              DNS names.
+                            type: string
                           duration:
                             default: 8760h
                             description: Duration controls the validity period of

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -159,6 +159,18 @@ var _ = Describe("Builders", func() {
 				Value: "search",
 			}))
 		})
+		It("should set node.roles to [] for coordinator-only nodes (OpenSearch 3.0+)", func() {
+			clusterObject := ClusterDescWithVersion("3.0.0")
+			nodePool := opsterv1.NodePool{
+				Component: "coordinators",
+				Roles:     []string{},
+			}
+			result := NewSTSForNodePool("foobar", &clusterObject, nodePool, "foobar", nil, nil, nil)
+			Expect(result.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{
+				Name:  "node.roles",
+				Value: "[]",
+			}))
+		})
 		It("should have annotations added to node", func() {
 			clusterObject := ClusterDescWithVersion("1.3.0")
 			nodePool := opsterv1.NodePool{


### PR DESCRIPTION
### Description
OpenSearch 3.0 allows setting node.roles to `[]` to create coordinator nodes. https://github.com/opensearch-project/OpenSearch/pull/10625

In the CRD, `roles` can now be assigned an empty array in yaml, which will result in the created nodes having no roles assigned.

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-k8s-operator/issues/1023

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [x] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [x] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
