### PR TITLE
Use higher cpu limit for operator

### DIFF
--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -50,9 +50,9 @@ The following table lists the configurable parameters of the Helm chart.
 | `priorityClassName` | string | `""` |  |
 | `manager.securityContext.allowPrivilegeEscalation` | bool | `false` |  |
 | `manager.extraEnv` | list | `[]` |  |
-| `manager.resources.limits.cpu` | string | `"200m"` |  |
+| `manager.resources.limits.cpu` | string | `"1000m"` |  |
 | `manager.resources.limits.memory` | string | `"500Mi"` |  |
-| `manager.resources.requests.cpu` | string | `"100m"` |  |
+| `manager.resources.requests.cpu` | string | `"200m"` |  |
 | `manager.resources.requests.memory` | string | `"350Mi"` |  |
 | `manager.livenessProbe.failureThreshold` | int | `3` |  |
 | `manager.livenessProbe.httpGet.path` | string | `"/healthz"` |  |

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -14,10 +14,10 @@ manager:
   extraEnv: []
   resources:
     limits:
-      cpu: 200m
+      cpu: 1000m
       memory: 500Mi
     requests:
-      cpu: 100m
+      cpu: 200m
       memory: 350Mi
 
   livenessProbe:


### PR DESCRIPTION
### Description
Increase operator CPU request & limit to 1000 and 200 milli vCPU, instead of 200 and 100.

The intent is to ensure key generation happens in a reasonable timeframe even if the nodes the operator is on are quite small. The operator normally uses very little CPU, but key generation is CPU bound.

I looked around at some other popular operators and I don't think this is unreasonable. I also tested quite a lot of other ways to make the operator faster, especially on start, and this is by far the easiest most effective tweak, I think.

### Issues Resolved
Partially adddresses #1163 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
n/a

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
