### PR TITLE
fix: make security update job fail when retry attempts over

### DIFF
--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -37,15 +37,21 @@ echo 'Waiting to connect to the cluster'; sleep 20;
 done;`
 
 	ApplyAllYmlCmdTmpl = `count=0;
-until $ADMIN -cacert %s -cert %s -key %s -cd %s -icl -nhnv -h %s -p %v || (( count++ >= 20 ));
-do
-sleep 20;
+until $ADMIN -cacert %s -cert %s -key %s -cd %s -icl -nhnv -h %s -p %v; do
+  if (( count++ >= 20 )); then
+    echo "Failed to apply securityconfig after 20 attempts";
+    exit 1;
+  fi;
+  sleep 20;
 done;`
 
 	ApplySingleYmlCmdTmpl = `count=0;
-until $ADMIN -cacert %s -cert %s -key %s -f %s -t %s -icl -nhnv -h %s -p %v || (( count++ >= 20 ));
-do
-sleep 20;
+until $ADMIN -cacert %s -cert %s -key %s -f %s -t %s -icl -nhnv -h %s -p %v; do
+  if (( count++ >= 20 )); then
+    echo "Failed to apply securityconfig after 20 attempts";
+    exit 1;
+  fi;
+  sleep 20;
 done;`
 )
 

--- a/opensearch-operator/pkg/reconcilers/securityconfig_test.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig_test.go
@@ -290,9 +290,12 @@ until curl -k --silent https://no-securityconfig-tls-configured.no-securityconfi
 do
 echo 'Waiting to connect to the cluster'; sleep 20;
 done;count=0;
-until $ADMIN -cacert /certs/ca.crt -cert /certs/tls.crt -key /certs/tls.key -cd /usr/share/opensearch/config/opensearch-security -icl -nhnv -h no-securityconfig-tls-configured.no-securityconfig-tls-configured.svc.cluster.local -p 9200 || (( count++ >= 20 ));
-do
-sleep 20;
+until $ADMIN -cacert /certs/ca.crt -cert /certs/tls.crt -key /certs/tls.key -cd /usr/share/opensearch/config/opensearch-security -icl -nhnv -h no-securityconfig-tls-configured.no-securityconfig-tls-configured.svc.cluster.local -p 9200; do
+  if (( count++ >= 20 )); then
+    echo "Failed to apply securityconfig after 20 attempts";
+    exit 1;
+  fi;
+  sleep 20;
 done;`
 
 			Expect(createdJob.Spec.Template.Spec.Containers[0].Args[0]).To(Equal(cmdArg))


### PR DESCRIPTION
### Description
fix https://github.com/opensearch-project/opensearch-k8s-operator/issues/1202
### Issues Resolved
#1202

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
