### PR TITLE
fix: resolve version mismatch deadlock during rolling upgrades

### DIFF
--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchactiongroups.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchactiongroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: opensearchactiongroups.opensearch.opster.io
 spec:
   group: opensearch.opster.io

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: opensearchclusters.opensearch.opster.io
 spec:
   group: opensearch.opster.io

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchcomponenttemplates.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchcomponenttemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: opensearchcomponenttemplates.opensearch.opster.io
 spec:
   group: opensearch.opster.io

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchindextemplates.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchindextemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: opensearchindextemplates.opensearch.opster.io
 spec:
   group: opensearch.opster.io

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchismpolicies.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchismpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: opensearchismpolicies.opensearch.opster.io
 spec:
   group: opensearch.opster.io

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchroles.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchroles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: opensearchroles.opensearch.opster.io
 spec:
   group: opensearch.opster.io

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchsnapshotpolicies.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchsnapshotpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: opensearchsnapshotpolicies.opensearch.opster.io
 spec:
   group: opensearch.opster.io

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchtenants.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchtenants.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: opensearchtenants.opensearch.opster.io
 spec:
   group: opensearch.opster.io

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchuserrolebindings.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchuserrolebindings.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: opensearchuserrolebindings.opensearch.opster.io
 spec:
   group: opensearch.opster.io

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchusers.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchusers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: opensearchusers.opensearch.opster.io
 spec:
   group: opensearch.opster.io

--- a/opensearch-operator/config/rbac/role.yaml
+++ b/opensearch-operator/config/rbac/role.yaml
@@ -5,31 +5,6 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - apps
-  resources:
-  - deployments
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - batch
-  resources:
-  - jobs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - ""
   resources:
   - configmaps
@@ -54,6 +29,31 @@ rules:
   - create
   - patch
   - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:

--- a/opensearch-operator/opensearch-gateway/responses/AllocationExplainResponse.go
+++ b/opensearch-operator/opensearch-gateway/responses/AllocationExplainResponse.go
@@ -1,0 +1,36 @@
+package responses
+
+// AllocationExplainResponse represents the response from _cluster/allocation/explain API
+type AllocationExplainResponse struct {
+	Index            string                 `json:"index"`
+	Shard            int                    `json:"shard"`
+	Primary          bool                   `json:"primary"`
+	CurrentState     string                 `json:"current_state"`
+	CurrentNode      *AllocationExplainNode `json:"current_node,omitempty"`
+	UnassignedInfo   *UnassignedInfo        `json:"unassigned_info,omitempty"`
+	CanAllocate      string                 `json:"can_allocate"`
+	AllocateDecision *AllocateDecision      `json:"allocate_decision,omitempty"`
+}
+
+// AllocationExplainNode represents a node in the allocation explain response
+type AllocationExplainNode struct {
+	ID               string            `json:"id"`
+	Name             string            `json:"name"`
+	TransportAddress string            `json:"transport_address"`
+	Attributes       map[string]string `json:"attributes,omitempty"`
+}
+
+// UnassignedInfo contains information about why a shard is unassigned
+type UnassignedInfo struct {
+	Reason               string `json:"reason"`
+	At                   string `json:"at"`
+	Details              string `json:"details,omitempty"`
+	LastAllocationStatus string `json:"last_allocation_status,omitempty"`
+}
+
+// AllocateDecision contains the decision and explanation for allocation
+type AllocateDecision struct {
+	Decider     string `json:"decider"`
+	Decision    string `json:"decision"`
+	Explanation string `json:"explanation"`
+}


### PR DESCRIPTION
### Description
During rolling upgrades, when a replica shard resides on an old-version node while its primary shard is on a new-version node, OpenSearch refuses to move the replica to another old-version node (version downgrade prevention). This causes the drain operation to stall indefinitely.

This commit does;
- add allocation explain API support to detect version mismatch deadlocks
- automatically detect stuck replica shards due to node_version decider
- temporarily reduce number_of_replicas to 0 for affected indices
- store original replica counts in cluster annotations
- restore replica counts after upgrade completes
- integrate deadlock detection and resolution into PreparePodForDelete

This ensures rolling upgrades can proceed without manual intervention when facing version mismatch deadlocks.

### Issues Resolved
fixes #1153

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
