### PR TITLE
test: add Ordered to integration test suites

### DIFF
--- a/opensearch-operator/controllers/cluster_test.go
+++ b/opensearch-operator/controllers/cluster_test.go
@@ -30,7 +30,7 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var _ = Describe("Cluster Reconciler", func() {
+var _ = Describe("Cluster Reconciler", Ordered, func() {
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
 		clusterName = "cluster-test-cluster"
@@ -391,8 +391,8 @@ var _ = Describe("Cluster Reconciler", func() {
 
 			// Update the opensearch object
 			OpensearchCluster.Spec.NodePools = OpensearchCluster.Spec.NodePools[:2]
-			OpensearchCluster.Spec.General.Version = "1.1.0"
-			OpensearchCluster.Spec.General.PluginsList[0] = "http://foo-plugin-1.1.0"
+			OpensearchCluster.Spec.General.Version = "3.3.0"
+			OpensearchCluster.Spec.General.PluginsList[0] = "http://foo-plugin-3.3.0"
 			Expect(k8sClient.Update(context.Background(), &OpensearchCluster)).Should(Succeed())
 
 			Eventually(func() bool {
@@ -403,7 +403,7 @@ var _ = Describe("Cluster Reconciler", func() {
 				}
 
 				return len(stsList.Items) == 2
-			})
+			}, timeout, interval).Should(BeTrue())
 		})
 		It("should update the node pool image version", func() {
 			for _, pool := range OpensearchCluster.Spec.NodePools {
@@ -413,7 +413,7 @@ var _ = Describe("Cluster Reconciler", func() {
 					if err != nil {
 						return false
 					}
-					return sts.Spec.Template.Spec.Containers[0].Image == "docker.io/opensearchproject/opensearch:1.1.0"
+					return sts.Spec.Template.Spec.Containers[0].Image == "docker.io/opensearchproject/opensearch:3.3.0"
 				}).Should(BeTrue())
 			}
 		})
@@ -446,7 +446,7 @@ var _ = Describe("Cluster Reconciler", func() {
 					}, sts); err != nil {
 					return false
 				}
-				return sts.Spec.Template.Spec.Containers[0].Image == "docker.io/opensearchproject/opensearch:1.1.0"
+				return sts.Spec.Template.Spec.Containers[0].Image == "docker.io/opensearchproject/opensearch:3.3.0"
 			}, timeout, interval).Should(BeTrue())
 		})
 		It("should update any plugin URLs", func() {
@@ -460,7 +460,7 @@ var _ = Describe("Cluster Reconciler", func() {
 					}, sts); err != nil {
 					return false
 				}
-				return ArrayElementContains(sts.Spec.Template.Spec.Containers[0].Command, "http://foo-plugin-1.1.0")
+				return ArrayElementContains(sts.Spec.Template.Spec.Containers[0].Command, "http://foo-plugin-3.3.0")
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
@@ -501,7 +501,7 @@ var _ = Describe("Cluster Reconciler", func() {
 				if err := k8sClient.Get(context.Background(), client.ObjectKeyFromObject(&OpensearchCluster), &OpensearchCluster); err != nil {
 					return false
 				}
-				return OpensearchCluster.Status.Version == "1.1.0"
+				return OpensearchCluster.Status.Version == "3.3.0"
 			}, timeout, interval)
 		})
 		It("should update all the node pools", func() {
@@ -519,7 +519,7 @@ var _ = Describe("Cluster Reconciler", func() {
 						}, sts); err != nil {
 							return false
 						}
-						return sts.Spec.Template.Spec.Containers[0].Image == "docker.io/opensearchproject/opensearch:1.1.0"
+						return sts.Spec.Template.Spec.Containers[0].Image == "docker.io/opensearchproject/opensearch:3.3.0"
 					}, timeout, interval).Should(BeTrue())
 				}(nodePool)
 			}

--- a/opensearch-operator/controllers/dashboard_test.go
+++ b/opensearch-operator/controllers/dashboard_test.go
@@ -3,9 +3,10 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
+
 	sts "k8s.io/api/apps/v1"
 	"k8s.io/utils/ptr"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -19,7 +20,7 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var _ = Describe("Dashboards Reconciler", func() {
+var _ = Describe("Dashboards Reconciler", Ordered, func() {
 
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (

--- a/opensearch-operator/controllers/scaler_test.go
+++ b/opensearch-operator/controllers/scaler_test.go
@@ -22,7 +22,7 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var _ = Describe("Scaler Reconciler", func() {
+var _ = Describe("Scaler Reconciler", Ordered, func() {
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
 		clusterName = "cluster-test-nodes"

--- a/opensearch-operator/controllers/tls_test.go
+++ b/opensearch-operator/controllers/tls_test.go
@@ -20,7 +20,7 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var _ = Describe("TLS Reconciler", func() {
+var _ = Describe("TLS Reconciler", Ordered, func() {
 	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
 		clusterName = "cluster-test-tls"


### PR DESCRIPTION
### Description
add Ordered decorator to top-level Describe blocks in all integration test files to guarantee test execution order. This prevents flaky failures when tests have sequential dependencies on k8s resources.

### Issues Resolved
fix #1204

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
