### PR TITLE
upgrade linter to 2.7.2

### DIFF
--- a/.github/workflows/go-linting.yaml
+++ b/.github/workflows/go-linting.yaml
@@ -16,6 +16,5 @@ jobs:
         uses: golangci/golangci-lint-action@v8
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v2.1
+          version: v2.7
           working-directory: opensearch-operator
-          args: --timeout=6m --skip-dirs="(^|/)responses($|/)" -v

--- a/opensearch-operator/.golangci.yml
+++ b/opensearch-operator/.golangci.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+run:
+  timeout: 6m
+
+linters:
+  exclusions:
+    paths:
+      - opensearch-gateway/responses
+
+formatters:
+  exclusions:
+    paths:
+      - opensearch-gateway/responses

--- a/opensearch-operator/Makefile
+++ b/opensearch-operator/Makefile
@@ -59,7 +59,7 @@ fmt: ## Run go fmt against code.
 
 .PHONY: lint
 lint:
-	docker run --rm --volume="${PROJECT_PATH}:/go/src/opensearch-operator" -w /go/src/opensearch-operator golangci/golangci-lint:v1.57-alpine golangci-lint run -E gofmt --timeout=3m --exclude-dirs=opensearch-gateway/responses
+	docker run --rm --volume="${PROJECT_PATH}:/go/src/opensearch-operator" -w /go/src/opensearch-operator golangci/golangci-lint:v2.7-alpine golangci-lint run
 
 .PHONY: vet
 vet: ## Run go vet against code.


### PR DESCRIPTION
### Description
There were a lot of lint errors caused by the linter being too old.

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
