### PR TITLE
feat: automate CRD documentation generation

### DIFF
--- a/.github/workflows/crd-docs.yaml
+++ b/.github/workflows/crd-docs.yaml
@@ -1,0 +1,30 @@
+name: CRD Docs
+on:
+  pull_request:
+    paths:
+      - 'opensearch-operator/api/**'
+      - 'docs/designs/crd.md'
+      - 'docs/designs/crd-ref-docs-config.yaml'
+      - 'opensearch-operator/Makefile'
+
+jobs:
+  crd-docs:
+    name: crd docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.work'
+          cache: false
+      - name: Generate CRD docs
+        working-directory: ./opensearch-operator
+        run: |
+          make docs
+      - name: Check if docs are up to date
+        run: |
+          if ! git diff --exit-code --quiet docs/designs/crd.md; then
+            echo "CRD docs are out of date. Please run 'make docs' in the opensearch-operator directory and commit the changes."
+            exit 1
+          fi

--- a/docs/designs/crd-ref-docs-config.yaml
+++ b/docs/designs/crd-ref-docs-config.yaml
@@ -1,0 +1,25 @@
+processor:
+  # RE2 regular expressions describing types that should be excluded from the generated documentation.
+  ignoreTypes:
+    - ".*List$"
+    - ".*Status$"
+  # RE2 regular expressions describing type fields that should be excluded from the generated documentation.
+  ignoreFields:
+    - "status$"
+    - "TypeMeta$"
+    - "ObjectMeta$"
+
+render:
+  # Version of Kubernetes to use when generating links to Kubernetes API documentation.
+  kubernetesVersion: 1.28
+  # Generate better links for known types
+  knownTypes:
+    - name: ResourceRequirements
+      package: k8s.io/api/core/v1
+      link: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core
+    - name: PodSecurityContext
+      package: k8s.io/api/core/v1
+      link: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core
+    - name: SecurityContext
+      package: k8s.io/api/core/v1
+      link: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core

--- a/docs/designs/crd.md
+++ b/docs/designs/crd.md
@@ -1,1016 +1,1771 @@
-# Operator Custom Resource Reference Guide
+# API Reference
 
-Custom resources are extensions of the Kubernetes API.
-
-A resource is an endpoint in the Kubernetes API that stores a collection of API objects of a certain kind; for example, the built-in pods resource contains a collection of Pod objects.
-A [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) is an extension of the Kubernetes API, many core Kubernetes functions are now built using custom resources, making Kubernetes more modular.
-Cluster admins can update custom resources independently of the cluster itself. Once a custom resource is installed, users can create and access its objects using kubectl, just as they do for built-in resources like Pods.
-
-The CustomResourceDefinition API resource allows you to define custom resources. Defining a CRD object creates a new custom resource with a name and schema that you specify. The Kubernetes API serves and handles the storage of your custom resource. Every resource is build from `KGV` that stands for Group Version Resource and this is what drives the Kubernetes API Server structure.
-The `OpensearchCLuster` CRD is representing an Opensearch cluster.
+## Packages
+- [opensearch.opster.io/v1](#opensearchopsteriov1)
 
 
-Our CRD is Defined by kind: `OpenSearchCluster`,group: `opensearch.opster.io` and version `v1`.
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-      <td><b>apiVersion</b></td>
-      <td>string</td>
-      <td>opensearch.opster.io/v1</td>
-      <td>true</td>
-      </tr>
-      <tr>
-      <td><b>kind</b></td>
-      <td>string</td>
-      <td>OpenSearchCluster</td>
-      <td>true</td>
-      </tr>
-      <tr>
-      <td><b>metadata</b></td>
-      <td>object</td>
-      <td>Refer to the Kubernetes API documentation for the fields of the `metadata` field.</td>
-      <td>true</td>
-      </tr><tr>
-        <td><b>spec</b></td>
-        <td>object</td>
-        <td>ClusterSpec defines the desired state of OpenSearchSpec</td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>status</b></td>
-        <td>object</td>
-        <td>OpensearchClusterStatus defines the observed state of ClusterStatus. include ComponentsStatus that saves and share necessary state of the operator components.  </td>
-        <td>true</td>
-      </tr></tbody>
-</table>
-<h3 id="OpensearchClusterSPec">
-  OpensearchCluster.spec
-</h3>
+## opensearch.opster.io/v1
+
+Package v1 contains API Schema definitions for the opster v1 API group
+
+### Resource Types
+- [OpenSearchCluster](#opensearchcluster)
+- [OpenSearchISMPolicy](#opensearchismpolicy)
+- [OpensearchActionGroup](#opensearchactiongroup)
+- [OpensearchComponentTemplate](#opensearchcomponenttemplate)
+- [OpensearchIndexTemplate](#opensearchindextemplate)
+- [OpensearchRole](#opensearchrole)
+- [OpensearchSnapshotPolicy](#opensearchsnapshotpolicy)
+- [OpensearchTenant](#opensearchtenant)
+- [OpensearchUser](#opensearchuser)
+- [OpensearchUserRoleBinding](#opensearchuserrolebinding)
 
 
 
-ClusterSpec defines the desired state of OpensearchCluster
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>general</b></td>
-        <td>object</td>
-        <td>Opensearch general configuration</td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>Bootstrap</b></td>
-        <td>object</td>
-        <td>Bootstrap pod configuration</td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>Dashboards</b></td>
-        <td>object</td>
-        <td>Opensearch-dashboards configuration</td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>confMgmt</b></td>
-        <td>object</td>
-        <td>Config object to enable additional OpensearchOperator features/components</td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>security</b></td>
-        <td>object</td>
-        <td>Defined security reconciler configuration</td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>nodePools</b></td>
-        <td>[]object</td>
-        <td>List of objects that define the different nodePools in an OpensearchCluster. Each nodePool represents a group of nodes with the same opensearch roles and resources. Each nodePool is deployed as a Kubernetes StatefulSet. Together they form the opensearch cluster.</td>
-        <td>true</td>
-      </tr><tr>
-        <td><b>monitoring</b></td>
-        <td>object</td>
-        <td>monitoring configuration in an OpensearchCluster</td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>initHelper</b></td>
-        <td>object</td>
-        <td>InitHelper image configuration</td>
-        <td>false</td>
-      </tr>
-</table>
+#### Action
 
 
 
-<h3 id="GeneralConfig">
-  GeneralConfig
-</h3>
-
-GeneralConfig defines global Opensearch cluster configuration
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-            <th>default</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>httpPort</b></td>
-        <td>int32</td>
-        <td>http exposure port</td>
-        <td>false</td>
-        <td>9200</td>
-      </tr><tr>
-        <td><b>vendor</b></td>
-        <td>string</td>
-        <td>Vendor distribution to use for the cluster, currently only opensearch is supported</td>
-        <td>false</td>
-        <td>opensearch</td>
-      </tr><tr>
-        <td><b>command</b></td>
-        <td>string</td>
-        <td>Specify command in case you want to override the default command, useful if you have a custom image.</td>
-        <td>false</td>
-        <td>./opensearch-docker-entrypoint.sh</td>
-      </tr><tr>
-        <td><b>version</b></td>
-        <td>string</td>
-        <td>Version of opensearch to deploy</td>
-        <td>false</td>
-        <td>latest</td>
-      </tr><tr>
-        <td><b>ServiceAccount</b></td>
-        <td>string</td>
-        <td>k8s service account name</td>
-        <td>false</td>
-        <td>cluster name</td>
-      </tr><tr>
-        <td><b>ServiceName</b></td>
-        <td>string</td>
-        <td>Name to use for the k8s service to expose the cluster internally</td>
-        <td>false</td>
-        <td>cluster name</td>
-      </tr><tr>
-        <td><b>SetVMMaxMapCount</b></td>
-        <td>bool</td>
-        <td>will add VMmaxMapCount</td>
-        <td>true</td>
-        <td></td>
-      </tr><tr>
-        <td><b>additionalConfig</b></td>
-        <td>map[string]string</td>
-        <td>Extra items to add to opensearch.yml. These settings are added to a shared configmap that is mounted to all node pools. Settings must be provided as a map of strings (use flat form). If a nodepool has its own additionalConfig, it will be merged with this (nodepool settings override general settings).</td>
-        <td>false</td>
-        <td>{}</td>
-      </tr><tr>
-        <td><b>annotations</b></td>
-        <td>map[string]string</td>
-        <td>Adds support for annotations in services</td>
-        <td>false</td>
-        <td></td>
-      </tr><tr>
-        <td><b>labels</b></td>
-        <td>map[string]string</td>
-        <td>add user defined labels to nodePool</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>env</b></td>
-        <td>[]corev1.Env</td>
-        <td>add user defined environment variables to nodePool</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>DefaultRepo</b></td>
-        <td>string</td>
-        <td>Default image repository to use</td>
-        <td></td>
-        <td></td>
-      </tr><tr>
-        <td><b>keystore</b></td>
-        <td>[]opsterv1.KeystoreValue</td>
-        <td>List of objects that define secret values that will populate the opensearch keystore.</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>pluginsList</b></td>
-        <td>[]string</td>
-        <td>List of plugins that should be installed for OpenSearch at startup.</td>
-        <td>false</td>
-        <td> [] </td>
-      </tr><tr>
-        <td><b>podSecurityContext</b></td>
-        <td>*corev1.PodSecurityContext</td>
-        <td>Set the security context for the cluster pods.</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>securityContext</b></td>
-        <td>*corev1.SecurityContext</td>
-        <td>Set the security context for the cluster pods' containers.</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>snapshotRepositories</b></td>
-        <td>[]SnapshotRepoConfig</td>
-        <td>Snapshot Repo settings</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>additionalVolumes</b></td>
-        <td>[]object</td>
-        <td>List of additional volume mounts</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>hostAliases</b></td>
-        <td>[]corev1.HostAlias</td>
-        <td>Set the host aliases for the cluster pods.</td>
-        <td>false</td>
-        <td> - </td>
-      </tr>
-</table>
-
-<h3 id="GeneralConfig">
-  Bootstrap
-</h3>
-
-Bootstrap defines Opensearch bootstrap pod configuration
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-            <th>default</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>resources</b></td>
-        <td>corev1.ResourceRequirements</td>
-        <td>Define Opensearch bootstrap pod resources</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>diskSize</b></td>
-        <td>resource.Quantity</td>
-        <td> bootstrap pod data disk size </td>
-        <td>false</td>
-        <td> 1Gi </td>
-      </tr><tr>
-        <td><b>tolerations</b></td>
-        <td>[]corev1.Toleration</td>
-        <td>add toleration to bootstrap pod</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>nodeSelector</b></td>
-        <td>map[string]string</td>
-        <td>Add NodeSelector to bootstrap pod</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>affinity</b></td>
-        <td>corev1.Affinity</td>
-        <td>add affinity to bootstrap pod</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>jvm</b></td>
-        <td>string</td>
-        <td>JVM args. Use this to define heap size</td>
-        <td>false</td>
-        <td>-Xmx512M -Xms512M</td>
-      </tr><tr>
-        <td><b>env</b></td>
-        <td>[]corev1.Env</td>
-        <td>add user defined environment variables to bootstrap pod</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>keystore</b></td>
-        <td>[]opsterv1.KeystoreValue</td>
-        <td>List of objects that define secret values that will populate the opensearch keystore in the bootstrap pod</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>pluginsList</b></td>
-        <td>[]string</td>
-        <td>List of plugins that should be installed for OpenSearch at startup in the boostrap pod</td>
-        <td>false</td>
-        <td> [] </td>
-      </tr>
-       </tr><tr>
-        <td><b>initContainers</b></td>
-        <td>[]corev1.Container</td>
-        <td>List of init containers that should be added to the bootstrap pod</td>
-        <td>false</td>
-        <td> [] </td>
-      </tr><tr>
-        <td><b>hostAliases</b></td>
-        <td>[]corev1.HostAlias</td>
-        <td>Set the host aliases for the bootstrap pods.</td>
-        <td>false</td>
-        <td> - </td>
-      </tr>
-</table>
-
-<h3 id="GeneralConfig">
-  Dashboards
-</h3>
-
-Dashboards defines Opensearch-Dashboard configuration and deployment
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-            <th>default</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>enable</b></td>
-        <td>bool</td>
-        <td>if true, will deploy Opensearch-dashboards with the cluster</td>
-        <td>false</td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>replicas</b></td>
-        <td>int</td>
-        <td>defines Opensearch-Dashboards deployment's replicas</td>
-        <td>true</td>
-        <td>1</td>
-      </tr><tr>
-        <td><b>basePath</b></td>
-        <td>string</td>
-        <td>Defines the base path of opensearch dashboards (e.g. when using a reverse proxy)</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>resources</b></td>
-        <td>corev1.ResourceRequirements</td>
-        <td> Define Opensearch-Dashboard resources </td>
-        <td>false</td>
-        <td>Default Opensearch-dashboard resources</td>
-      </tr><tr>
-        <td><b>version</b></td>
-        <td>string</td>
-        <td>Opensearch-dashboards version</td>
-        <td>false</td>
-        <td>latest</td>
-      </tr><tr>
-        <td><b>additionalConfig</b></td>
-        <td>map[string]string</td>
-        <td>Added extra items to opensearch.yml</td>
-        <td>false</td>
-        <td>{}</td>
-      </tr><tr>
-        <td><b>Tls</b></td>
-        <td>DashboardsTlsConfig</td>
-        <td>defining Dashbaord TLS configuration</td>
-        <td>false</td>
-        <td>false</td>
-      </tr><tr>
-        <td><b>env</b></td>
-        <td>[]corev1.Env</td>
-        <td>add user defined environment variables to dashboard app</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>image</b></td>
-        <td>string</td>
-        <td>Define Opensearch-dashboards image</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>imagePullPolicy</b></td>
-        <td>corev1.PullPolicy</td>
-        <td>Define Opensearch-dashboards image pull policy</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>imagePullSecrets</b></td>
-        <td>corev1.LocalObjectReference</td>
-        <td>Define Opensearch-dashboards image pull secrets</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-      <td><b>tolerations</b></td>
-        <td>[]corev1.Toleration</td>
-        <td>Adds toleration to dashboard pods</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>nodeSelector</b></td>
-        <td>map[string]string</td>
-        <td>Adds NodeSelector to dashboard pods</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>affinity</b></td>
-        <td>corev1.Affinity</td>
-        <td>Adds affinity to dashboard pods</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>topologySpreadConstraints</b></td>
-        <td>[]corev1.TopologySpreadConstraint</td>
-        <td>add topology spread contraints to dashboard pods</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>labels</b></td>
-        <td>map[string]string</td>
-        <td>Adds labels to dashboard pods</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>annotations</b></td>
-        <td>map[string]string</td>
-        <td>Adds annotations to dashboard pods</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>service</b></td>
-        <td>opsterv1.DashboardsService</td>
-        <td>Customize dashboard service</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>pluginsList</b></td>
-        <td>[]string</td>
-        <td>List of plugins that should be installed for OpenSearch Dashboards at startup.</td>
-        <td>false</td>
-        <td> [] </td>
-      </tr><tr>
-        <td><b>podSecurityContext</b></td>
-        <td>*corev1.PodSecurityContext</td>
-        <td>Set the security context for the dashboards pods.</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>securityContext</b></td>
-        <td>*corev1.SecurityContext</td>
-        <td>Set the security context for the dashboards pods' containers.</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>hostAliases</b></td>
-        <td>[]corev1.HostAlias</td>
-        <td>Set the host aliases for the dashboards pods.</td>
-        <td>false</td>
-        <td> - </td>
-      </tr>
-    </tr>
-</table>
+Actions are the steps that the policy sequentially executes on entering a specific state.
 
 
-<h3 id="GeneralConfig">
-  NodePools
-</h3>
 
-Every NodePool is defining different Opensearch Nodes StatefulSet
+_Appears in:_
+- [State](#state)
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-            <th>default</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>component</b></td>
-        <td>string</td>
-        <td>statefulset name - will create $cluster-name-$component STS </td>
-        <td>true</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>replicas</b></td>
-        <td>int</td>
-        <td>defines NodePool deployment's replicas</td>
-        <td>true</td>
-        <td>1</td>
-      </tr><tr>
-        <td><b>diskSize</b></td>
-        <td>resource.Quantity</td>
-        <td> nodePool data disk size </td>
-        <td>true</td>
-        <td> 30Gi </td>
-      </tr><tr>
-        <td><b>NodeSelector</b></td>
-        <td>map[string]string</td>
-        <td>add NodeSelector to nodePool</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-      </tr><tr>
-        <td><b>Tls</b></td>
-        <td>DashboardsTlsConfig</td>
-        <td>defining Dashbaord TLS configuration</td>
-        <td>false</td>
-        <td>false</td>
-      </tr><tr>
-      </tr><tr>
-        <td><b>resources</b></td>
-        <td>corev1.ResourceRequirements</td>
-        <td> Define NodePool resources </td>
-        <td>false</td>
-        <td></td>
-      </tr><tr>
-      </tr><tr>
-        <td><b>roles</b></td>
-        <td>[]string </td>
-        <td>List of OpenSearch roles to assign to the nodePool</td>
-        <td>true</td>
-        <td> - </td>
-      </tr><tr>
-      </tr><tr>
-        <td><b>JVM</b></td>
-        <td>string</td>
-        <td>JVM args. Use this to define heap size (recommendation: Set to half of memory request)</td>
-        <td>false</td>
-        <td>Half of `resources.requests.memory` if jvm is not set. Fallback value is `-Xmx512M -Xms512M` if neither `resources.requests.memory` nor jvm are set.</td>
-      </tr><tr>
-      </tr><tr>
-        <td><b>Affinity</b></td>
-        <td>corev1.Affinity</td>
-        <td>add affinity to nodePool</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-      </tr><tr>
-        <td><b>Tolerations</b></td>
-        <td>[]corev1.Toleration</td>
-        <td>add toleration to nodePool</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-      </tr><tr>
-        <td><b>topologySpreadConstraints</b></td>
-        <td>[]corev1.TopologySpreadConstraint</td>
-        <td>add topology spread contraints to nodePool</td>
-        <td>false</td>
-        <td> - </td>
-      </tr>
-      </tr><tr>
-        <td><b>annotations</b></td>
-        <td>map[string]string</td>
-        <td>Adds annotations to node pods</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-      </tr><tr>
-        <td><b>priorityClassName</b></td>
-        <td>string</td>
-        <td>Adds a priority class to nodes</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-      </tr><tr>
-        <td><b>probes</b></td>
-        <td>ProbesConfig</td>
-        <td>Updates the probes timeouts and thresholds config</td>
-        <td>false</td>
-        <td>-</td>
-      </tr>
-       </tr><tr>
-        <td><b>initContainers</b></td>
-        <td>[]corev1.Container</td>
-        <td>List of init containers that should be added to the nodepool pods</td>
-        <td>false</td>
-        <td> [] </td>
-      </tr>
-       </tr><tr>
-        <td><b>additionalConfig</b></td>
-        <td>map[string]string</td>
-        <td>Extra items to add to opensearch.yml for this specific nodepool. These settings are merged with spec.general.additionalConfig (nodepool settings override general settings). When specified, this nodepool will get its own configmap with the merged configuration. Settings must be provided as a map of strings (use flat form).</td>
-        <td>false</td>
-        <td>{}</td>
-      </tr>
-</table>
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `alias` _[Alias](#alias)_ |  |  |  |
+| `allocation` _[Allocation](#allocation)_ | Allocate the index to a node with a specific attribute set |  |  |
+| `close` _[Close](#close)_ | Closes the managed index. |  |  |
+| `delete` _[Delete](#delete)_ | Deletes a managed index. |  |  |
+| `forceMerge` _[ForceMerge](#forcemerge)_ | Reduces the number of Lucene segments by merging the segments of individual shards. |  |  |
+| `indexPriority` _[IndexPriority](#indexpriority)_ | Set the priority for the index in a specific state. |  |  |
+| `notification` _[Notification](#notification)_ | Name          string        `json:"name,omitempty"` |  |  |
+| `open` _[Open](#open)_ | Opens a managed index. |  |  |
+| `readOnly` _[ReadOnly](#readonly)_ | Sets a managed index to be read only. |  |  |
+| `readWrite` _[ReadWrite](#readwrite)_ | Sets a managed index to be writeable. |  |  |
+| `replicaCount` _[ReplicaCount](#replicacount)_ | Sets the number of replicas to assign to an index. |  |  |
+| `retry` _[Retry](#retry)_ | The retry configuration for the action. |  |  |
+| `rollover` _[Rollover](#rollover)_ | Rolls an alias over to a new index when the managed index meets one of the rollover conditions. |  |  |
+| `rollup` _[Rollup](#rollup)_ | Periodically reduce data granularity by rolling up old data into summarized indexes. |  |  |
+| `shrink` _[Shrink](#shrink)_ | Allows you to reduce the number of primary shards in your indexes |  |  |
+| `snapshot` _[Snapshot](#snapshot)_ | Back up your cluster’s indexes and state |  |  |
+| `timeout` _string_ | The timeout period for the action. Accepts time units for minutes, hours, and days. |  |  |
 
-<h3 id="InitHelperConfig">
-  InitHelperConfig
-</h3>
 
-InitHelperConfig defines global Opensearch InitHelper image configuration
+#### AdditionalVolume
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-            <th>default</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>image</b></td>
-        <td>string</td>
-        <td>Define InitHelper image</td>
-        <td>false</td>
-        <td>docker.io/busybox</td>
-      </tr><tr>
-      </tr><tr>
-        <td><b>imagePullPolicy</b></td>
-        <td>corev1.PullPolicy</td>
-        <td>Define InitHelper image pull policy</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>resources</b></td>
-        <td>corev1.ResourceRequirements</td>
-        <td>Define initcontainer resorces</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>version</b></td>
-        <td>string</td>
-        <td>Version of InitHelper (busybox) image to deploy</td>
-        <td>false</td>
-        <td>1.27.2-buildx</td>
-      </tr>
-</table>
 
-<h3 id="GeneralConfig">
-  Monitoring
-</h3>
 
-Monitoring defines Opensearch monitoring configuration
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-            <th>default</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>enable</b></td>
-        <td>bool</td>
-        <td>Define if to enable monitoring for that cluster</td>
-        <td>true</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>labels</b></td>
-        <td>map[string]string</td>
-        <td>Add LabelsSelector to ServiceMonitor</td>
-        <td>false</td>
-        <td>-</td>
-      </tr><tr>
-        <td><b>monitoringUserSecret</b></td>
-        <td>[]string</td>
-        <td>Define from which user the monitor will run (Getting Secret name, the secret should contain 'username':'password' fileds).</td>
-        <td>false</td>
-        <td>admin</td>
-      </tr><tr>
-        <td><b>scrapeInterval</b></td>
-        <td>string</td>
-        <td>Define interval for scraping</td>
-        <td>false</td>
-        <td>30s</td>
-      </tr><tr>
-        <td><b>pluginURL</b></td>
-        <td>string</td>
-        <td>Define offline link to monitoring Plugin</td>
-        <td>false</td>
-        <td>https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/<YOUR_CLUSTER_VERSION>/prometheus-exporter-<YOUR_CLUSTER_VERSION>.zip/</td>
-      </tr><tr>
-        <td><b>tlsConfig</b></td>
-        <td>map[]</td>
-        <td>Tls Configuration <b>See <i>tlsConfig</i> below</b></td>
-        <td>false</td>
-        <td> - </td>
-     </tr>
-</table>
 
-<h3 id="GeneralConfig">
-  Monitoring.tlsConfig
-</h3>
 
-Monitoring TLS configuration options
 
-<table>
-  <thead>
-      <tr>
-          <th>Name</th>
-          <th>Type</th>
-          <th>Description</th>
-          <th>Required</th>
-          <th>default</th>
-      </tr>
-  </thead>
-  <tbody><tr>
-      <td><b>serverName</b></td>
-      <td>string</td>
-      <td>Used to verify the hostname for the targets</td>
-      <td>false</td>
-      <td></td>
-    </tr><tr>
-      <td><b>insecureSkipVerify</b></td>
-      <td>bool</td>
-      <td>Disable target certificate validation</td>
-      <td>false</td>
-      <td>false</td>
-    </tr>
-  </tbody>
-</table>
+_Appears in:_
+- [DashboardsConfig](#dashboardsconfig)
+- [GeneralConfig](#generalconfig)
 
-<h3 id="GeneralConfig">
-  Keystore
-</h3>
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name to use for the volume. Required. |  |  |
+| `path` _string_ | Path in the container to mount the volume at. Required. |  |  |
+| `subPath` _string_ | SubPath of the referenced volume to mount. |  |  |
+| `secret` _[SecretVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretvolumesource-v1-core)_ | Secret to use populate the volume |  |  |
+| `configMap` _[ConfigMapVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#configmapvolumesource-v1-core)_ | ConfigMap to use to populate the volume |  |  |
+| `emptyDir` _[EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#emptydirvolumesource-v1-core)_ | EmptyDir to use to populate the volume |  |  |
+| `csi` _[CSIVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#csivolumesource-v1-core)_ | CSI object to use to populate the volume |  |  |
+| `persistentVolumeClaim` _[PersistentVolumeClaimVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeclaimvolumesource-v1-core)_ | PersistentVolumeClaim object to use to populate the volume |  |  |
+| `projected` _[ProjectedVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#projectedvolumesource-v1-core)_ | Projected object to use to populate the volume |  |  |
+| `nfs` _[NFSVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#nfsvolumesource-v1-core)_ | NFS object to use to populate the volume |  |  |
+| `restartPods` _boolean_ | Whether to restart the pods on content change |  |  |
 
-Every Keystore Value defines a secret to pull secrets from.
-<table>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Type</th>
-      <th>Description</th>
-      <th>Required</th>
-      <th>default</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><b>secret</b></td>
-      <td>corev1.LocalObjectReference</td>
-      <td>Define secret that contains key value pairs</td>
-      <td>true</td>
-      <td>-</td>
-    </tr>
-    <tr>
-      <td><b>keyMappings</b></td>
-      <td>map</td>
-      <td>Define key mappings from secret to keystore entry. Example: "old: new" creates a keystore entry "new" with the value from the secret entry "old". When a map is provided, only the specified keys are loaded from the secret, so use "key: key" to load a key that should not be renamed.</td>
-      <td>false</td>
-      <td>-</td>
-    </tr>
-  </tbody>
-</table>
 
-<h3 id="AdditionalVolume">
-  AdditionalVolume
-</h3>
+#### Alias
 
-AdditionalVolume object define additional volume and volumeMount
-<table>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Type</th>
-      <th>Description</th>
-      <th>Required</th>
-      <th>default</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><b>name</b></td>
-      <td>string</td>
-      <td>Defines name for additional volume</td>
-      <td>true</td>
-      <td>-</td>
-    </tr><tr>
-      <td><b>path</b></td>
-      <td>string</td>
-      <td>Defines mount path for additional volume</td>
-      <td>true</td>
-      <td>-</td>
-    </tr><tr>
-      <td><b>subPath</b></td>
-      <td>string</td>
-      <td>key of the configmap or secret to use (mounts only that key at the given path), ignored for other volume types</td>
-      <td>false</td>
-      <td>-</td>
-    </tr><tr>
-      <td><b>restartPods</b></td>
-      <td>bool</td>
-      <td>Defines if pod should restar or not in case of change in VolumeSource object</td>
-      <td>false</td>
-      <td>false</td>
-    </tr><tr>
-      <td><b>emptyDir</b></td>
-      <td>corev1.EmptyDirVolumeSource</td>
-      <td>Defines emptyDir object to be mouted</td>
-      <td>false</td>
-      <td>-</td>
-    </tr><tr>
-      <td><b>configMap</b></td>
-      <td>corev1.ConfigMapVolumeSource</td>
-      <td>Defines ConfgMap object to be mounted</td>
-      <td>false</td>
-      <td>-</td>
-    </tr><tr>
-      <td><b>secret</b></td>
-      <td>corev1.SecretVolumeSource</td>
-      <td>Defines Secret object to be mounted</td>
-      <td>false</td>
-      <td>-</td>
-    </tr><tr>
-      <td><b>csi</b></td>
-      <td>corev1.CSIVolumeSource</td>
-      <td>Defines the CSI object to be mounted</td>
-      <td>false</td>
-      <td>-</td>
-    </tr>
-    </tr><tr>
-      <td><b>projected</b></td>
-      <td>corev1.ProjectedVolumeSource</td>
-      <td>Defines the Projected object to be mounted</td>
-      <td>false</td>
-      <td>-</td>
-    </tr>
-    </tr><tr>
-      <td><b>persistentVolumeClaim</b></td>
-      <td>corev1.PersistentVolumeClaimVolumeSource</td>
-      <td>Defines the PersistentVolumeClaim object to be mounted</td>
-      <td>false</td>
-      <td>-</td>
-    </tr>
-  </tbody>
-</table>
 
-<h3 id="ProbesConfig">
-  ProbesConfig
-</h3>
 
-ProbesConfig defines per nodepool probes thresholds and timeouts instead of defaults
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-            <th>default</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>liveness</b></td>
-        <td>ProbeConfig</td>
-        <td>Update liveness probe thresholds and timeouts</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>readiness</b></td>
-        <td>CommandProbeConfig</td>
-        <td>Update readiness probe thresholds, timeouts and command</td>
-        <td>false</td>
-        <td> - </td>
-      </tr><tr>
-        <td><b>startup</b></td>
-        <td>CommandProbeConfig</td>
-        <td>Update startup probe thresholds, timeouts and command</td>
-        <td>false</td>
-        <td> - </td>
-      </tr>
-</table>
 
-<h3 id="ProbeConfig">
-  ProbeConfig
-</h3>
 
-ProbeConfig defines per probe thresholds and timeouts instead of defaults
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-            <th>default</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>initialDelaySeconds</b></td>
-        <td>int32</td>
-        <td>Update probe's initialDelaySeconds</td>
-        <td>false</td>
-        <td> 10 </td>
-      </tr><tr>
-        <td><b>periodSeconds</b></td>
-        <td>int32</td>
-        <td>Update probe's periodSeconds</td>
-        <td>false</td>
-        <td> 20 </td>
-      </tr><tr>
-        <td><b>timeoutSeconds</b></td>
-        <td>int32</td>
-        <td>Update probe's timeoutSeconds</td>
-        <td>false</td>
-        <td> 5 </td>
-      </tr><tr>
-        <td><b>successThreshold</b></td>
-        <td>int32</td>
-        <td>Update probe's successThreshold</td>
-        <td>false</td>
-        <td> 1 </td>
-      </tr><tr>
-        <td><b>failureThreshold</b></td>
-        <td>int32</td>
-        <td>Update probe's failureThreshold</td>
-        <td>false</td>
-        <td> 10 </td>
-      </tr>
-</table>
+_Appears in:_
+- [Action](#action)
 
-<h3 id="CommandProbeConfig">
-  CommandProbeConfig
-</h3>
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `actions` _[AliasAction](#aliasaction) array_ | Allocate the index to a node with a specified attribute. |  |  |
 
-CommandProbeConfig defines per probe thresholds and timeouts instead of defaults
 
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Type</th>
-            <th>Description</th>
-            <th>Required</th>
-            <th>default</th>
-        </tr>
-    </thead>
-    <tbody><tr>
-        <td><b>initialDelaySeconds</b></td>
-        <td>int32</td>
-        <td>Update probe's initialDelaySeconds</td>
-        <td>false</td>
-        <td>
-          Startup: 10</br>
-          Readiness: 60
-        </td>
-      </tr><tr>
-        <td><b>periodSeconds</b></td>
-        <td>int32</td>
-        <td>Update probe's periodSeconds</td>
-        <td>false</td>
-        <td>
-          Startup: 30</br>
-          Readiness: 30
-        </td>
-      </tr><tr>
-        <td><b>timeoutSeconds</b></td>
-        <td>int32</td>
-        <td>Update probe's timeoutSeconds</td>
-        <td>false</td>
-        <td>
-          Startup: 30</br>
-          Readiness: 30
-        </td>
-      </tr><tr>
-        <td><b>successThreshold</b></td>
-        <td>int32</td>
-        <td>Update probe's successThreshold</td>
-        <td>false</td>
-        <td>
-          Startup: 1</br>
-          Readiness: 1
-        </td>
-      </tr><tr>
-        <td><b>failureThreshold</b></td>
-        <td>int32</td>
-        <td>Update probe's failureThreshold</td>
-        <td>false</td>
-        <td>
-          Startup: 10</br>
-          Readiness: 5</br>
-        </td>
-      </tr><tr>
-        <td><b>command</b></td>
-        <td>[]string</td>
-        <td>Custom probe command</td>
-        <td>false</td>
-        <td>
-          Startup: ["/bin/bash", "-c" , "curl -k -u \"$(cat /mnt/admin-credentials/username):$(cat /mnt/admin-credentials/password)\" --silent --fail 'https://localhost:9200'"]</br>
-          Readiness: ["/bin/bash", "-c" , "curl -k -u \"$(cat /mnt/admin-credentials/username):$(cat /mnt/admin-credentials/password)\" --silent --fail 'https://localhost:9200'"]</td>
-      </tr>
-    </tbody>
-</table>
+#### AliasAction
+
+
+
+
+
+
+
+_Appears in:_
+- [Alias](#alias)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `add` _[AliasDetails](#aliasdetails)_ |  |  |  |
+| `remove` _[AliasDetails](#aliasdetails)_ |  |  |  |
+
+
+
+
+#### Allocation
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `exclude` _string_ | Allocate the index to a node with a specified attribute. |  |  |
+| `include` _string_ | Allocate the index to a node with any of the specified attributes. |  |  |
+| `require` _string_ | Don’t allocate the index to a node with any of the specified attributes. |  |  |
+| `waitFor` _string_ | Wait for the policy to execute before allocating the index to a node with a specified attribute. |  |  |
+
+
+#### BootstrapConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [ClusterSpec](#clusterspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ |  |  |  |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#toleration-v1-core) array_ |  |  |  |
+| `nodeSelector` _object (keys:string, values:string)_ |  |  |  |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#affinity-v1-core)_ |  |  |  |
+| `jvm` _string_ |  |  |  |
+| `annotations` _object (keys:string, values:string)_ |  |  |  |
+| `labels` _object (keys:string, values:string)_ |  |  |  |
+| `pluginsList` _string array_ |  |  |  |
+| `keystore` _[KeystoreValue](#keystorevalue) array_ |  |  |  |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ |  |  |  |
+| `initContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#container-v1-core) array_ |  |  | Schemaless: \{\} <br /> |
+| `hostAliases` _[HostAlias](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#hostalias-v1-core) array_ |  |  |  |
+| `diskSize` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quantity-resource-api)_ |  |  |  |
+| `priorityClassName` _string_ |  |  |  |
+
+
+#### Close
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+
+
+#### ClusterSpec
+
+
+
+ClusterSpec defines the desired state of OpenSearchCluster
+
+
+
+_Appears in:_
+- [OpenSearchCluster](#opensearchcluster)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `general` _[GeneralConfig](#generalconfig)_ | INSERT ADDITIONAL SPEC FIELDS - desired state of cluster<br />Important: Run "make" to regenerate code after modifying this file |  |  |
+| `confMgmt` _[ConfMgmt](#confmgmt)_ |  |  |  |
+| `bootstrap` _[BootstrapConfig](#bootstrapconfig)_ |  |  |  |
+| `dashboards` _[DashboardsConfig](#dashboardsconfig)_ |  |  |  |
+| `security` _[Security](#security)_ |  |  |  |
+| `nodePools` _[NodePool](#nodepool) array_ |  |  |  |
+| `initHelper` _[InitHelperConfig](#inithelperconfig)_ |  |  |  |
+
+
+#### CommandProbeConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [ProbesConfig](#probesconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `initialDelaySeconds` _integer_ |  |  |  |
+| `periodSeconds` _integer_ |  |  |  |
+| `timeoutSeconds` _integer_ |  |  |  |
+| `successThreshold` _integer_ |  |  |  |
+| `failureThreshold` _integer_ |  |  |  |
+| `command` _string array_ |  |  |  |
+
+
+#### Condition
+
+
+
+
+
+
+
+_Appears in:_
+- [Transition](#transition)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `cron` _[Cron](#cron)_ | The cron job that triggers the transition if no other transition happens first. |  |  |
+| `minDocCount` _integer_ | The minimum document count of the index required to transition. |  |  |
+| `minIndexAge` _string_ | The minimum age of the index required to transition. |  |  |
+| `minRolloverAge` _string_ | The minimum age required after a rollover has occurred to transition to the next state. |  |  |
+| `minSize` _string_ | The minimum size of the total primary shard storage (not counting replicas) required to transition. |  |  |
+
+
+#### ConfMgmt
+
+
+
+ConfMgmt defines which additional services will be deployed
+
+
+
+_Appears in:_
+- [ClusterSpec](#clusterspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `autoScaler` _boolean_ |  |  |  |
+| `VerUpdate` _boolean_ |  |  |  |
+| `smartScaler` _boolean_ |  |  |  |
+
+
+#### Cron
+
+
+
+
+
+
+
+_Appears in:_
+- [Condition](#condition)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `cron` _[CronDetails](#crondetails)_ | A wrapper for the cron job that triggers the transition if no other transition happens first. This wrapper is here to adhere to the OpenSearch API. |  |  |
+
+
+#### CronDetails
+
+_Underlying type:_ _[struct{Expression string "json:\"expression\""; Timezone string "json:\"timezone\""}](#struct{expression-string-"json:\"expression\"";-timezone-string-"json:\"timezone\""})_
+
+
+
+
+
+_Appears in:_
+- [Cron](#cron)
+
+
+
+#### CronExpression
+
+
+
+
+
+
+
+_Appears in:_
+- [CronSchedule](#cronschedule)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `expression` _string_ |  |  |  |
+| `timezone` _string_ |  |  |  |
+
+
+#### CronSchedule
+
+
+
+
+
+
+
+_Appears in:_
+- [SnapshotCreation](#snapshotcreation)
+- [SnapshotDeletion](#snapshotdeletion)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `cron` _[CronExpression](#cronexpression)_ |  |  |  |
+
+
+#### DashboardsConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [ClusterSpec](#clusterspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enable` _boolean_ |  |  |  |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ |  |  |  |
+| `replicas` _integer_ |  | 1 |  |
+| `tls` _[DashboardsTlsConfig](#dashboardstlsconfig)_ |  |  |  |
+| `version` _string_ |  |  |  |
+| `basePath` _string_ | Base Path for Opensearch Clusters running behind a reverse proxy |  |  |
+| `additionalConfig` _object (keys:string, values:string)_ | Additional properties for opensearch_dashboards.yaml |  |  |
+| `opensearchCredentialsSecret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | Secret that contains fields username and password for dashboards to use to login to opensearch, must only be supplied if a custom securityconfig is provided |  |  |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ |  |  |  |
+| `additionalVolumes` _[AdditionalVolume](#additionalvolume) array_ |  |  |  |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#toleration-v1-core) array_ |  |  |  |
+| `nodeSelector` _object (keys:string, values:string)_ |  |  |  |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#affinity-v1-core)_ |  |  |  |
+| `labels` _object (keys:string, values:string)_ |  |  |  |
+| `annotations` _object (keys:string, values:string)_ |  |  |  |
+| `service` _[DashboardsServiceSpec](#dashboardsservicespec)_ |  |  |  |
+| `pluginsList` _string array_ |  |  |  |
+| `hostAliases` _[HostAlias](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#hostalias-v1-core) array_ |  |  |  |
+| `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#topologyspreadconstraint-v1-core) array_ |  |  |  |
+| `podSecurityContext` _[PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core)_ | Set security context for the dashboards pods |  |  |
+| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | Set security context for the dashboards pods' container |  |  |
+| `priorityClassName` _string_ |  |  |  |
+
+
+#### DashboardsServiceSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [DashboardsConfig](#dashboardsconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `type` _[ServiceType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#servicetype-v1-core)_ |  | ClusterIP | Enum: [ClusterIP NodePort LoadBalancer] <br /> |
+| `loadBalancerSourceRanges` _string array_ |  |  |  |
+| `labels` _object (keys:string, values:string)_ |  |  |  |
+
+
+#### DashboardsTlsConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [DashboardsConfig](#dashboardsconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enable` _boolean_ | Enable HTTPS for Dashboards |  |  |
+| `generate` _boolean_ | Generate certificate, if false secret must be provided |  |  |
+| `TlsCertificateConfig` _[TlsCertificateConfig](#tlscertificateconfig)_ | TLS certificate configuration |  |  |
+
+
+#### Delete
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+
+
+#### Destination
+
+
+
+
+
+
+
+_Appears in:_
+- [ErrorNotification](#errornotification)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `slack` _[DestinationURL](#destinationurl)_ |  |  |  |
+| `amazon` _[DestinationURL](#destinationurl)_ |  |  |  |
+| `chime` _[DestinationURL](#destinationurl)_ |  |  |  |
+| `customWebhook` _[DestinationURL](#destinationurl)_ |  |  |  |
+
+
+#### DestinationURL
+
+
+
+
+
+
+
+_Appears in:_
+- [Destination](#destination)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `url` _string_ |  |  |  |
+
+
+#### ErrorNotification
+
+
+
+
+
+
+
+_Appears in:_
+- [OpenSearchISMPolicySpec](#opensearchismpolicyspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `destination` _[Destination](#destination)_ | The destination URL. |  |  |
+| `channel` _string_ |  |  |  |
+| `messageTemplate` _[MessageTemplate](#messagetemplate)_ | The text of the message |  |  |
+
+
+#### ForceMerge
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `maxNumSegments` _integer_ | The number of segments to reduce the shard to. |  |  |
+
+
+#### GeneralConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [ClusterSpec](#clusterspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `httpPort` _integer_ |  | 9200 |  |
+| `vendor` _string_ |  |  | Enum: [Opensearch Op OP os opensearch] <br /> |
+| `version` _string_ |  |  |  |
+| `serviceAccount` _string_ |  |  |  |
+| `serviceName` _string_ |  |  |  |
+| `setVMMaxMapCount` _boolean_ |  | true |  |
+| `defaultRepo` _string_ |  |  |  |
+| `additionalConfig` _object (keys:string, values:string)_ | Extra items to add to the opensearch.yml |  |  |
+| `annotations` _object (keys:string, values:string)_ | Adds support for annotations in services |  |  |
+| `drainDataNodes` _boolean_ | Drain data nodes controls whether to drain data notes on rolling restart operations |  |  |
+| `pluginsList` _string array_ |  |  |  |
+| `command` _string_ |  |  |  |
+| `additionalVolumes` _[AdditionalVolume](#additionalvolume) array_ | Additional volumes to mount to all pods in the cluster |  |  |
+| `monitoring` _[MonitoringConfig](#monitoringconfig)_ |  |  |  |
+| `keystore` _[KeystoreValue](#keystorevalue) array_ | Populate opensearch keystore before startup |  |  |
+| `snapshotRepositories` _[SnapshotRepoConfig](#snapshotrepoconfig) array_ |  |  |  |
+| `podSecurityContext` _[PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core)_ | Set security context for the cluster pods |  |  |
+| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | Set security context for the cluster pods' container |  |  |
+| `hostAliases` _[HostAlias](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#hostalias-v1-core) array_ |  |  |  |
+| `operatorClusterURL` _string_ | Operator cluster URL. If set, the operator will use this URL to communicate with OpenSearch<br />instead of the default internal Kubernetes service DNS name. |  |  |
+
+
+#### ISMTemplate
+
+
+
+
+
+
+
+_Appears in:_
+- [OpenSearchISMPolicySpec](#opensearchismpolicyspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `indexPatterns` _string array_ | Index patterns on which this policy has to be applied |  |  |
+| `priority` _integer_ | Priority of the template, defaults to 0 |  |  |
+
+
+#### ImageSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [DashboardsConfig](#dashboardsconfig)
+- [GeneralConfig](#generalconfig)
+- [InitHelperConfig](#inithelperconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `image` _string_ |  |  |  |
+| `imagePullPolicy` _[PullPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#pullpolicy-v1-core)_ |  |  |  |
+| `imagePullSecrets` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core) array_ |  |  |  |
+
+
+#### IndexPermissionSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [OpensearchRoleSpec](#opensearchrolespec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `indexPatterns` _string array_ |  |  |  |
+| `dls` _string_ |  |  |  |
+| `fls` _string array_ |  |  |  |
+| `allowedActions` _string array_ |  |  |  |
+| `maskedFields` _string array_ |  |  |  |
+
+
+#### IndexPriority
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `priority` _integer_ | The priority for the index as soon as it enters a state. |  |  |
+
+
+#### InitHelperConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [ClusterSpec](#clusterspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ |  |  |  |
+| `version` _string_ |  |  |  |
+
+
+#### KeystoreValue
+
+
+
+
+
+
+
+_Appears in:_
+- [BootstrapConfig](#bootstrapconfig)
+- [GeneralConfig](#generalconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `secret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | Secret containing key value pairs |  |  |
+| `keyMappings` _object (keys:string, values:string)_ | Key mappings from secret to keystore keys |  |  |
+
+
+#### MessageTemplate
+
+
+
+
+
+
+
+_Appears in:_
+- [ErrorNotification](#errornotification)
+- [Notification](#notification)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `source` _string_ |  |  |  |
+
+
+#### MonitoringConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [GeneralConfig](#generalconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enable` _boolean_ |  |  |  |
+| `monitoringUserSecret` _string_ |  |  |  |
+| `scrapeInterval` _string_ |  |  |  |
+| `pluginUrl` _string_ |  |  |  |
+| `tlsConfig` _[MonitoringConfigTLS](#monitoringconfigtls)_ |  |  |  |
+| `labels` _object (keys:string, values:string)_ |  |  |  |
+
+
+#### MonitoringConfigTLS
+
+
+
+
+
+
+
+_Appears in:_
+- [MonitoringConfig](#monitoringconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `serverName` _string_ |  |  |  |
+| `insecureSkipVerify` _boolean_ |  |  |  |
+
+
+#### NodePool
+
+
+
+
+
+
+
+_Appears in:_
+- [ClusterSpec](#clusterspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `component` _string_ |  |  |  |
+| `replicas` _integer_ |  |  |  |
+| `diskSize` _[Quantity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#quantity-resource-api)_ |  |  |  |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ |  |  |  |
+| `jvm` _string_ |  |  |  |
+| `roles` _string array_ |  |  |  |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#toleration-v1-core) array_ |  |  |  |
+| `nodeSelector` _object (keys:string, values:string)_ |  |  |  |
+| `affinity` _[Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#affinity-v1-core)_ |  |  |  |
+| `topologySpreadConstraints` _[TopologySpreadConstraint](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#topologyspreadconstraint-v1-core) array_ |  |  |  |
+| `persistence` _[PersistenceConfig](#persistenceconfig)_ |  |  |  |
+| `labels` _object (keys:string, values:string)_ |  |  |  |
+| `annotations` _object (keys:string, values:string)_ |  |  |  |
+| `env` _[EnvVar](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#envvar-v1-core) array_ |  |  |  |
+| `priorityClassName` _string_ |  |  |  |
+| `pdb` _[PdbConfig](#pdbconfig)_ |  |  |  |
+| `probes` _[ProbesConfig](#probesconfig)_ |  |  |  |
+| `additionalConfig` _object (keys:string, values:string)_ | Extra items to add to the opensearch.yml for this nodepool (merged with general.additionalConfig) |  |  |
+| `sidecarContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#container-v1-core) array_ |  |  | Schemaless: \{\} <br /> |
+| `initContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#container-v1-core) array_ |  |  | Schemaless: \{\} <br /> |
+
+
+#### Notification
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `destination` _string_ |  |  |  |
+| `messageTemplate` _[MessageTemplate](#messagetemplate)_ |  |  |  |
+
+
+#### NotificationChannel
+
+
+
+
+
+
+
+_Appears in:_
+- [SnapshotNotification](#snapshotnotification)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `id` _string_ |  |  |  |
+
+
+#### NotificationConditions
+
+
+
+
+
+
+
+_Appears in:_
+- [SnapshotNotification](#snapshotnotification)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `creation` _boolean_ |  |  |  |
+| `deletion` _boolean_ |  |  |  |
+| `failure` _boolean_ |  |  |  |
+
+
+#### Open
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+
+
+#### OpenSearchCluster
+
+
+
+Es is the Schema for the es API
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `opensearch.opster.io/v1` | | |
+| `kind` _string_ | `OpenSearchCluster` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[ClusterSpec](#clusterspec)_ |  |  |  |
+
+
+
+
+#### OpenSearchISMPolicy
+
+
+
+
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `opensearch.opster.io/v1` | | |
+| `kind` _string_ | `OpenSearchISMPolicy` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[OpenSearchISMPolicySpec](#opensearchismpolicyspec)_ |  |  |  |
+
+
+#### OpenSearchISMPolicySpec
+
+
+
+ISMPolicySpec is the specification for the ISM policy for OS.
+
+
+
+_Appears in:_
+- [OpenSearchISMPolicy](#opensearchismpolicy)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `opensearchCluster` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ |  |  |  |
+| `defaultState` _string_ | The default starting state for each index that uses this policy. |  |  |
+| `description` _string_ | A human-readable description of the policy. |  |  |
+| `applyToExistingIndices` _boolean_ | If true, apply the policy to existing indices that match the index patterns in the ISM template. |  |  |
+| `errorNotification` _[ErrorNotification](#errornotification)_ |  |  |  |
+| `ismTemplate` _[ISMTemplate](#ismtemplate)_ | Specify an ISM template pattern that matches the index to apply the policy. |  |  |
+| `policyId` _string_ |  |  |  |
+| `states` _[State](#state) array_ | The states that you define in the policy. |  |  |
+
+
+#### OpensearchActionGroup
+
+
+
+OpensearchActionGroup is the Schema for the opensearchactiongroups API
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `opensearch.opster.io/v1` | | |
+| `kind` _string_ | `OpensearchActionGroup` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[OpensearchActionGroupSpec](#opensearchactiongroupspec)_ |  |  |  |
+
+
+#### OpensearchActionGroupSpec
+
+
+
+OpensearchActionGroupSpec defines the desired state of OpensearchActionGroup
+
+
+
+_Appears in:_
+- [OpensearchActionGroup](#opensearchactiongroup)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `opensearchCluster` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ |  |  |  |
+| `allowedActions` _string array_ |  |  |  |
+| `type` _string_ |  |  |  |
+| `description` _string_ |  |  |  |
+
+
+
+
+
+
+#### OpensearchComponentTemplate
+
+
+
+OpensearchComponentTemplate is the schema for the OpenSearch component templates API
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `opensearch.opster.io/v1` | | |
+| `kind` _string_ | `OpensearchComponentTemplate` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[OpensearchComponentTemplateSpec](#opensearchcomponenttemplatespec)_ |  |  |  |
+
+
+#### OpensearchComponentTemplateSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [OpensearchComponentTemplate](#opensearchcomponenttemplate)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `opensearchCluster` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ |  |  |  |
+| `name` _string_ | The name of the component template. Defaults to metadata.name |  |  |
+| `template` _[OpensearchIndexSpec](#opensearchindexspec)_ | The template that should be applied |  |  |
+| `version` _integer_ | Version number used to manage the component template externally |  |  |
+| `allowAutoCreate` _boolean_ | If true, then indices can be automatically created using this template |  |  |
+| `_meta` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Optional user metadata about the component template |  |  |
+
+
+
+
+#### OpensearchDatastreamSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [OpensearchIndexTemplateSpec](#opensearchindextemplatespec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `timestamp_field` _[OpensearchDatastreamTimestampFieldSpec](#opensearchdatastreamtimestampfieldspec)_ | TimestampField for dataStream |  |  |
+
+
+#### OpensearchDatastreamTimestampFieldSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [OpensearchDatastreamSpec](#opensearchdatastreamspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ | Name of the field that are used for the DataStream |  |  |
+
+
+
+
+#### OpensearchIndexAliasSpec
+
+
+
+Describes the specs of an index alias
+
+
+
+_Appears in:_
+- [OpensearchIndexSpec](#opensearchindexspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `index` _string_ | The name of the index that the alias points to. |  |  |
+| `alias` _string_ | The name of the alias. |  |  |
+| `filter` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Query used to limit documents the alias can access. |  |  |
+| `routing` _string_ | Value used to route indexing and search operations to a specific shard. |  |  |
+| `isWriteIndex` _boolean_ | If true, the index is the write index for the alias |  |  |
+
+
+#### OpensearchIndexSpec
+
+
+
+Describes the specs of an index
+
+
+
+_Appears in:_
+- [OpensearchComponentTemplateSpec](#opensearchcomponenttemplatespec)
+- [OpensearchIndexTemplateSpec](#opensearchindextemplatespec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `settings` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Configuration options for the index |  |  |
+| `mappings` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Mapping for fields in the index |  |  |
+| `aliases` _object (keys:string, values:[OpensearchIndexAliasSpec](#opensearchindexaliasspec))_ | Aliases to add |  |  |
+
+
+#### OpensearchIndexTemplate
+
+
+
+OpensearchIndexTemplate is the schema for the OpenSearch index templates API
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `opensearch.opster.io/v1` | | |
+| `kind` _string_ | `OpensearchIndexTemplate` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[OpensearchIndexTemplateSpec](#opensearchindextemplatespec)_ |  |  |  |
+
+
+#### OpensearchIndexTemplateSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [OpensearchIndexTemplate](#opensearchindextemplate)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `opensearchCluster` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ |  |  |  |
+| `name` _string_ | The name of the index template. Defaults to metadata.name |  |  |
+| `indexPatterns` _string array_ | Array of wildcard expressions used to match the names of indices during creation |  |  |
+| `dataStream` _[OpensearchDatastreamSpec](#opensearchdatastreamspec)_ | The dataStream config that should be applied |  |  |
+| `template` _[OpensearchIndexSpec](#opensearchindexspec)_ | The template that should be applied |  |  |
+| `composedOf` _string array_ | An ordered list of component template names. Component templates are merged in the order specified,<br />meaning that the last component template specified has the highest precedence |  |  |
+| `priority` _integer_ | Priority to determine index template precedence when a new data stream or index is created.<br />The index template with the highest priority is chosen |  |  |
+| `version` _integer_ | Version number used to manage the component template externally |  |  |
+| `_meta` _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#json-v1-apiextensions-k8s-io)_ | Optional user metadata about the index template |  |  |
+
+
+
+
+#### OpensearchRole
+
+
+
+OpensearchRole is the Schema for the opensearchroles API
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `opensearch.opster.io/v1` | | |
+| `kind` _string_ | `OpensearchRole` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[OpensearchRoleSpec](#opensearchrolespec)_ |  |  |  |
+
+
+#### OpensearchRoleSpec
+
+
+
+OpensearchRoleSpec defines the desired state of OpensearchRole
+
+
+
+_Appears in:_
+- [OpensearchRole](#opensearchrole)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `opensearchCluster` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ |  |  |  |
+| `clusterPermissions` _string array_ |  |  |  |
+| `indexPermissions` _[IndexPermissionSpec](#indexpermissionspec) array_ |  |  |  |
+| `tenantPermissions` _[TenantPermissionsSpec](#tenantpermissionsspec) array_ |  |  |  |
+
+
+
+
+#### OpensearchSnapshotPolicy
+
+
+
+OpensearchSnapshotPolicy is the Schema for the opensearchsnapshotpolicies API
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `opensearch.opster.io/v1` | | |
+| `kind` _string_ | `OpensearchSnapshotPolicy` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[OpensearchSnapshotPolicySpec](#opensearchsnapshotpolicyspec)_ |  |  |  |
+
+
+#### OpensearchSnapshotPolicySpec
+
+
+
+
+
+
+
+_Appears in:_
+- [OpensearchSnapshotPolicy](#opensearchsnapshotpolicy)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `opensearchCluster` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ |  |  |  |
+| `policyName` _string_ |  |  |  |
+| `description` _string_ |  |  |  |
+| `enabled` _boolean_ |  |  |  |
+| `snapshotConfig` _[SnapshotConfig](#snapshotconfig)_ |  |  |  |
+| `creation` _[SnapshotCreation](#snapshotcreation)_ |  |  |  |
+| `deletion` _[SnapshotDeletion](#snapshotdeletion)_ |  |  |  |
+| `notification` _[SnapshotNotification](#snapshotnotification)_ |  |  |  |
+
+
+
+
+#### OpensearchTenant
+
+
+
+OpensearchTenant is the Schema for the opensearchtenants API
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `opensearch.opster.io/v1` | | |
+| `kind` _string_ | `OpensearchTenant` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[OpensearchTenantSpec](#opensearchtenantspec)_ |  |  |  |
+
+
+#### OpensearchTenantSpec
+
+
+
+OpensearchTenantSpec defines the desired state of OpensearchTenant
+
+
+
+_Appears in:_
+- [OpensearchTenant](#opensearchtenant)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `opensearchCluster` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ |  |  |  |
+| `description` _string_ |  |  |  |
+
+
+
+
+#### OpensearchUser
+
+
+
+OpensearchUser is the Schema for the opensearchusers API
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `opensearch.opster.io/v1` | | |
+| `kind` _string_ | `OpensearchUser` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[OpensearchUserSpec](#opensearchuserspec)_ |  |  |  |
+
+
+#### OpensearchUserRoleBinding
+
+
+
+OpensearchUserRoleBinding is the Schema for the opensearchuserrolebindings API
+
+
+
+
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `apiVersion` _string_ | `opensearch.opster.io/v1` | | |
+| `kind` _string_ | `OpensearchUserRoleBinding` | | |
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+| `spec` _[OpensearchUserRoleBindingSpec](#opensearchuserrolebindingspec)_ |  |  |  |
+
+
+#### OpensearchUserRoleBindingSpec
+
+
+
+OpensearchUserRoleBindingSpec defines the desired state of OpensearchUserRoleBinding
+
+
+
+_Appears in:_
+- [OpensearchUserRoleBinding](#opensearchuserrolebinding)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `opensearchCluster` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ |  |  |  |
+| `roles` _string array_ |  |  |  |
+| `users` _string array_ |  |  |  |
+| `backendRoles` _string array_ |  |  |  |
+
+
+
+
+#### OpensearchUserSpec
+
+
+
+OpensearchUserSpec defines the desired state of OpensearchUser
+
+
+
+_Appears in:_
+- [OpensearchUser](#opensearchuser)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `opensearchCluster` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ |  |  |  |
+| `passwordFrom` _[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core)_ |  |  |  |
+| `opendistroSecurityRoles` _string array_ |  |  |  |
+| `backendRoles` _string array_ |  |  |  |
+| `attributes` _object (keys:string, values:string)_ |  |  |  |
+
+
+
+
+#### PVCSource
+
+
+
+
+
+
+
+_Appears in:_
+- [PersistenceSource](#persistencesource)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `storageClass` _string_ |  |  |  |
+| `accessModes` _[PersistentVolumeAccessMode](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#persistentvolumeaccessmode-v1-core) array_ |  |  |  |
+| `annotations` _object (keys:string, values:string)_ |  |  |  |
+| `labels` _object (keys:string, values:string)_ |  |  |  |
+
+
+#### PdbConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [NodePool](#nodepool)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enable` _boolean_ |  |  |  |
+| `minAvailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#intorstring-intstr-util)_ |  |  |  |
+| `maxUnavailable` _[IntOrString](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#intorstring-intstr-util)_ |  |  |  |
+
+
+#### PersistenceConfig
+
+
+
+PersistenceConfig defines options for data persistence
+
+
+
+_Appears in:_
+- [NodePool](#nodepool)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `PersistenceSource` _[PersistenceSource](#persistencesource)_ |  |  |  |
+
+
+#### PersistenceSource
+
+
+
+
+
+
+
+_Appears in:_
+- [PersistenceConfig](#persistenceconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `pvc` _[PVCSource](#pvcsource)_ |  |  |  |
+| `emptyDir` _[EmptyDirVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#emptydirvolumesource-v1-core)_ |  |  |  |
+| `hostPath` _[HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#hostpathvolumesource-v1-core)_ |  |  |  |
+
+
+#### ProbeConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [ProbesConfig](#probesconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `initialDelaySeconds` _integer_ |  |  |  |
+| `periodSeconds` _integer_ |  |  |  |
+| `timeoutSeconds` _integer_ |  |  |  |
+| `successThreshold` _integer_ |  |  |  |
+| `failureThreshold` _integer_ |  |  |  |
+
+
+#### ProbesConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [NodePool](#nodepool)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `liveness` _[ProbeConfig](#probeconfig)_ |  |  |  |
+| `readiness` _[CommandProbeConfig](#commandprobeconfig)_ |  |  |  |
+| `startup` _[CommandProbeConfig](#commandprobeconfig)_ |  |  |  |
+
+
+#### ReadOnly
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+
+
+#### ReadWrite
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+
+
+#### ReplicaCount
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `numberOfReplicas` _integer_ |  |  |  |
+
+
+#### Retry
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `backoff` _string_ | The backoff policy type to use when retrying. |  |  |
+| `count` _integer_ | The number of retry counts. |  |  |
+| `delay` _string_ | The time to wait between retries. |  |  |
+
+
+#### Rollover
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `minDocCount` _integer_ | The minimum number of documents required to roll over the index. |  |  |
+| `minIndexAge` _string_ | The minimum age required to roll over the index. |  |  |
+| `minPrimaryShardSize` _string_ | The minimum storage size of a single primary shard required to roll over the index. |  |  |
+| `minSize` _string_ | The minimum size of the total primary shard storage (not counting replicas) required to roll over the index. |  |  |
+
+
+#### Rollup
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+
+
+#### Security
+
+
+
+Security defines options for managing the opensearch-security plugin
+
+
+
+_Appears in:_
+- [ClusterSpec](#clusterspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `tls` _[TlsConfig](#tlsconfig)_ |  |  |  |
+| `config` _[SecurityConfig](#securityconfig)_ |  |  |  |
+
+
+#### SecurityConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [Security](#security)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `securityConfigSecret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | Optional secret that contains the different yml files of the opensearch-security config (config.yml, internal_users.yml, ...).<br />When omitted the operator seeds the cluster with its bundled defaults. |  |  |
+| `adminSecret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | TLS Secret that contains a client certificate (tls.key, tls.crt, ca.crt) with admin rights in the opensearch cluster. Must be set if http certificates are provided by user and not generated |  |  |
+| `adminCredentialsSecret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | Secret that contains fields username and password to be used by the operator to access the opensearch cluster for node draining. Must be set if custom securityconfig is provided. |  |  |
+| `updateJob` _[SecurityUpdateJobConfig](#securityupdatejobconfig)_ |  |  |  |
+
+
+#### SecurityUpdateJobConfig
+
+
+
+Specific configs for the SecurityConfig update job
+
+
+
+_Appears in:_
+- [SecurityConfig](#securityconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#resourcerequirements-v1-core)_ |  |  |  |
+| `priorityClassName` _string_ |  |  |  |
+| `labels` _object (keys:string, values:string)_ |  |  |  |
+
+
+#### Shrink
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `forceUnsafe` _boolean_ | If true, executes the shrink action even if there are no replicas. |  |  |
+| `maxShardSize` _string_ | The maximum size in bytes of a shard for the target index. |  |  |
+| `numNewShards` _integer_ | The maximum number of primary shards in the shrunken index. |  |  |
+| `percentageOfSourceShards` _integer_ | Percentage of the number of original primary shards to shrink. |  |  |
+| `targetIndexNameTemplate` _string_ | The name of the shrunken index. |  |  |
+
+
+#### Snapshot
+
+
+
+
+
+
+
+_Appears in:_
+- [Action](#action)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `repository` _string_ | The repository name that you register through the native snapshot API operations. |  |  |
+| `snapshot` _string_ | The name of the snapshot. |  |  |
+
+
+#### SnapshotConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [OpensearchSnapshotPolicySpec](#opensearchsnapshotpolicyspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `dateFormat` _string_ |  |  |  |
+| `dateFormatTimezone` _string_ |  |  |  |
+| `indices` _string_ |  |  |  |
+| `repository` _string_ |  |  |  |
+| `ignoreUnavailable` _boolean_ |  |  |  |
+| `includeGlobalState` _boolean_ |  |  |  |
+| `partial` _boolean_ |  |  |  |
+| `metadata` _object (keys:string, values:string)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
+
+
+#### SnapshotCreation
+
+
+
+
+
+
+
+_Appears in:_
+- [OpensearchSnapshotPolicySpec](#opensearchsnapshotpolicyspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `schedule` _[CronSchedule](#cronschedule)_ |  |  |  |
+| `timeLimit` _string_ |  |  |  |
+
+
+#### SnapshotDeleteCondition
+
+
+
+
+
+
+
+_Appears in:_
+- [SnapshotDeletion](#snapshotdeletion)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `maxCount` _integer_ |  |  |  |
+| `maxAge` _string_ |  |  |  |
+| `minCount` _integer_ |  |  |  |
+
+
+#### SnapshotDeletion
+
+
+
+
+
+
+
+_Appears in:_
+- [OpensearchSnapshotPolicySpec](#opensearchsnapshotpolicyspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `schedule` _[CronSchedule](#cronschedule)_ |  |  |  |
+| `timeLimit` _string_ |  |  |  |
+| `deleteCondition` _[SnapshotDeleteCondition](#snapshotdeletecondition)_ |  |  |  |
+
+
+#### SnapshotNotification
+
+
+
+
+
+
+
+_Appears in:_
+- [OpensearchSnapshotPolicySpec](#opensearchsnapshotpolicyspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `channel` _[NotificationChannel](#notificationchannel)_ |  |  |  |
+| `conditions` _[NotificationConditions](#notificationconditions)_ |  |  |  |
+
+
+#### SnapshotRepoConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [GeneralConfig](#generalconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `name` _string_ |  |  |  |
+| `type` _string_ |  |  |  |
+| `settings` _object (keys:string, values:string)_ |  |  |  |
+
+
+#### State
+
+
+
+
+
+
+
+_Appears in:_
+- [OpenSearchISMPolicySpec](#opensearchismpolicyspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `actions` _[Action](#action) array_ | The actions to execute after entering a state. |  |  |
+| `name` _string_ | The name of the state. |  |  |
+| `transitions` _[Transition](#transition) array_ | The next states and the conditions required to transition to those states. If no transitions exist, the policy assumes that it’s complete and can now stop managing the index |  |  |
+
+
+#### TenantPermissionsSpec
+
+
+
+
+
+
+
+_Appears in:_
+- [OpensearchRoleSpec](#opensearchrolespec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `tenantPatterns` _string array_ |  |  |  |
+| `allowedActions` _string array_ |  |  |  |
+
+
+#### TlsCertificateConfig
+
+
+
+
+
+
+
+_Appears in:_
+- [DashboardsTlsConfig](#dashboardstlsconfig)
+- [TlsConfigHttp](#tlsconfighttp)
+- [TlsConfigTransport](#tlsconfigtransport)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `secret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |  |  |
+| `caSecret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | Optional, secret that contains the ca certificate as ca.crt. If this and generate=true is set the existing CA cert from that secret is used to generate the node certs. In this case must contain ca.crt and ca.key fields |  |  |
+| `duration` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | Duration controls the validity period of generated certificates (e.g. "8760h", "720h"). | 8760h |  |
+| `enableHotReload` _boolean_ | Enable hot reloading of TLS certificates. When enabled, certificates are mounted as directories instead of using subPath, allowing Kubernetes to update certificate files when secrets are updated. |  |  |
+
+
+#### TlsConfig
+
+
+
+Configure tls usage for transport and http interface
+
+
+
+_Appears in:_
+- [Security](#security)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `transport` _[TlsConfigTransport](#tlsconfigtransport)_ |  |  |  |
+| `http` _[TlsConfigHttp](#tlsconfighttp)_ |  |  |  |
+
+
+#### TlsConfigHttp
+
+
+
+
+
+
+
+_Appears in:_
+- [TlsConfig](#tlsconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enabled` _boolean_ | enabled controls if TLS should be enabled for the HTTP layer.<br />If false: TLS is explicitly disabled for HTTP.<br />If not set (default): TLS is enabled if HTTP configuration is provided, or if security.tls is set.<br />If true: TLS is explicitly enabled. HTTP configuration must be provided. |  |  |
+| `generate` _boolean_ | If set to true the operator will generate a CA and certificates for the cluster to use, if false secrets with existing certificates must be supplied |  |  |
+| `customFQDN` _string_ | Custom FQDN to use for the HTTP certificate. If not set, the operator will use the default cluster DNS names. |  |  |
+| `rotateDaysBeforeExpiry` _integer_ | Automatically rotate certificates before they expire, set to -1 to disable | -1 |  |
+| `TlsCertificateConfig` _[TlsCertificateConfig](#tlscertificateconfig)_ |  |  |  |
+| `adminDn` _string array_ | DNs of certificates that should have admin access, mainly used for securityconfig updates via securityadmin.sh, only used when existing certificates are provided |  |  |
+
+
+#### TlsConfigTransport
+
+
+
+
+
+
+
+_Appears in:_
+- [TlsConfig](#tlsconfig)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `enabled` _boolean_ | enabled controls if TLS should be enabled for the transport layer.<br />If false: TLS is explicitly disabled for transport.<br />If not set (default): TLS is enabled if transport configuration is provided, or if security.tls is set.<br />If true: TLS is explicitly enabled. Transport configuration must be provided. |  |  |
+| `generate` _boolean_ | If set to true the operator will generate a CA and certificates for the cluster to use, if false secrets with existing certificates must be supplied |  |  |
+| `perNode` _boolean_ | Configure transport node certificate |  |  |
+| `rotateDaysBeforeExpiry` _integer_ | Automatically rotate certificates before they expire, set to -1 to disable | -1 |  |
+| `TlsCertificateConfig` _[TlsCertificateConfig](#tlscertificateconfig)_ |  |  |  |
+| `nodesDn` _string array_ | Allowed Certificate DNs for nodes, only used when existing certificates are provided |  |  |
+| `adminDn` _string array_ | Deprecated: DNs of certificates that should have admin access. This field is deprecated and will be removed in a future version.<br />For OpenSearch 2.0.0+, use security.tls.http.adminDn instead. |  |  |
+
+
+
+
+#### Transition
+
+
+
+
+
+
+
+_Appears in:_
+- [State](#state)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `conditions` _[Condition](#condition)_ | conditions for the transition. |  |  |
+| `stateName` _string_ | The name of the state to transition to if the conditions are met. |  |  |
+
+

--- a/opensearch-operator/Makefile
+++ b/opensearch-operator/Makefile
@@ -48,6 +48,24 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 generate: controller-gen helm-docs ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations and helm-docs.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+.PHONY: docs
+docs: crd-ref-docs manifests ## Generate CRD API reference documentation.
+	@echo "Generating CRD documentation..."
+	@mkdir -p ../docs/designs
+	@if [ -f ../docs/designs/crd-ref-docs-config.yaml ]; then \
+		$(CRD_REF_DOCS) \
+			--source-path=$(CURDIR)/api \
+			--config=../docs/designs/crd-ref-docs-config.yaml \
+			--renderer=markdown \
+			--output-path=../docs/designs/crd.md; \
+	else \
+		$(CRD_REF_DOCS) \
+			--source-path=$(CURDIR)/api \
+			--renderer=markdown \
+			--output-path=../docs/designs/crd.md; \
+	fi
+	@echo "CRD documentation generated at ../docs/designs/crd.md"
+
 .PHONY: helm-docs
 helm-docs: ${HELM_DOCS}
 	${HELM_DOCS} -s file -c ../charts/opensearch-operator
@@ -123,12 +141,14 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 MOCKERY ?= $(LOCALBIN)/mockery
 HELM_DOCS := $(LOCALBIN)/helm-docs
+CRD_REF_DOCS ?= $(LOCALBIN)/crd-ref-docs
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_TOOLS_VERSION ?= v0.19.0
 MOCKERY_VERSION ?= v2.52.2
 HELM_DOCS_VERSION ?= 1.14.2
+CRD_REF_DOCS_VERSION ?= v0.2.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize
@@ -156,3 +176,8 @@ helm-docs: $(HELM_DOCS) ## Download helm-docs locally if necessary.
 $(HELM_DOCS): $(LOCALBIN)
 	@curl -sL "https://github.com/norwoodj/helm-docs/releases/download/v$(HELM_DOCS_VERSION)/helm-docs_$(HELM_DOCS_VERSION)_$$(uname -s)_x86_64.tar.gz" | tar -xz -C $(LOCALBIN) helm-docs
 	@chmod +x $(HELM_DOCS)
+
+.PHONY: crd-ref-docs
+crd-ref-docs: $(CRD_REF_DOCS) ## Download crd-ref-docs locally if necessary.
+$(CRD_REF_DOCS): $(LOCALBIN)
+	test -s $(LOCALBIN)/crd-ref-docs || GOBIN=$(LOCALBIN) go install github.com/elastic/crd-ref-docs@$(CRD_REF_DOCS_VERSION)


### PR DESCRIPTION
### Description
Add automatic generation of CRD API reference documentation using crd-ref-docs tool, replacing manual maintenance of docs/designs/crd.md.
Previously, CRD documentation had to be manually updated whenever API types changed, which was tedious and often forgotten, resulting in outdated documentation.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
