### PR TITLE
feat: add PodManagementPolicy to NodePool

### DIFF
--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -6245,6 +6245,16 @@ spec:
                               type: string
                           type: object
                       type: object
+                    podManagementPolicy:
+                      description: |-
+                        PodManagementPolicy controls how pods are created during initial scale up,
+                        when replacing pods on nodes, or when scaling down.
+                        OrderedReady (default): pods are created in order and wait for previous pod to be Ready
+                        Parallel: all pods are created at once without waiting
+                      enum:
+                      - OrderedReady
+                      - Parallel
+                      type: string
                     priorityClassName:
                       type: string
                     probes:

--- a/docs/designs/crd.md
+++ b/docs/designs/crd.md
@@ -707,6 +707,7 @@ _Appears in:_
 | `additionalConfig` _object (keys:string, values:string)_ | Extra items to add to the opensearch.yml for this nodepool (merged with general.additionalConfig) |  |  |
 | `sidecarContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#container-v1-core) array_ |  |  | Schemaless: \{\} <br /> |
 | `initContainers` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#container-v1-core) array_ |  |  | Schemaless: \{\} <br /> |
+| `podManagementPolicy` _[PodManagementPolicyType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podmanagementpolicytype-v1-apps)_ | PodManagementPolicy controls how pods are created during initial scale up,<br />when replacing pods on nodes, or when scaling down.<br />OrderedReady (default): pods are created in order and wait for previous pod to be Ready<br />Parallel: all pods are created at once without waiting |  | Enum: [OrderedReady Parallel] <br /> |
 
 
 #### Notification

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -140,6 +141,12 @@ type NodePool struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Schemaless
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`
+	// PodManagementPolicy controls how pods are created during initial scale up,
+	// when replacing pods on nodes, or when scaling down.
+	// OrderedReady (default): pods are created in order and wait for previous pod to be Ready
+	// Parallel: all pods are created at once without waiting
+	// +kubebuilder:validation:Enum=OrderedReady;Parallel
+	PodManagementPolicy appsv1.PodManagementPolicyType `json:"podManagementPolicy,omitempty"`
 }
 
 // PersistenceConfig defines options for data persistence

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -6245,6 +6245,16 @@ spec:
                               type: string
                           type: object
                       type: object
+                    podManagementPolicy:
+                      description: |-
+                        PodManagementPolicy controls how pods are created during initial scale up,
+                        when replacing pods on nodes, or when scaling down.
+                        OrderedReady (default): pods are created in order and wait for previous pod to be Ready
+                        Parallel: all pods are created at once without waiting
+                      enum:
+                      - OrderedReady
+                      - Parallel
+                      type: string
                     priorityClassName:
                       type: string
                     probes:

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -519,6 +519,12 @@ func NewSTSForNodePool(
 		initContainers = append(initContainers, keystoreInitContainer)
 	}
 
+	// Determine PodManagementPolicy - default to OrderedReady if not specified
+	podManagementPolicy := appsv1.OrderedReadyPodManagement
+	if node.PodManagementPolicy != "" {
+		podManagementPolicy = node.PodManagementPolicy
+	}
+
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        cr.Name + "-" + node.Component,
@@ -531,7 +537,7 @@ func NewSTSForNodePool(
 			Selector: &metav1.LabelSelector{
 				MatchLabels: matchLabels,
 			},
-			PodManagementPolicy: appsv1.OrderedReadyPodManagement,
+			PodManagementPolicy: podManagementPolicy,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.OnDeleteStatefulSetStrategyType,
 			},


### PR DESCRIPTION
### Description
#### Summary
This PR adds the ability to configure PodManagementPolicy for each NodePool/component in OpenSearch clusters. This allows operators to choose between OrderedReady (default) and Parallel pod management strategies per component.

#### Motivation
In production environments with autoscaling enabled, the default OrderedReady policy can significantly slow down horizontal scaling. Each pod must wait for the previous one to become Ready before the next can be created, resulting in sequential scaling that takes ~4-5 minute per node.

#### Real-world impact:
With OrderedReady: Scaling from 5 to 15 data nodes takes ~40 minutes
With Parallel: The same scaling operation completes in ~4 minutes

#### This is critical for:
Autoscaling scenarios: When traffic spikes occur, hot nodes need to offload pressure quickly
Disaster recovery: Faster recovery when multiple pods fail simultaneously
Cost optimization: Reduce the window of degraded performance during scale-up events

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
