### PR TITLE
update golang to 1.24.11

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -4,7 +4,7 @@ This page provides information how to develop changes for the operator code. Ple
 
 ## Needed environment and tools
 
-The operator is developed in Go, as such you need a current Go toolkit (for Linux most distributions provide packages, otherwise get it from the [go homepage](https://go.dev/)). Please use version 1.24.4 as this version is used by the CI pipelines. You also need an editor/IDE, ideally with Go support. We recommend either [VS Code](https://code.visualstudio.com/) with the official Go extension or [GoLand](https://www.jetbrains.com/go/).
+The operator is developed in Go, as such you need a current Go toolkit (for Linux most distributions provide packages, otherwise get it from the [go homepage](https://go.dev/)). Please use version 1.24.11 as this version is used by the CI pipelines. You also need an editor/IDE, ideally with Go support. We recommend either [VS Code](https://code.visualstudio.com/) with the official Go extension or [GoLand](https://www.jetbrains.com/go/).
 
 Additional tools you will need:
 

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.24.4
+go 1.24.11
 
 use (
 	./opensearch-operator

--- a/opensearch-operator/Dockerfile
+++ b/opensearch-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.24.4 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24.11 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/opensearch-operator/functionaltests/go.mod
+++ b/opensearch-operator/functionaltests/go.mod
@@ -1,6 +1,6 @@
 module github.com/Opster/opensearch-k8s-operator/functionaltests
 
-go 1.24.4
+go 1.24.11
 
 require (
 	github.com/Opster/opensearch-k8s-operator/opensearch-operator v0.0.0-20250618201830-61fae951a751

--- a/opensearch-operator/functionaltests/operatortests/docs/integrity_test.md
+++ b/opensearch-operator/functionaltests/operatortests/docs/integrity_test.md
@@ -52,7 +52,7 @@ The test creates realistic test data across three indices:
 
 - k3d installed and configured
 - Helm installed
-- Go 1.24.4 or later
+- Go 1.24.11 or later
 - Docker (for building operator image)
 
 ### Local Execution
@@ -84,7 +84,7 @@ go test ./operatortests -ginkgo.focus="DataIntegrity" -timeout 60m
 
 ### CI/CD Execution
 
-The test will run automatically as part of the functional tests workflow in GitHub Actions when:                                                                  
+The test will run automatically as part of the functional tests workflow in GitHub Actions when:
 - A pull request is created
 - The workflow is manually triggered
 
@@ -202,10 +202,10 @@ var _ = Describe("DataIntegrityMyOperation", func() {
         // Import test data
         testData, err := dataManager.ImportTestData(getDefaultTestData())
         Expect(err).NotTo(HaveOccurred())
-        
+
         // Perform your operation
         // ...
-        
+
         // Verify data integrity
         err = dataManager.ValidateDataIntegrity(testData)
         Expect(err).NotTo(HaveOccurred())

--- a/opensearch-operator/go.mod
+++ b/opensearch-operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/Opster/opensearch-k8s-operator/opensearch-operator
 
-go 1.24.4
+go 1.24.11
 
 require (
 	emperror.dev/errors v0.8.1


### PR DESCRIPTION
### Description
Upgrade of go 1.24.4 to 1.24.11 to address a number of CVEs in the go standard library shipped in the operator 2.8.0.

### Issues Resolved
Closes #1258

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
