### PR TITLE
add rotateDaysBeforeExpiry to the OpenSearchCluster manifest

### DIFF
--- a/charts/opensearch-cluster/templates/cluster.yaml
+++ b/charts/opensearch-cluster/templates/cluster.yaml
@@ -54,6 +54,9 @@ spec:
         {{- with .tls.transport.secret }}
         secret: {{ . | toYaml | nindent 10 }}
         {{- end }}
+        {{- if .tls.transport.rotateDaysBeforeExpiry }}
+        rotateDaysBeforeExpiry: {{ .tls.transport.rotateDaysBeforeExpiry }}
+        {{- end }}
         {{- if .tls.transport.duration }}
         duration: {{ .tls.transport.duration }}
         {{- end }}
@@ -72,6 +75,9 @@ spec:
         {{- end }}
         {{- with .tls.http.caSecret }}
         caSecret: {{ . | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if .tls.http.rotateDaysBeforeExpiry }}
+        rotateDaysBeforeExpiry: {{ .tls.http.rotateDaysBeforeExpiry }}
         {{- end }}
         {{- if .tls.http.duration }}
         duration: {{ .tls.http.duration }}


### PR DESCRIPTION
Signed-off-by: Andrii Petruchek <apetruchek@gmail.com>

### Description
Fixed rotateDaysBeforeExpiry value propagation in opensearch-cluster helm chart

### Issues Resolved
Fixes https://github.com/opensearch-project/opensearch-k8s-operator/issues/1280

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [-] Unittest added for the new/changed functionality and all unit tests are successful
- [-] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [-] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [-] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
