### PR TITLE
Support multi-arch downloads for helm docs

### DIFF
--- a/opensearch-operator/Makefile
+++ b/opensearch-operator/Makefile
@@ -174,7 +174,9 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: helm-docs
 helm-docs: $(HELM_DOCS) ## Download helm-docs locally if necessary.
 $(HELM_DOCS): $(LOCALBIN)
-	@curl -sL "https://github.com/norwoodj/helm-docs/releases/download/v$(HELM_DOCS_VERSION)/helm-docs_$(HELM_DOCS_VERSION)_$$(uname -s)_x86_64.tar.gz" | tar -xz -C $(LOCALBIN) helm-docs
+	@ARCH=$$(uname -m); \
+	if [ "$$ARCH" = "aarch64" ] || [ "$$ARCH" = "arm64" ]; then ARCH="arm64"; else ARCH="x86_64"; fi; \
+	curl -sL "https://github.com/norwoodj/helm-docs/releases/download/v$(HELM_DOCS_VERSION)/helm-docs_$(HELM_DOCS_VERSION)_$$(uname -s)_$$ARCH.tar.gz" | tar -xz -C $(LOCALBIN) helm-docs
 	@chmod +x $(HELM_DOCS)
 
 .PHONY: crd-ref-docs


### PR DESCRIPTION
### Description
_x86_64 is hardcoded for downloading helm docs tar, it needs to support other formats also.

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
