### PR TITLE
Fix incorrect CA certificate path when using generate: true with cust…

### DIFF
--- a/opensearch-operator/pkg/reconcilers/tls.go
+++ b/opensearch-operator/pkg/reconcilers/tls.go
@@ -712,7 +712,9 @@ func (r *TLSReconciler) handleHttp() error {
 	r.reconcilerContext.AddConfig("plugins.security.ssl.http.enabled", "true")
 
 	// Set certificate file paths based on mounting configuration
-	if tlsConfig.CaSecret.Name == "" || tlsConfig.CaSecret.Name == tlsConfig.Secret.Name {
+	// When generate is true, the CA cert is included in the generated secret mounted at tls-http/
+	// Only when generate is false AND CaSecret differs from Secret do we use the separate tls-http-ca/ mount
+	if tlsConfig.Generate || tlsConfig.CaSecret.Name == "" || tlsConfig.CaSecret.Name == tlsConfig.Secret.Name {
 		// Single secret mounted as directory
 		r.reconcilerContext.AddConfig("plugins.security.ssl.http.pemcert_filepath", fmt.Sprintf("tls-http/%s", corev1.TLSCertKey))
 		r.reconcilerContext.AddConfig("plugins.security.ssl.http.pemkey_filepath", fmt.Sprintf("tls-http/%s", corev1.TLSPrivateKeyKey))

--- a/opensearch-operator/pkg/reconcilers/tls_test.go
+++ b/opensearch-operator/pkg/reconcilers/tls_test.go
@@ -321,6 +321,12 @@ var _ = Describe("TLS Controller", func() {
 			value, exists := reconcilerContext.OpenSearchConfig["plugins.security.nodes_dn"]
 			Expect(exists).To(BeTrue())
 			Expect(value).To(Equal("[\"CN=tls-withca-*,OU=tls-withca\"]"))
+
+			// Verify that the CA cert path uses tls-http/ (not tls-http-ca/) since generate=true
+			// includes the CA cert in the generated secret (Fixes #1279)
+			value, exists = reconcilerContext.OpenSearchConfig["plugins.security.ssl.http.pemtrustedcas_filepath"]
+			Expect(exists).To(BeTrue())
+			Expect(value).To(Equal("tls-http/ca.crt"))
 		})
 	})
 


### PR DESCRIPTION
…om caSecret

When http TLS is configured with generate: true and a custom caSecret, the CA cert is included in the generated secret mounted at tls-http/, but the path was incorrectly set to tls-http-ca/ca.crt which doesn't exist.

Fixes #1279

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
