### PR TITLE
Fix/reconcile bootstrap pod

### DIFF
--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1512,4 +1512,32 @@ var _ = Describe("Builders", func() {
 		})
 	})
 
+	When("Computing BootstrapPodSpecHash", func() {
+		It("should return a 40-character hex string", func() {
+			clusterObject := ClusterDescWithVersion("2.8.0")
+			pod := NewBootstrapPod(&clusterObject, nil, nil)
+
+			hash := BootstrapPodSpecHash(pod)
+			Expect(hash).To(HaveLen(40))
+		})
+
+		It("should return the same hash for identical pods", func() {
+			clusterObject := ClusterDescWithVersion("2.8.0")
+			pod1 := NewBootstrapPod(&clusterObject, nil, nil)
+			pod2 := NewBootstrapPod(&clusterObject, nil, nil)
+
+			Expect(BootstrapPodSpecHash(pod1)).To(Equal(BootstrapPodSpecHash(pod2)))
+		})
+
+		It("should return a different hash when the pod spec differs", func() {
+			clusterObject := ClusterDescWithVersion("2.8.0")
+			pod1 := NewBootstrapPod(&clusterObject, nil, nil)
+
+			modified := clusterObject.DeepCopy()
+			modified.Spec.General.ServiceAccount = "different-sa"
+			pod2 := NewBootstrapPod(modified, nil, nil)
+
+			Expect(BootstrapPodSpecHash(pod1)).NotTo(Equal(BootstrapPodSpecHash(pod2)))
+		})
+	})
 })

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1511,4 +1511,5 @@ var _ = Describe("Builders", func() {
 			Expect(pod.Spec.HostAliases).To(Equal([]corev1.HostAlias{bootstrapHostAlias}))
 		})
 	})
+
 })

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -21,7 +21,6 @@ import (
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/tls"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -360,45 +359,3 @@ func GetAvailableOpenSearchNodes(k8sClient k8s.K8sClient, ctx context.Context, c
 	return availableNodes
 }
 
-// PodSpecChanged checks if any meaningful pod spec fields have changed
-func PodSpecChanged(existing, desired *corev1.Pod) bool {
-	existingSpec := existing.Spec
-	desiredSpec := desired.Spec
-
-	sanitizeBootstrapPodSpec(&existingSpec)
-	sanitizeBootstrapPodSpec(&desiredSpec)
-
-	return !apiequality.Semantic.DeepEqual(existingSpec, desiredSpec)
-}
-
-func sanitizeBootstrapPodSpec(spec *corev1.PodSpec) {
-	spec.NodeName = ""
-	spec.Tolerations = removeDefaultNodeLifecycleTolerations(spec.Tolerations)
-}
-
-func removeDefaultNodeLifecycleTolerations(tolerations []corev1.Toleration) []corev1.Toleration {
-	if len(tolerations) == 0 {
-		return tolerations
-	}
-
-	filtered := make([]corev1.Toleration, 0, len(tolerations))
-	for _, tol := range tolerations {
-		if isDefaultNodeLifecycleToleration(tol) {
-			continue
-		}
-		filtered = append(filtered, tol)
-	}
-	return filtered
-}
-
-func isDefaultNodeLifecycleToleration(t corev1.Toleration) bool {
-	if t.Operator != corev1.TolerationOpExists || t.Effect != corev1.TaintEffectNoExecute {
-		return false
-	}
-
-	if t.TolerationSeconds == nil || *t.TolerationSeconds != 300 {
-		return false
-	}
-
-	return t.Key == "node.kubernetes.io/not-ready" || t.Key == "node.kubernetes.io/unreachable"
-}


### PR DESCRIPTION
### Description
- StatefulSets don't have this issue because the operator only updates the StatefulSet template — Kubernetes manages the actual pods. The bootstrap pod is managed directly, so runtime mutations from the scheduler pollute the comparison. 
- Fixed: Compute hash of the pod spec produced by NewBootstrapPod(), store it as an annotation on the pod. On each reconcile, compare the hash of the freshly generated spec against the stored hash. Only proceed with update/recreate when the hash differs.
### Issues Resolved
 #1295 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
