### PR TITLE
chore: add markStsReady helper function

### DIFF
--- a/opensearch-operator/controllers/cluster_test.go
+++ b/opensearch-operator/controllers/cluster_test.go
@@ -457,6 +457,10 @@ var _ = Describe("Cluster Reconciler", Ordered, func() {
 			Expect(k8sClient.Update(context.Background(), &OpensearchCluster)).Should(Succeed())
 
 			Eventually(func() bool {
+				// Simulate the StatefulSet controller by marking all STS as ready,
+				// so that nodePoolsReady() in the scaler reconciler passes.
+				_ = MarkStsReady(k8sClient, OpensearchCluster.Namespace)
+
 				stsList := &appsv1.StatefulSetList{}
 				err := k8sClient.List(context.Background(), stsList, client.InNamespace(OpensearchCluster.Name))
 				if err != nil {

--- a/opensearch-operator/controllers/dashboard_test.go
+++ b/opensearch-operator/controllers/dashboard_test.go
@@ -100,6 +100,12 @@ var _ = Describe("Dashboards Reconciler", Ordered, func() {
 			By("Opensearch Dashboard")
 			Eventually(func() bool {
 				fmt.Println("\n DAShBOARD - START - 2")
+
+				// Simulate the StatefulSet controller by marking all STS as ready,
+				// so that nodePoolsReady() in the scaler reconciler passes and
+				// the dashboards reconciler is allowed to run.
+				_ = MarkStsReady(k8sClient, OpensearchCluster.Namespace)
+
 				//// -------- Dashboard tests ---------
 				if OpensearchCluster.Spec.Dashboards.Enable {
 					if err := k8sClient.Get(context.Background(), client.ObjectKey{Namespace: clusterName, Name: clusterName + "-dashboards"}, &deploy); err != nil {


### PR DESCRIPTION
### Description
this func simulates the sts controller by setting available replicas to make unit tests pass.
There is no unit test requiring this helper function. This is a supplementary pr for https://github.com/opensearch-project/opensearch-k8s-operator/pull/1190
### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
