### PR TITLE
fixed smartscaler skip draining pods on multinode

### DIFF
--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -146,8 +146,12 @@ func (r *ScalerReconciler) reconcileNodePool(nodePool *opensearchv1.NodePool) (b
 		}
 	}
 	if currentStatus.Status == "Excluded" {
+		targetNodeName := ""
+		if len(currentStatus.Conditions) > 0 {
+			targetNodeName = currentStatus.Conditions[0]
+		}
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Start to Exclude %s/%s", r.instance.Namespace, r.instance.Name)
-		err := r.drainNode(currentStatus, currentSts, nodePool.Component)
+		err := r.drainNode(currentStatus, currentSts, nodePool.Component, targetNodeName)
 		return true, err
 	}
 	if currentStatus.Status == "Drained" {
@@ -238,6 +242,7 @@ func (r *ScalerReconciler) excludeNode(currentStatus opensearchv1.ComponentStatu
 			Component:   "Scaler",
 			Status:      "Excluded",
 			Description: nodePoolGroupName,
+			Conditions:  []string{lastReplicaNodeName},
 		}
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Scaler", "Finished to Exclude %s/%s", r.instance.Namespace, r.instance.Name)
 		lg.Info(fmt.Sprintf("Group: %s, Excluded node: %s", nodePoolGroupName, lastReplicaNodeName))
@@ -272,10 +277,15 @@ func (r *ScalerReconciler) excludeNode(currentStatus opensearchv1.ComponentStatu
 	return err
 }
 
-func (r *ScalerReconciler) drainNode(currentStatus opensearchv1.ComponentStatus, currentSts appsv1.StatefulSet, nodePoolGroupName string) error {
+func (r *ScalerReconciler) drainNode(currentStatus opensearchv1.ComponentStatus, currentSts appsv1.StatefulSet, nodePoolGroupName string, targetNodeName string) error {
 	lg := log.FromContext(r.ctx)
 	annotations := map[string]string{"cluster-name": r.instance.GetName()}
-	lastReplicaNodeName := helpers.ReplicaHostName(currentSts, *currentSts.Spec.Replicas-1)
+
+	// Use tracked node name, fall back to computing from STS if not available (backward compat)
+	lastReplicaNodeName := targetNodeName
+	if lastReplicaNodeName == "" {
+		lastReplicaNodeName = helpers.ReplicaHostName(currentSts, *currentSts.Spec.Replicas-1)
+	}
 
 	clusterClient, err := util.CreateClientForCluster(r.client, r.ctx, r.instance, r.osClientTransport)
 	if err != nil {
@@ -291,6 +301,7 @@ func (r *ScalerReconciler) drainNode(currentStatus opensearchv1.ComponentStatus,
 		Component:   "Scaler",
 		Status:      "Drained",
 		Description: nodePoolGroupName,
+		Conditions:  []string{lastReplicaNodeName},
 	}
 	lg.Info(fmt.Sprintf("Group: %s, Node %s is drained", nodePoolGroupName, lastReplicaNodeName))
 	err = r.client.UpdateOpenSearchClusterStatus(client.ObjectKeyFromObject(r.instance), func(instance *opensearchv1.OpenSearchCluster) {

--- a/opensearch-operator/pkg/reconcilers/scaler_test.go
+++ b/opensearch-operator/pkg/reconcilers/scaler_test.go
@@ -5,17 +5,20 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
-	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
+	k8sMock "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconciler"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func newScalerReconciler(client *k8s.MockK8sClient, spec *opensearchv1.OpenSearchCluster) *ScalerReconciler {
+func newScalerReconciler(client *k8sMock.MockK8sClient, spec *opensearchv1.OpenSearchCluster) *ScalerReconciler {
 	reconcilerContext := NewReconcilerContext(&helpers.MockEventRecorder{}, spec, spec.Spec.NodePools)
 	underTest := &ScalerReconciler{
 		client:            client,
@@ -51,7 +54,7 @@ var _ = Describe("Scaler Controller", func() {
 				},
 			}
 
-			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			mockClient := k8sMock.NewMockK8sClient(GinkgoT())
 			// Mock the ListStatefulSets call to verify it uses the correct namespace
 			mockClient.On("ListStatefulSets",
 				client.InNamespace(clusterNamespace),
@@ -88,7 +91,7 @@ var _ = Describe("Scaler Controller", func() {
 				},
 			}
 
-			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			mockClient := k8sMock.NewMockK8sClient(GinkgoT())
 			// Mock the ListStatefulSets call with the WRONG namespace (the bug scenario)
 			// This should NOT be called if the fix is working correctly
 			mockClient.On("ListStatefulSets",
@@ -111,6 +114,305 @@ var _ = Describe("Scaler Controller", func() {
 
 			// Verify that the correct namespace was used, not the wrong one
 			// This test ensures the bug is fixed
+			mockClient.AssertExpectations(GinkgoT())
+		})
+	})
+
+	Context("When tracking node names through Conditions during scale-down", func() {
+		var (
+			clusterName      = "test-cluster"
+			clusterNamespace = "test-namespace"
+			nodePoolComp     = "data"
+			stsName          = clusterName + "-" + nodePoolComp
+		)
+
+		makeSpec := func(replicas int32, smartScaler bool, componentStatuses []opensearchv1.ComponentStatus) *opensearchv1.OpenSearchCluster {
+			return &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: clusterNamespace,
+					UID:       "dummyuid",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{},
+					ConfMgmt: opensearchv1.ConfMgmt{
+						SmartScaler: smartScaler,
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: nodePoolComp,
+							Replicas:  replicas,
+							Roles:     []string{"data"},
+						},
+					},
+				},
+				Status: opensearchv1.ClusterStatus{
+					ComponentsStatus: componentStatuses,
+				},
+			}
+		}
+
+		makeSts := func(replicas int32) appsv1.StatefulSet {
+			return appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      stsName,
+					Namespace: clusterNamespace,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: &replicas,
+				},
+				Status: appsv1.StatefulSetStatus{
+					ReadyReplicas: replicas,
+				},
+			}
+		}
+
+		It("Should store node name in Conditions when setting Excluded status", func() {
+			// STS has 5 replicas, spec wants 4 → scale down by 1 with SmartScaler enabled
+			spec := makeSpec(4, true, nil)
+			mockClient := k8sMock.NewMockK8sClient(GinkgoT())
+			underTest := newScalerReconciler(mockClient, spec)
+
+			sts := makeSts(5)
+
+			// Mock GetStatefulSet
+			mockClient.On("GetStatefulSet", stsName, clusterNamespace).Return(sts, nil)
+
+			// Mock ListPods for ReadyReplicasForNodePool
+			mockClient.On("ListPods", mock.Anything).Return(corev1.PodList{}, nil)
+
+			// Mock UpdateOpenSearchClusterStatus for the "Running" status set
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything).Return(nil).Once()
+
+			// Mock GetSecret for OS client creation in excludeNode
+			mockClient.On("GetSecret", clusterName+"-admin-password", clusterNamespace).Return(
+				corev1.Secret{
+					Data: map[string][]byte{
+						"username": []byte("admin"),
+						"password": []byte("admin"),
+					},
+				}, nil,
+			)
+
+			// Call reconcileNodePool - it will reach excludeNode, which will fail
+			// at the OS client HTTP call, but we can verify the code path
+			nodePool := &spec.Spec.NodePools[0]
+			_, err := underTest.reconcileNodePool(nodePool)
+			// Error is expected since we can't actually connect to OpenSearch
+			// The key assertion is that the mock expectations are met
+			_ = err
+			mockClient.AssertExpectations(GinkgoT())
+		})
+
+		It("Should extract Conditions[0] from Excluded status and pass to drainNode", func() {
+			// Status already has "Excluded" with Conditions tracking the target node
+			targetNode := stsName + "-4"
+			spec := makeSpec(4, true, []opensearchv1.ComponentStatus{
+				{
+					Component:   "Scaler",
+					Status:      "Excluded",
+					Description: nodePoolComp,
+					Conditions:  []string{targetNode},
+				},
+			})
+
+			mockClient := k8sMock.NewMockK8sClient(GinkgoT())
+			underTest := newScalerReconciler(mockClient, spec)
+
+			sts := makeSts(5)
+
+			// Mock GetStatefulSet
+			mockClient.On("GetStatefulSet", stsName, clusterNamespace).Return(sts, nil)
+
+			// Mock ListPods for ReadyReplicasForNodePool
+			mockClient.On("ListPods", mock.Anything).Return(corev1.PodList{}, nil)
+
+			// Mock GetSecret for OS client creation in drainNode
+			mockClient.On("GetSecret", clusterName+"-admin-password", clusterNamespace).Return(
+				corev1.Secret{
+					Data: map[string][]byte{
+						"username": []byte("admin"),
+						"password": []byte("admin"),
+					},
+				}, nil,
+			)
+
+			// Call reconcileNodePool - it will enter the "Excluded" handler and call drainNode
+			// which will use targetNode from Conditions[0]
+			nodePool := &spec.Spec.NodePools[0]
+			_, err := underTest.reconcileNodePool(nodePool)
+			// Error expected since OS client can't connect; the important thing is
+			// we verified the code path goes through the Excluded handler
+			_ = err
+			mockClient.AssertExpectations(GinkgoT())
+		})
+
+		It("Should handle Excluded status without Conditions (backward compatibility)", func() {
+			// Status has "Excluded" without Conditions (pre-fix state)
+			spec := makeSpec(4, true, []opensearchv1.ComponentStatus{
+				{
+					Component:   "Scaler",
+					Status:      "Excluded",
+					Description: nodePoolComp,
+				},
+			})
+
+			mockClient := k8sMock.NewMockK8sClient(GinkgoT())
+			underTest := newScalerReconciler(mockClient, spec)
+
+			sts := makeSts(5)
+
+			// Mock GetStatefulSet
+			mockClient.On("GetStatefulSet", stsName, clusterNamespace).Return(sts, nil)
+
+			// Mock ListPods for ReadyReplicasForNodePool
+			mockClient.On("ListPods", mock.Anything).Return(corev1.PodList{}, nil)
+
+			// Mock GetSecret for OS client creation in drainNode
+			mockClient.On("GetSecret", clusterName+"-admin-password", clusterNamespace).Return(
+				corev1.Secret{
+					Data: map[string][]byte{
+						"username": []byte("admin"),
+						"password": []byte("admin"),
+					},
+				}, nil,
+			)
+
+			// Call reconcileNodePool - should still work even without Conditions
+			// drainNode falls back to computing node name from STS
+			nodePool := &spec.Spec.NodePools[0]
+			_, err := underTest.reconcileNodePool(nodePool)
+			_ = err
+			mockClient.AssertExpectations(GinkgoT())
+		})
+
+		It("Should scale down without SmartScaler and remove status correctly", func() {
+			// STS has 5 replicas, spec wants 4, SmartScaler disabled
+			spec := makeSpec(4, false, nil)
+			mockClient := k8sMock.NewMockK8sClient(GinkgoT())
+			underTest := newScalerReconciler(mockClient, spec)
+
+			sts := makeSts(5)
+
+			// Mock GetStatefulSet
+			mockClient.On("GetStatefulSet", stsName, clusterNamespace).Return(sts, nil)
+
+			// Mock ListPods for ReadyReplicasForNodePool
+			mockClient.On("ListPods", mock.Anything).Return(corev1.PodList{}, nil)
+
+			// Mock UpdateOpenSearchClusterStatus for the "Running" status set
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything).Return(nil)
+
+			// Mock ReconcileResource for the STS update (decrease replicas)
+			mockClient.On("ReconcileResource", mock.Anything, mock.Anything).Return(nil, nil)
+
+			nodePool := &spec.Spec.NodePools[0]
+			requeue, err := underTest.reconcileNodePool(nodePool)
+			Expect(err).To(BeNil())
+			Expect(requeue).To(BeFalse())
+			mockClient.AssertExpectations(GinkgoT())
+		})
+
+		It("Should clear status and restart cycle for next node on multi-node scale-down", func() {
+			// After removing node 4, status is cleared. Next reconcile finds
+			// STS at 4 replicas, spec wants 3 → should start fresh cycle for node 3
+			spec := makeSpec(3, true, nil)
+			mockClient := k8sMock.NewMockK8sClient(GinkgoT())
+			underTest := newScalerReconciler(mockClient, spec)
+
+			sts := makeSts(4) // STS now has 4 replicas after previous node was removed
+
+			// Mock GetStatefulSet
+			mockClient.On("GetStatefulSet", stsName, clusterNamespace).Return(sts, nil)
+
+			// Mock ListPods for ReadyReplicasForNodePool
+			mockClient.On("ListPods", mock.Anything).Return(corev1.PodList{}, nil)
+
+			// Mock UpdateOpenSearchClusterStatus - capture the status update to verify
+			var capturedStatus opensearchv1.ComponentStatus
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything,
+				mock.MatchedBy(func(f func(*opensearchv1.OpenSearchCluster)) bool {
+					return true
+				}),
+			).Run(func(args mock.Arguments) {
+				updateFunc := args.Get(1).(func(*opensearchv1.OpenSearchCluster))
+				// Apply the update to capture what it does
+				testInstance := &opensearchv1.OpenSearchCluster{}
+				updateFunc(testInstance)
+				if len(testInstance.Status.ComponentsStatus) > 0 {
+					capturedStatus = testInstance.Status.ComponentsStatus[0]
+				}
+			}).Return(nil).Once()
+
+			// Mock GetSecret for OS client creation in excludeNode
+			mockClient.On("GetSecret", clusterName+"-admin-password", clusterNamespace).Return(
+				corev1.Secret{
+					Data: map[string][]byte{
+						"username": []byte("admin"),
+						"password": []byte("admin"),
+					},
+				}, nil,
+			)
+
+			nodePool := &spec.Spec.NodePools[0]
+			requeue, err := underTest.reconcileNodePool(nodePool)
+			// Error expected since OS client can't connect
+			_ = err
+			_ = requeue
+
+			// Verify that the status was set to "Running" with the correct Description
+			// This proves the state machine restarted fresh for the next node
+			Expect(capturedStatus.Component).To(Equal("Scaler"))
+			Expect(capturedStatus.Status).To(Equal("Running"))
+			Expect(capturedStatus.Description).To(Equal(nodePoolComp))
+		})
+
+		It("Should preserve Conditions through Drained status", func() {
+			targetNode := stsName + "-4"
+			spec := makeSpec(4, true, []opensearchv1.ComponentStatus{
+				{
+					Component:   "Scaler",
+					Status:      "Drained",
+					Description: nodePoolComp,
+					Conditions:  []string{targetNode},
+				},
+			})
+
+			mockClient := k8sMock.NewMockK8sClient(GinkgoT())
+			underTest := newScalerReconciler(mockClient, spec)
+
+			sts := makeSts(5)
+
+			// Mock GetStatefulSet
+			mockClient.On("GetStatefulSet", stsName, clusterNamespace).Return(sts, nil)
+
+			// Mock ListPods for ReadyReplicasForNodePool
+			mockClient.On("ListPods", mock.Anything).Return(corev1.PodList{}, nil)
+
+			// Mock UpdateOpenSearchClusterStatus for RemoveIt in decreaseOneNode
+			mockClient.On("UpdateOpenSearchClusterStatus",
+				types.NamespacedName{Name: clusterName, Namespace: clusterNamespace},
+				mock.Anything,
+			).Return(nil)
+
+			// Mock ReconcileResource for the STS update (decrease replicas)
+			mockClient.On("ReconcileResource", mock.Anything, mock.Anything).Return(nil, nil)
+
+			// Mock GetSecret for OS client creation in decreaseOneNode (for RemoveExcludeNodeHost)
+			mockClient.On("GetSecret", clusterName+"-admin-password", clusterNamespace).Return(
+				corev1.Secret{
+					Data: map[string][]byte{
+						"username": []byte("admin"),
+						"password": []byte("admin"),
+					},
+				}, nil,
+			)
+
+			nodePool := &spec.Spec.NodePools[0]
+			_, err := underTest.reconcileNodePool(nodePool)
+			// The decreaseOneNode call will proceed, and then try to create OS client
+			// for RemoveExcludeNodeHost which will fail at the HTTP level
+			_ = err
 			mockClient.AssertExpectations(GinkgoT())
 		})
 	})


### PR DESCRIPTION
### Description
- Previously, drainNode always recomputed the target node name from the current StatefulSet replica count.  This fix tracks the target node name through the Conditions field of ComponentStatus as it flows through each state transition (Excluded → Drained)

### Issues Resolved
-  #961 

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
