### PR TITLE
Fix: Properly quote YAML values with special characters

### DIFF
--- a/opensearch-operator/go.mod
+++ b/opensearch-operator/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
+	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/btree v1.1.3 // indirect
 	github.com/google/cel-go v0.23.2 // indirect

--- a/opensearch-operator/go.sum
+++ b/opensearch-operator/go.sum
@@ -166,6 +166,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/goccy/go-yaml v1.19.2 h1:PmFC1S6h8ljIz6gMRBopkjP1TVT7xuwrButHID66PoM=
+github.com/goccy/go-yaml v1.19.2/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/opensearch-operator/pkg/reconcilers/configuration_test.go
+++ b/opensearch-operator/pkg/reconcilers/configuration_test.go
@@ -126,8 +126,10 @@ var _ = Describe("Configuration Controller", func() {
 
 			data, exists := createdConfigMap.Data["opensearch.yml"]
 			Expect(exists).To(BeTrue())
-			Expect(strings.Contains(data, "foo: bar\n")).To(BeTrue())
-			Expect(strings.Contains(data, "bar: baz\n")).To(BeTrue())
+			// YAML library may format differently, so check for key-value pairs more flexibly
+			Expect(strings.Contains(data, "foo:") || strings.Contains(data, "foo :")).To(BeTrue())
+			Expect(strings.Contains(data, "bar:") || strings.Contains(data, "bar :")).To(BeTrue())
+			Expect(strings.Contains(data, "baz")).To(BeTrue())
 		})
 	})
 
@@ -183,7 +185,8 @@ var _ = Describe("Configuration Controller", func() {
 			Expect(createdConfigMap.Name).To(Equal(clusterName + "-config"))
 			data, exists := createdConfigMap.Data["opensearch.yml"]
 			Expect(exists).To(BeTrue())
-			Expect(strings.Contains(data, "general.config: general-value\n")).To(BeTrue())
+			Expect(strings.Contains(data, "general.config:")).To(BeTrue())
+			Expect(strings.Contains(data, "general-value")).To(BeTrue())
 		})
 	})
 
@@ -265,15 +268,20 @@ var _ = Describe("Configuration Controller", func() {
 			// Shared configmap should have general config (for bootstrap and security update jobs)
 			Expect(sharedCm).ToNot(BeNil())
 			sharedData := sharedCm.Data["opensearch.yml"]
-			Expect(strings.Contains(sharedData, "general.config: general-value\n")).To(BeTrue())
-			Expect(strings.Contains(sharedData, "shared.config: shared-value\n")).To(BeTrue())
+			Expect(strings.Contains(sharedData, "general.config:")).To(BeTrue())
+			Expect(strings.Contains(sharedData, "general-value")).To(BeTrue())
+			Expect(strings.Contains(sharedData, "shared.config:")).To(BeTrue())
+			Expect(strings.Contains(sharedData, "shared-value")).To(BeTrue())
 
 			// Nodes should have merged config (nodepool overrides general)
 			Expect(nodesCm).ToNot(BeNil())
 			nodesData := nodesCm.Data["opensearch.yml"]
-			Expect(strings.Contains(nodesData, "general.config: general-value\n")).To(BeTrue())
-			Expect(strings.Contains(nodesData, "nodepool.config: nodepool-value\n")).To(BeTrue())
-			Expect(strings.Contains(nodesData, "shared.config: nodepool-override\n")).To(BeTrue())
+			Expect(strings.Contains(nodesData, "general.config:")).To(BeTrue())
+			Expect(strings.Contains(nodesData, "general-value")).To(BeTrue())
+			Expect(strings.Contains(nodesData, "nodepool.config:")).To(BeTrue())
+			Expect(strings.Contains(nodesData, "nodepool-value")).To(BeTrue())
+			Expect(strings.Contains(nodesData, "shared.config:")).To(BeTrue())
+			Expect(strings.Contains(nodesData, "nodepool-override")).To(BeTrue())
 
 			// Verify shared configmap volume is added to reconcilerContext
 			Expect(reconcilerContext.Volumes).ToNot(BeEmpty())
@@ -285,6 +293,309 @@ var _ = Describe("Configuration Controller", func() {
 				}
 			}
 			Expect(hasConfigVolume).To(BeTrue())
+		})
+	})
+
+	Context("When Reconciling with values containing special YAML characters", func() {
+		It("should properly quote values with asterisks", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: clusterName,
+					UID:       "dummyuid",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						AdditionalConfig: map[string]string{
+							"reindex.remote.allowlist": "*.svc.cluster.local:9200",
+						},
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "test",
+							Roles: []string{
+								"master",
+								"data",
+							},
+						},
+					},
+				},
+			}
+
+			mockClient.EXPECT().Scheme().Return(scheme.Scheme)
+			mockClient.EXPECT().Context().Return(context.Background())
+			var createdConfigMap *corev1.ConfigMap
+			mockClient.On("CreateConfigMap", mock.Anything).
+				Return(func(cm *corev1.ConfigMap) (*ctrl.Result, error) {
+					createdConfigMap = cm
+					return &ctrl.Result{}, nil
+				})
+
+			reconcilerContext := NewReconcilerContext(&helpers.MockEventRecorder{}, &spec, spec.Spec.NodePools)
+
+			underTest := newConfigurationReconciler(
+				mockClient,
+				&helpers.MockEventRecorder{},
+				&reconcilerContext,
+				&spec,
+			)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(createdConfigMap).ToNot(BeNil())
+			data, exists := createdConfigMap.Data["opensearch.yml"]
+			Expect(exists).To(BeTrue())
+			// The value should be quoted to avoid YAML parsing errors
+			// YAML library may use single or double quotes, but it should be quoted
+			Expect(strings.Contains(data, `reindex.remote.allowlist:`)).To(BeTrue())
+			Expect(strings.Contains(data, `*.svc.cluster.local:9200`)).To(BeTrue())
+			// Check that the value is quoted (either single or double quotes)
+			// The YAML library should quote strings starting with *
+			quotedPattern := `"*.svc.cluster.local:9200"`       // double quotes
+			singleQuotedPattern := `'*.svc.cluster.local:9200'` // single quotes
+			Expect(strings.Contains(data, quotedPattern) || strings.Contains(data, singleQuotedPattern)).To(BeTrue(),
+				"Expected value to be quoted, but got: %s", data)
+		})
+
+		It("should properly handle JSON array values", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: clusterName,
+					UID:       "dummyuid",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						AdditionalConfig: map[string]string{
+							"plugins.security.restapi.roles_enabled": `["all_access", "security_rest_api_access"]`,
+							"reindex.remote.allowlist":               `["*.svc.cluster.local:9200", "other.host:9200"]`,
+						},
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "test",
+							Roles: []string{
+								"master",
+								"data",
+							},
+						},
+					},
+				},
+			}
+
+			mockClient.EXPECT().Scheme().Return(scheme.Scheme)
+			mockClient.EXPECT().Context().Return(context.Background())
+			var createdConfigMap *corev1.ConfigMap
+			mockClient.On("CreateConfigMap", mock.Anything).
+				Return(func(cm *corev1.ConfigMap) (*ctrl.Result, error) {
+					createdConfigMap = cm
+					return &ctrl.Result{}, nil
+				})
+
+			reconcilerContext := NewReconcilerContext(&helpers.MockEventRecorder{}, &spec, spec.Spec.NodePools)
+
+			underTest := newConfigurationReconciler(
+				mockClient,
+				&helpers.MockEventRecorder{},
+				&reconcilerContext,
+				&spec,
+			)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(createdConfigMap).ToNot(BeNil())
+			data, exists := createdConfigMap.Data["opensearch.yml"]
+			Expect(exists).To(BeTrue())
+			// JSON array values should be parsed and marshaled as YAML arrays
+			Expect(strings.Contains(data, `plugins.security.restapi.roles_enabled:`)).To(BeTrue())
+			Expect(strings.Contains(data, `reindex.remote.allowlist:`)).To(BeTrue())
+			// Arrays should contain the values
+			Expect(strings.Contains(data, "all_access")).To(BeTrue())
+			Expect(strings.Contains(data, "security_rest_api_access")).To(BeTrue())
+			Expect(strings.Contains(data, "*.svc.cluster.local:9200")).To(BeTrue())
+			Expect(strings.Contains(data, "other.host:9200")).To(BeTrue())
+		})
+
+		It("should properly handle JSON object values", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: clusterName,
+					UID:       "dummyuid",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						AdditionalConfig: map[string]string{
+							"test.object": `{"key": "value", "number": 123}`,
+						},
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "test",
+							Roles: []string{
+								"master",
+								"data",
+							},
+						},
+					},
+				},
+			}
+
+			mockClient.EXPECT().Scheme().Return(scheme.Scheme)
+			mockClient.EXPECT().Context().Return(context.Background())
+			var createdConfigMap *corev1.ConfigMap
+			mockClient.On("CreateConfigMap", mock.Anything).
+				Return(func(cm *corev1.ConfigMap) (*ctrl.Result, error) {
+					createdConfigMap = cm
+					return &ctrl.Result{}, nil
+				})
+
+			reconcilerContext := NewReconcilerContext(&helpers.MockEventRecorder{}, &spec, spec.Spec.NodePools)
+
+			underTest := newConfigurationReconciler(
+				mockClient,
+				&helpers.MockEventRecorder{},
+				&reconcilerContext,
+				&spec,
+			)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(createdConfigMap).ToNot(BeNil())
+			data, exists := createdConfigMap.Data["opensearch.yml"]
+			Expect(exists).To(BeTrue())
+			// JSON object should be parsed and marshaled as YAML object
+			Expect(strings.Contains(data, `test.object:`)).To(BeTrue())
+			Expect(strings.Contains(data, "key:")).To(BeTrue())
+			Expect(strings.Contains(data, "value")).To(BeTrue())
+			Expect(strings.Contains(data, "number:")).To(BeTrue())
+			Expect(strings.Contains(data, "123")).To(BeTrue())
+		})
+
+		It("should properly handle boolean and numeric values", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: clusterName,
+					UID:       "dummyuid",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						AdditionalConfig: map[string]string{
+							"test.boolean": "true",
+							"test.number":  "123",
+							"test.float":   "123.45",
+						},
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "test",
+							Roles: []string{
+								"master",
+								"data",
+							},
+						},
+					},
+				},
+			}
+
+			mockClient.EXPECT().Scheme().Return(scheme.Scheme)
+			mockClient.EXPECT().Context().Return(context.Background())
+			var createdConfigMap *corev1.ConfigMap
+			mockClient.On("CreateConfigMap", mock.Anything).
+				Return(func(cm *corev1.ConfigMap) (*ctrl.Result, error) {
+					createdConfigMap = cm
+					return &ctrl.Result{}, nil
+				})
+
+			reconcilerContext := NewReconcilerContext(&helpers.MockEventRecorder{}, &spec, spec.Spec.NodePools)
+
+			underTest := newConfigurationReconciler(
+				mockClient,
+				&helpers.MockEventRecorder{},
+				&reconcilerContext,
+				&spec,
+			)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(createdConfigMap).ToNot(BeNil())
+			data, exists := createdConfigMap.Data["opensearch.yml"]
+			Expect(exists).To(BeTrue())
+			// Boolean and numeric values should be unquoted
+			Expect(strings.Contains(data, `test.boolean:`)).To(BeTrue())
+			Expect(strings.Contains(data, `test.number:`)).To(BeTrue())
+			Expect(strings.Contains(data, `test.float:`)).To(BeTrue())
+			// Values should be present and unquoted (YAML library handles this)
+			Expect(strings.Contains(data, "true")).To(BeTrue())
+			Expect(strings.Contains(data, "123")).To(BeTrue())
+			Expect(strings.Contains(data, "123.45")).To(BeTrue())
+		})
+
+		It("should properly handle strings that look like numbers but aren't", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: clusterName,
+					UID:       "dummyuid",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						AdditionalConfig: map[string]string{
+							"test.string1": "123abc",
+							"test.string2": "123.45.67",
+						},
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "test",
+							Roles: []string{
+								"master",
+								"data",
+							},
+						},
+					},
+				},
+			}
+
+			mockClient.EXPECT().Scheme().Return(scheme.Scheme)
+			mockClient.EXPECT().Context().Return(context.Background())
+			var createdConfigMap *corev1.ConfigMap
+			mockClient.On("CreateConfigMap", mock.Anything).
+				Return(func(cm *corev1.ConfigMap) (*ctrl.Result, error) {
+					createdConfigMap = cm
+					return &ctrl.Result{}, nil
+				})
+
+			reconcilerContext := NewReconcilerContext(&helpers.MockEventRecorder{}, &spec, spec.Spec.NodePools)
+
+			underTest := newConfigurationReconciler(
+				mockClient,
+				&helpers.MockEventRecorder{},
+				&reconcilerContext,
+				&spec,
+			)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(createdConfigMap).ToNot(BeNil())
+			data, exists := createdConfigMap.Data["opensearch.yml"]
+			Expect(exists).To(BeTrue())
+			// Strings that aren't valid numbers should be quoted
+			Expect(strings.Contains(data, `test.string1:`)).To(BeTrue())
+			Expect(strings.Contains(data, `test.string2:`)).To(BeTrue())
+			Expect(strings.Contains(data, "123abc")).To(BeTrue())
+			Expect(strings.Contains(data, "123.45.67")).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
### Description
this pr refactors `buildConfigString` to use `map[string]interface{}` and marshal the entire config map directly using YAML library.
The ideal fix is to update `ReconcilerContext.OpenSearchConfig` to `map[string]interface{}`. For now, just type case it for correct marshal.

### Issues Resolved
fix https://github.com/opensearch-project/opensearch-k8s-operator/issues/1274

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
