### PR TITLE
helm: support ingress configuration per nodePool

### DIFF
--- a/charts/opensearch-cluster/Chart.yaml
+++ b/charts/opensearch-cluster/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for OpenSearch Cluster
 type: application
 
 ## The opensearch-cluster Helm Chart version
-version: 3.2.2
+version: 3.3.0
 
 ## The operator version
 appVersion: 2.8.0

--- a/charts/opensearch-cluster/README.md
+++ b/charts/opensearch-cluster/README.md
@@ -81,9 +81,10 @@ The following table lists the configurable parameters of the Helm chart.
 | `cluster.initHelper.imagePullSecrets` | list | `[]` | initHelper image pull secret |
 | `cluster.initHelper.resources` | object | `{}` | initHelper pod cpu and memory resources |
 | `cluster.initHelper.version` | string | `"1.36"` | initHelper version |
-| `cluster.nodePools` | list | `[{"additionalConfig":{},"annotations":{},"component":"masters","diskSize":"30Gi","replicas":3,"resources":{"limits":{"cpu":"500m","memory":"2Gi"},"requests":{"cpu":"500m","memory":"2Gi"}},"roles":["master","data"],"sidecarContainers":[]}]` | Opensearch nodes configuration |
+| `cluster.nodePools` | list | `[{"additionalConfig":{},"annotations":{},"component":"masters","diskSize":"30Gi","ingress":{"enabled":false},"replicas":3,"resources":{"limits":{"cpu":"500m","memory":"2Gi"},"requests":{"cpu":"500m","memory":"2Gi"}},"roles":["master","data"],"sidecarContainers":[]}]` | Opensearch nodes configuration |
 | `cluster.nodePools[0].annotations` | object | `{}` | node pool pod annotations |
 | `cluster.nodePools[0].additionalConfig` | object | `{}` | Extra items to add to opensearch.yml for this specific nodepool (merged with general.additionalConfig) |
+| `cluster.nodePools[0].ingress` | object | `{"enabled":false}` | Per-nodePool ingress configuration. Creates a separate Ingress targeting this nodePool's service. |
 | `cluster.nodePools[0].sidecarContainers` | list | `[]` | These containers will be deployed as sidecars in the same pod as the OpenSearch container |
 | `cluster.security.config.adminCredentialsSecret` | object | `{}` | Secret that contains fields username and password to be used by the operator to access the opensearch cluster for node draining. Must be set if custom securityconfig is provided. |
 | `cluster.security.config.adminSecret` | object | `{}` | TLS Secret that contains a client certificate (tls.key, tls.crt, ca.crt) with admin rights in the opensearch cluster. Must be set if http certificates are provided by user and not generated |
@@ -124,4 +125,4 @@ The following table lists the configurable parameters of the Helm chart.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
-Opensearch-cluster Helm Chart version: `3.2.2`
+Opensearch-cluster Helm Chart version: `3.3.0`

--- a/charts/opensearch-cluster/templates/cluster.yaml
+++ b/charts/opensearch-cluster/templates/cluster.yaml
@@ -33,8 +33,11 @@ spec:
     {{- omit . "image" | toYaml | nindent 4 }}
     image: {{ .image }}:{{ .version }}
   {{- end }}
-  {{- with .Values.cluster.nodePools }}
-  nodePools: {{ . | toYaml | nindent 4 }}
+  {{- if .Values.cluster.nodePools }}
+  nodePools:
+    {{- range .Values.cluster.nodePools }}
+    - {{ omit . "ingress" | toYaml | nindent 6 | trim }}
+    {{- end }}
   {{- end }}
   {{- with .Values.cluster.security }}
   security:

--- a/charts/opensearch-cluster/templates/ingress.yaml
+++ b/charts/opensearch-cluster/templates/ingress.yaml
@@ -1,7 +1,70 @@
 {{- $clusterName := include "opensearch-cluster.cluster-name" . }}
 {{- $svcPort := .Values.cluster.general.httpPort -}}
 {{- $svcName := .Values.cluster.general.serviceName | default $clusterName }}
-{{- if .Values.cluster.ingress.opensearch.enabled -}}
+
+{{- range $pool := .Values.cluster.nodePools }}
+{{- if and $pool.ingress $pool.ingress.enabled }}
+---
+{{- if and $pool.ingress.className (not (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey $pool.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set $pool.ingress.annotations "kubernetes.io/ingress.class" $pool.ingress.className }}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" $.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $clusterName }}-{{ $pool.component }}
+  labels:
+    {{- include "opensearch-cluster.labels" $ | nindent 4 }}
+  {{- with $pool.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and $pool.ingress.className (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ $pool.ingress.className }}
+  {{- end }}
+  {{- if $pool.ingress.tls }}
+  tls:
+    {{- range $pool.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range $pool.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $svcName }}-{{ $pool.component }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $svcName }}-{{ $pool.component }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.cluster.ingress.opensearch.enabled }}
 ---
 {{- if and .Values.cluster.ingress.opensearch.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.cluster.ingress.opensearch.annotations "kubernetes.io/ingress.class") }}

--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -294,6 +294,21 @@ cluster:
         limits:
           memory: "2Gi"
           cpu: "500m"
+      # -- Per-nodePool ingress configuration. Creates a separate Ingress targeting this nodePool's service.
+      ingress:
+        enabled: false
+      #   annotations: {}
+      #   className: ""
+      #   hosts:
+      #     - host: opensearch-data.example.com
+      #       paths:
+      #         - path: /
+      #           pathType: ImplementationSpecific
+      #   tls: []
+      #     - hosts:
+      #         - opensearch-data.example.com
+      #       secretName: tls-secret
+
       # -- These containers will be deployed as sidecars in the same pod as the OpenSearch container
       sidecarContainers: []
       # Example configurations:


### PR DESCRIPTION
### Description

Each nodePool can now optionally define its own Ingress resource, targeting the nodePool-specific service (`{serviceName}-{component}`).

This allows routing client traffic to specific node pools (e.g. data or coordinating nodes) while keeping master nodes isolated, which is a recommended practice by both AWS and Elastic.

### Changes

- `values.yaml`: Added optional `ingress` block under nodePool configuration (default: `enabled: false`)
- `templates/ingress.yaml`: Added per-nodePool Ingress generation loop
- `templates/cluster.yaml`: Filtered out the `ingress` field from nodePools when rendering the CRD to avoid unknown field warnings

### Usage

```yaml
cluster:
  nodePools:
    - component: data
      roles: ["data"]
      ingress:
        enabled: true
        className: "alb"
        annotations: {}
        hosts:
          - host: opensearch-data.example.com
            paths:
              - path: /
                pathType: ImplementationSpecific
        tls: []
```

### Backward Compatibility

- Existing cluster-wide ingress (`cluster.ingress.opensearch`) remains unchanged
- NodePool ingress is opt-in (`enabled: false` by default)
- No CRD changes required

### Testing

- Verified with `helm template` across multiple scenarios (nodePool only, cluster only, both, multiple nodePools with TLS)
- Verified with `helm lint`
- Deployed and tested on a live EKS cluster

Resolves #1289