### PR TITLE
Added support for custom OpenSearch HOME path

### DIFF
--- a/charts/opensearch-cluster/Chart.yaml
+++ b/charts/opensearch-cluster/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for OpenSearch Cluster
 type: application
 
 ## The opensearch-cluster Helm Chart version
-version: 3.2.0
+version: 3.2.1
 
 ## The operator version
 appVersion: 2.8.0

--- a/charts/opensearch-cluster/README.md
+++ b/charts/opensearch-cluster/README.md
@@ -124,4 +124,4 @@ The following table lists the configurable parameters of the Helm chart.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
-Opensearch-cluster Helm Chart version: `3.2.0`
+Opensearch-cluster Helm Chart version: `3.2.1`

--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -129,6 +129,10 @@ cluster:
     # -- Opensearch version
     version: 2.3.0
 
+    # -- OpenSearch installation directory inside the container.
+    # If not set, defaults to /usr/share/opensearch.
+    # opensearchHome: "/usr/share/opensearch"
+
   # cluster boostrap pod configuration
   bootstrap:
     # -- bootstrap pod env variables
@@ -248,6 +252,10 @@ cluster:
 
     # -- dashboards version
     version: 2.3.0
+
+    # -- OpenSearch Dashboards installation directory inside the container.
+    # If not set, defaults to /usr/share/opensearch-dashboards.
+    # opensearchDashboardsHome: "/usr/share/opensearch-dashboards"
 
   # initHelper configuration
   initHelper:

--- a/charts/opensearch-operator/Chart.yaml
+++ b/charts/opensearch-operator/Chart.yaml
@@ -6,5 +6,5 @@ sources:
   - https://github.com/opensearch-project/OpenSearch
   - https://github.com/opensearch-project/opensearch-k8s-operator
 type: application
-version: 2.8.1
+version: 2.8.2
 appVersion: 2.8.0

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -135,4 +135,4 @@ subjects:
   namespace: <monitoring-namespace>
 ```
 
-Opensearch-operator Helm Chart version: `2.8.1`
+Opensearch-operator Helm Chart version: `2.8.2`

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -3019,6 +3019,11 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  opensearchDashboardsHome:
+                    description: OpenSearch Dashboards installation directory inside
+                      the container. Defaults to /usr/share/opensearch-dashboards
+                      if not set.
+                    type: string
                   pluginsList:
                     items:
                       type: string
@@ -4533,6 +4538,10 @@ spec:
                             type: string
                         type: object
                     type: object
+                  opensearchHome:
+                    description: OpenSearch installation directory inside the container.
+                      Defaults to /usr/share/opensearch if not set.
+                    type: string
                   operatorClusterURL:
                     description: |-
                       Operator cluster URL. If set, the operator will use this URL to communicate with OpenSearch

--- a/charts/opensearch-operator/files/opensearch.org_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchclusters.yaml
@@ -3039,6 +3039,11 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  opensearchDashboardsHome:
+                    description: OpenSearch Dashboards installation directory inside
+                      the container. Defaults to /usr/share/opensearch-dashboards
+                      if not set.
+                    type: string
                   pluginsList:
                     items:
                       type: string
@@ -4640,6 +4645,10 @@ spec:
                             type: string
                         type: object
                     type: object
+                  opensearchHome:
+                    description: OpenSearch installation directory inside the container.
+                      Defaults to /usr/share/opensearch if not set.
+                    type: string
                   operatorClusterURL:
                     description: |-
                       Operator cluster URL. If set, the operator will use this URL to communicate with OpenSearch

--- a/docs/designs/crd.md
+++ b/docs/designs/crd.md
@@ -362,6 +362,7 @@ _Appears in:_
 | `podSecurityContext` _[PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core)_ | Set security context for the dashboards pods |  |  |
 | `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | Set security context for the dashboards pods' container |  |  |
 | `priorityClassName` _string_ |  |  |  |
+| `opensearchDashboardsHome` _string_ | OpenSearch Dashboards installation directory inside the container. Defaults to /usr/share/opensearch-dashboards if not set. |  |  |
 
 
 #### DashboardsServiceSpec
@@ -516,6 +517,7 @@ _Appears in:_
 | `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | Set security context for the cluster pods' container |  |  |
 | `hostAliases` _[HostAlias](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#hostalias-v1-core) array_ |  |  |  |
 | `operatorClusterURL` _string_ | Operator cluster URL. If set, the operator will use this URL to communicate with OpenSearch<br />instead of the default internal Kubernetes service DNS name. |  |  |
+| `opensearchHome` _string_ | OpenSearch installation directory inside the container. Defaults to /usr/share/opensearch if not set. |  |  |
 
 
 #### ISMTemplate
@@ -2131,6 +2133,7 @@ _Appears in:_
 | `podSecurityContext` _[PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podsecuritycontext-v1-core)_ | Set security context for the dashboards pods |  |  |
 | `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core)_ | Set security context for the dashboards pods' container |  |  |
 | `priorityClassName` _string_ |  |  |  |
+| `opensearchDashboardsHome` _string_ | OpenSearch Dashboards installation directory inside the container. Defaults to /usr/share/opensearch-dashboards if not set. |  |  |
 
 
 #### DashboardsServiceSpec
@@ -2286,6 +2289,7 @@ _Appears in:_
 | `operatorClusterURL` _string_ | Operator cluster URL. If set, the operator will use this URL to communicate with OpenSearch<br />instead of the default internal Kubernetes service DNS name. |  |  |
 | `grpc` _[GrpcConfig](#grpcconfig)_ | gRPC API configuration for OpenSearch |  |  |
 | `hostNetwork` _boolean_ | HostNetwork enables host networking for all pods in the cluster. |  |  |
+| `opensearchHome` _string_ | OpenSearch installation directory inside the container. Defaults to /usr/share/opensearch if not set. |  |  |
 
 
 #### GrpcConfig

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -1103,6 +1103,20 @@ manager:
       value: "true"
 ```
 
+### Custom OpenSearch Path
+
+By default, the operator assumes OpenSearch is installed at `/usr/share/opensearch` inside the container (and `/usr/share/opensearch-dashboards` for Dashboards). If you use a custom OpenSearch image with a different installation directory, you can override these paths:
+
+```yaml
+spec:
+  general:
+    opensearchHome: "/opt/opensearch"
+  dashboards:
+    opensearchDashboardsHome: "/opt/opensearch-dashboards"
+```
+
+The operator uses these paths for all volume mounts (data, config, TLS certificates, keystore, security plugin) and init container commands. When not set, the defaults are used. Any trailing slashes in the provided path are automatically removed.
+
 ### PodDisruptionBudget
 
 The PDB (Pod Disruption Budget) is a Kubernetes resource that helps ensure the high availability of applications by defining the acceptable disruption level during maintenance or unexpected events.

--- a/opensearch-operator/api/opensearch.org/v1/opensearch_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearch_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,6 +83,8 @@ type GeneralConfig struct {
 	Grpc *GrpcConfig `json:"grpc,omitempty"`
 	// HostNetwork enables host networking for all pods in the cluster.
 	HostNetwork bool `json:"hostNetwork,omitempty"`
+	// OpenSearch installation directory inside the container. Defaults to /usr/share/opensearch if not set.
+	OpenSearchHome string `json:"opensearchHome,omitempty"`
 }
 
 type PdbConfig struct {
@@ -245,6 +249,8 @@ type DashboardsConfig struct {
 	// Set security context for the dashboards pods' container
 	SecurityContext   *corev1.SecurityContext `json:"securityContext,omitempty"`
 	PriorityClassName string                  `json:"priorityClassName,omitempty"`
+	// OpenSearch Dashboards installation directory inside the container. Defaults to /usr/share/opensearch-dashboards if not set.
+	OpenSearchDashboardsHome string `json:"opensearchDashboardsHome,omitempty"`
 }
 
 type DashboardsTlsConfig struct {
@@ -496,6 +502,25 @@ type OpenSearchClusterList struct {
 
 func init() {
 	SchemeBuilder.Register(&OpenSearchCluster{}, &OpenSearchClusterList{})
+}
+
+const (
+	DefaultOpenSearchHome           = "/usr/share/opensearch"
+	DefaultOpenSearchDashboardsHome = "/usr/share/opensearch-dashboards"
+)
+
+func (g GeneralConfig) GetOpenSearchHome() string {
+	if g.OpenSearchHome != "" {
+		return strings.TrimRight(g.OpenSearchHome, "/")
+	}
+	return DefaultOpenSearchHome
+}
+
+func (d DashboardsConfig) GetOpenSearchDashboardsHome() string {
+	if d.OpenSearchDashboardsHome != "" {
+		return strings.TrimRight(d.OpenSearchDashboardsHome, "/")
+	}
+	return DefaultOpenSearchDashboardsHome
 }
 
 func (s ImageSpec) GetImagePullPolicy() (_ corev1.PullPolicy) {

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -79,6 +81,8 @@ type GeneralConfig struct {
 	// Operator cluster URL. If set, the operator will use this URL to communicate with OpenSearch
 	// instead of the default internal Kubernetes service DNS name.
 	OperatorClusterURL *string `json:"operatorClusterURL,omitempty"`
+	// OpenSearch installation directory inside the container. Defaults to /usr/share/opensearch if not set.
+	OpenSearchHome string `json:"opensearchHome,omitempty"`
 }
 
 type PdbConfig struct {
@@ -242,6 +246,8 @@ type DashboardsConfig struct {
 	// Set security context for the dashboards pods' container
 	SecurityContext   *corev1.SecurityContext `json:"securityContext,omitempty"`
 	PriorityClassName string                  `json:"priorityClassName,omitempty"`
+	// OpenSearch Dashboards installation directory inside the container. Defaults to /usr/share/opensearch-dashboards if not set.
+	OpenSearchDashboardsHome string `json:"opensearchDashboardsHome,omitempty"`
 }
 
 type DashboardsTlsConfig struct {
@@ -458,6 +464,25 @@ type OpenSearchClusterList struct {
 
 func init() {
 	SchemeBuilder.Register(&OpenSearchCluster{}, &OpenSearchClusterList{})
+}
+
+const (
+	DefaultOpenSearchHome           = "/usr/share/opensearch"
+	DefaultOpenSearchDashboardsHome = "/usr/share/opensearch-dashboards"
+)
+
+func (g GeneralConfig) GetOpenSearchHome() string {
+	if g.OpenSearchHome != "" {
+		return strings.TrimRight(g.OpenSearchHome, "/")
+	}
+	return DefaultOpenSearchHome
+}
+
+func (d DashboardsConfig) GetOpenSearchDashboardsHome() string {
+	if d.OpenSearchDashboardsHome != "" {
+		return strings.TrimRight(d.OpenSearchDashboardsHome, "/")
+	}
+	return DefaultOpenSearchDashboardsHome
 }
 
 func (s ImageSpec) GetImagePullPolicy() (_ corev1.PullPolicy) {

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -3019,6 +3019,11 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  opensearchDashboardsHome:
+                    description: OpenSearch Dashboards installation directory inside
+                      the container. Defaults to /usr/share/opensearch-dashboards
+                      if not set.
+                    type: string
                   pluginsList:
                     items:
                       type: string
@@ -4537,6 +4542,10 @@ spec:
                             type: string
                         type: object
                     type: object
+                  opensearchHome:
+                    description: OpenSearch installation directory inside the container.
+                      Defaults to /usr/share/opensearch if not set.
+                    type: string
                   operatorClusterURL:
                     description: |-
                       Operator cluster URL. If set, the operator will use this URL to communicate with OpenSearch

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchclusters.yaml
@@ -3039,6 +3039,11 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  opensearchDashboardsHome:
+                    description: OpenSearch Dashboards installation directory inside
+                      the container. Defaults to /usr/share/opensearch-dashboards
+                      if not set.
+                    type: string
                   pluginsList:
                     items:
                       type: string
@@ -4640,6 +4645,10 @@ spec:
                             type: string
                         type: object
                     type: object
+                  opensearchHome:
+                    description: OpenSearch installation directory inside the container.
+                      Defaults to /usr/share/opensearch if not set.
+                    type: string
                   operatorClusterURL:
                     description: |-
                       Operator cluster URL. If set, the operator will use this URL to communicate with OpenSearch

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -164,9 +164,10 @@ func NewSTSForNodePool(
 		}
 	}
 
+	opensearchHome := cr.Spec.General.GetOpenSearchHome()
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
 		Name:      "data",
-		MountPath: "/usr/share/opensearch/data",
+		MountPath: opensearchHome + "/data",
 	})
 
 	labels := map[string]string{
@@ -417,14 +418,14 @@ func NewSTSForNodePool(
 			ImagePullPolicy: initHelperImage.GetImagePullPolicy(),
 			Resources:       resources,
 			Command:         []string{"sh", "-c"},
-			Args:            []string{helpers.GetChownCommand(uid, gid, "/usr/share/opensearch/data")},
+			Args:            []string{helpers.GetChownCommand(uid, gid, opensearchHome+"/data")},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser: &runas,
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "data",
-					MountPath: "/usr/share/opensearch/data",
+					MountPath: opensearchHome + "/data",
 				},
 			},
 		})
@@ -443,7 +444,7 @@ func NewSTSForNodePool(
 
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "keystore",
-			MountPath: "/usr/share/opensearch/config/opensearch.keystore",
+			MountPath: opensearchHome + "/config/opensearch.keystore",
 			SubPath:   "opensearch.keystore",
 		})
 
@@ -491,27 +492,27 @@ func NewSTSForNodePool(
 			Command: []string{
 				"sh",
 				"-c",
-				`
+				fmt.Sprintf(`
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				if [ ! -f /usr/share/opensearch/config/opensearch.keystore ]; then
-				  /usr/share/opensearch/bin/opensearch-keystore create
+				if [ ! -f %[1]s/config/opensearch.keystore ]; then
+				  %[1]s/bin/opensearch-keystore create
 				fi
 				for i in /tmp/keystoreSecrets/*/*; do
 				  key=$(basename $i)
 				  echo "Adding file $i to keystore key $key"
-				  /usr/share/opensearch/bin/opensearch-keystore add-file "$key" "$i" --force
+				  %[1]s/bin/opensearch-keystore add-file "$key" "$i" --force
 				done
 
 				# Add the bootstrap password since otherwise the opensearch entrypoint tries to do this on startup
 				if [ ! -z ${PASSWORD+x} ]; then
 				  echo 'Adding env $PASSWORD to keystore as key bootstrap.password'
-				  echo "$PASSWORD" | /usr/share/opensearch/bin/opensearch-keystore add -x bootstrap.password
+				  echo "$PASSWORD" | %[1]s/bin/opensearch-keystore add -x bootstrap.password
 				fi
 
-				cp -a /usr/share/opensearch/config/opensearch.keystore /tmp/keystore/
-				`,
+				cp -a %[1]s/config/opensearch.keystore /tmp/keystore/
+				`, opensearchHome),
 			},
 			VolumeMounts:    initContainerVolumeMounts,
 			SecurityContext: securityContext,
@@ -933,9 +934,10 @@ func NewBootstrapPod(
 		},
 	})
 
+	opensearchHome := cr.Spec.General.GetOpenSearchHome()
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
 		Name:      "data",
-		MountPath: "/usr/share/opensearch/data",
+		MountPath: opensearchHome + "/data",
 	})
 
 	podSecurityContext := cr.Spec.General.PodSecurityContext
@@ -1008,14 +1010,14 @@ func NewBootstrapPod(
 			ImagePullPolicy: initHelperImage.GetImagePullPolicy(),
 			Resources:       cr.Spec.InitHelper.Resources,
 			Command:         []string{"sh", "-c"},
-			Args:            []string{helpers.GetChownCommand(uid, gid, "/usr/share/opensearch/data")},
+			Args:            []string{helpers.GetChownCommand(uid, gid, opensearchHome+"/data")},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser: ptr.To(int64(0)),
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "data",
-					MountPath: "/usr/share/opensearch/data",
+					MountPath: opensearchHome + "/data",
 				},
 			},
 		})
@@ -1034,7 +1036,7 @@ func NewBootstrapPod(
 
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "keystore",
-			MountPath: "/usr/share/opensearch/config/opensearch.keystore",
+			MountPath: opensearchHome + "/config/opensearch.keystore",
 			SubPath:   "opensearch.keystore",
 		})
 
@@ -1082,27 +1084,27 @@ func NewBootstrapPod(
 			Command: []string{
 				"sh",
 				"-c",
-				`
+				fmt.Sprintf(`
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				if [ ! -f /usr/share/opensearch/config/opensearch.keystore ]; then
-				  /usr/share/opensearch/bin/opensearch-keystore create
+				if [ ! -f %[1]s/config/opensearch.keystore ]; then
+				  %[1]s/bin/opensearch-keystore create
 				fi
 				for i in /tmp/keystoreSecrets/*/*; do
 				  key=$(basename $i)
 				  echo "Adding file $i to keystore key $key"
-				  /usr/share/opensearch/bin/opensearch-keystore add-file "$key" "$i" --force
+				  %[1]s/bin/opensearch-keystore add-file "$key" "$i" --force
 				done
 
 				# Add the bootstrap password since otherwise the opensearch entrypoint tries to do this on startup
 				if [ ! -z ${PASSWORD+x} ]; then
 				  echo 'Adding env $PASSWORD to keystore as key bootstrap.password'
-				  echo "$PASSWORD" | /usr/share/opensearch/bin/opensearch-keystore add -x bootstrap.password
+				  echo "$PASSWORD" | %[1]s/bin/opensearch-keystore add -x bootstrap.password
 				fi
 
-				cp -a /usr/share/opensearch/config/opensearch.keystore /tmp/keystore/
-				`,
+				cp -a %[1]s/config/opensearch.keystore /tmp/keystore/
+				`, opensearchHome),
 			},
 			VolumeMounts:    initContainerVolumeMounts,
 			SecurityContext: securityContext,

--- a/opensearch-operator/pkg/builders/dashboards.go
+++ b/opensearch-operator/pkg/builders/dashboards.go
@@ -32,9 +32,10 @@ func NewDashboardsDeploymentForCR(cr *opensearchv1.OpenSearchCluster, volumes []
 			},
 		},
 	})
+	dashboardsHome := cr.Spec.Dashboards.GetOpenSearchDashboardsHome()
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
 		Name:      "dashboards-config",
-		MountPath: "/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml",
+		MountPath: dashboardsHome + "/config/opensearch_dashboards.yml",
 		SubPath:   "opensearch_dashboards.yml",
 	})
 

--- a/opensearch-operator/pkg/helpers/reconcile-helpers.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers.go
@@ -154,12 +154,13 @@ func VersionCheck(instance *opensearchv1.OpenSearchCluster) (int32, int32, strin
 		}
 	}
 
+	opensearchHome := instance.Spec.General.GetOpenSearchHome()
 	if isVersion2OrHigher {
 		securityConfigPort = httpPort
-		securityConfigPath = "/usr/share/opensearch/config/opensearch-security"
+		securityConfigPath = opensearchHome + "/config/opensearch-security"
 	} else {
 		securityConfigPort = 9300
-		securityConfigPath = "/usr/share/opensearch/plugins/opensearch-security/securityconfig"
+		securityConfigPath = opensearchHome + "/plugins/opensearch-security/securityconfig"
 	}
 	return httpPort, securityConfigPort, securityConfigPath
 }

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -198,7 +198,7 @@ func (r *ClusterReconciler) reconcileNodeStatefulSet(nodePool opensearchv1.NodeP
 		})
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "config",
-			MountPath: "/usr/share/opensearch/config/opensearch.yml",
+			MountPath: r.instance.Spec.General.GetOpenSearchHome() + "/config/opensearch.yml",
 			SubPath:   "opensearch.yml",
 		})
 	}

--- a/opensearch-operator/pkg/reconcilers/configuration.go
+++ b/opensearch-operator/pkg/reconcilers/configuration.go
@@ -185,7 +185,7 @@ func (r *ConfigurationReconciler) Reconcile() (ctrl.Result, error) {
 
 		mount := corev1.VolumeMount{
 			Name:      "config",
-			MountPath: "/usr/share/opensearch/config/opensearch.yml",
+			MountPath: r.instance.Spec.General.GetOpenSearchHome() + "/config/opensearch.yml",
 			SubPath:   "opensearch.yml",
 		}
 		r.reconcilerContext.VolumeMounts = append(r.reconcilerContext.VolumeMounts, mount)

--- a/opensearch-operator/pkg/reconcilers/dashboards.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards.go
@@ -178,19 +178,21 @@ func (r *DashboardsReconciler) handleTls() ([]corev1.Volume, []corev1.VolumeMoun
 		// Mount secret
 		volume := corev1.Volume{Name: "tls-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: tlsSecretName}}}
 		volumes = append(volumes, volume)
-		mount := corev1.VolumeMount{Name: "tls-cert", MountPath: "/usr/share/opensearch-dashboards/certs"}
+		dashboardsHome := r.instance.Spec.Dashboards.GetOpenSearchDashboardsHome()
+		mount := corev1.VolumeMount{Name: "tls-cert", MountPath: dashboardsHome + "/certs"}
 		volumeMounts = append(volumeMounts, mount)
 	} else {
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Security", "Notice - using externally provided certificates for Dashboard Cluster")
 		volume := corev1.Volume{Name: "tls-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: tlsConfig.Secret.Name}}}
 		volumes = append(volumes, volume)
-		mount := corev1.VolumeMount{Name: "tls-cert", MountPath: "/usr/share/opensearch-dashboards/certs"}
+		dashboardsHome := r.instance.Spec.Dashboards.GetOpenSearchDashboardsHome()
+		mount := corev1.VolumeMount{Name: "tls-cert", MountPath: dashboardsHome + "/certs"}
 		volumeMounts = append(volumeMounts, mount)
 	}
-	// Update dashboards config
+	dashboardsHome := r.instance.Spec.Dashboards.GetOpenSearchDashboardsHome()
 	r.reconcilerContext.AddDashboardsConfig("server.ssl.enabled", "true")
-	r.reconcilerContext.AddDashboardsConfig("server.ssl.key", "/usr/share/opensearch-dashboards/certs/tls.key")
-	r.reconcilerContext.AddDashboardsConfig("server.ssl.certificate", "/usr/share/opensearch-dashboards/certs/tls.crt")
+	r.reconcilerContext.AddDashboardsConfig("server.ssl.key", dashboardsHome+"/certs/tls.key")
+	r.reconcilerContext.AddDashboardsConfig("server.ssl.certificate", dashboardsHome+"/certs/tls.crt")
 	return volumes, volumeMounts, nil
 }
 

--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -30,7 +30,7 @@ const (
 	adminKey  = "/certs/tls.key"
 	caCert    = "/certs/ca.crt"
 
-	SecurityAdminBaseCmdTmpl = `ADMIN=/usr/share/opensearch/plugins/opensearch-security/tools/securityadmin.sh;
+	SecurityAdminBaseCmdTmpl = `ADMIN=%s/plugins/opensearch-security/tools/securityadmin.sh;
 chmod +x $ADMIN;
 until curl -k --silent https://%s:%v;
 do
@@ -197,8 +197,9 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 	// securityconfig secret was not passed, build the command to apply all yml files
 	if !r.instance.Status.Initialized || len(cmdArg) == 0 {
 		clusterHostName := BuildClusterSvcHostName(r.instance)
+		opensearchHome := r.instance.Spec.General.GetOpenSearchHome()
 		httpPort, securityConfigPort, securityconfigPath := helpers.VersionCheck(r.instance)
-		cmdArg = fmt.Sprintf(SecurityAdminBaseCmdTmpl, clusterHostName, httpPort) +
+		cmdArg = fmt.Sprintf(SecurityAdminBaseCmdTmpl, opensearchHome, clusterHostName, httpPort) +
 			fmt.Sprintf(ApplyAllYmlCmdTmpl, caCert, adminCert, adminKey, securityconfigPath, clusterHostName, securityConfigPort)
 	}
 
@@ -228,9 +229,10 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 // securityconfig secret. yml files which are not present in the secret are not applied/updated
 func BuildCmdArg(instance *opensearchv1.OpenSearchCluster, secret *corev1.Secret, log logr.Logger) string {
 	clusterHostName := BuildClusterSvcHostName(instance)
+	opensearchHome := instance.Spec.General.GetOpenSearchHome()
 	httpPort, securityConfigPort, securityconfigPath := helpers.VersionCheck(instance)
 
-	arg := fmt.Sprintf(SecurityAdminBaseCmdTmpl, clusterHostName, httpPort)
+	arg := fmt.Sprintf(SecurityAdminBaseCmdTmpl, opensearchHome, clusterHostName, httpPort)
 
 	// Get the list of yml files and sort them
 	// This will ensure commands are always generated in the same order

--- a/opensearch-operator/pkg/reconcilers/tls.go
+++ b/opensearch-operator/pkg/reconcilers/tls.go
@@ -436,7 +436,7 @@ func (r *TLSReconciler) handleTransportGenerate() error {
 	// Tell cluster controller to mount secrets
 	volume := corev1.Volume{Name: "transport-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: nodeSecretName}}}
 	r.reconcilerContext.Volumes = append(r.reconcilerContext.Volumes, volume)
-	mount := corev1.VolumeMount{Name: "transport-cert", MountPath: "/usr/share/opensearch/config/tls-transport"}
+	mount := corev1.VolumeMount{Name: "transport-cert", MountPath: r.instance.Spec.General.GetOpenSearchHome() + "/config/tls-transport"}
 	r.reconcilerContext.VolumeMounts = append(r.reconcilerContext.VolumeMounts, mount)
 
 	// Extend opensearch.yml
@@ -563,8 +563,9 @@ func (r *TLSReconciler) handleTransportExistingCerts() error {
 		return err
 	}
 
+	opensearchHome := r.instance.Spec.General.GetOpenSearchHome()
 	if tlsConfig.PerNode {
-		mountFolder("transport", "certs", tlsConfig.Secret.Name, r.reconcilerContext)
+		mountFolder("transport", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
 		// Extend opensearch.yml
 		r.reconcilerContext.AddConfig("plugins.security.ssl.transport.pemcert_filepath", "tls-transport/${HOSTNAME}.crt")
 		r.reconcilerContext.AddConfig("plugins.security.ssl.transport.pemkey_filepath", "tls-transport/${HOSTNAME}.key")
@@ -574,16 +575,16 @@ func (r *TLSReconciler) handleTransportExistingCerts() error {
 		switch name := tlsConfig.CaSecret.Name; name {
 		case "":
 			// If CaSecret.Name is empty, mount Secret.Name as a directory
-			mountFolder("transport", "certs", tlsConfig.Secret.Name, r.reconcilerContext)
+			mountFolder("transport", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
 		case tlsConfig.Secret.Name:
 			// If CaSecret.Name is same as Secret.Name, mount only Secret.Name as a directory
-			mountFolder("transport", "certs", tlsConfig.Secret.Name, r.reconcilerContext)
+			mountFolder("transport", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
 		default:
 			// If CaSecret.Name is different from Secret.Name, mount both secrets as directories
 			// Mount Secret.Name as tls-transport/
-			mountFolder("transport", "certs", tlsConfig.Secret.Name, r.reconcilerContext)
+			mountFolder("transport", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
 			// Mount CaSecret.Name as tls-transport-ca/
-			mountFolder("transport", "ca", tlsConfig.CaSecret.Name, r.reconcilerContext)
+			mountFolder("transport", "ca", tlsConfig.CaSecret.Name, opensearchHome, r.reconcilerContext)
 		}
 
 		// Extend opensearch.yml with appropriate file paths based on mounting logic
@@ -682,7 +683,7 @@ func (r *TLSReconciler) handleHttp() error {
 		// Tell cluster controller to mount secrets
 		volume := corev1.Volume{Name: "http-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: nodeSecretName}}}
 		r.reconcilerContext.Volumes = append(r.reconcilerContext.Volumes, volume)
-		mount := corev1.VolumeMount{Name: "http-cert", MountPath: "/usr/share/opensearch/config/tls-" + "http"}
+		mount := corev1.VolumeMount{Name: "http-cert", MountPath: r.instance.Spec.General.GetOpenSearchHome() + "/config/tls-http"}
 		r.reconcilerContext.VolumeMounts = append(r.reconcilerContext.VolumeMounts, mount)
 	} else {
 		if tlsConfig.Secret.Name == "" {
@@ -693,19 +694,20 @@ func (r *TLSReconciler) handleHttp() error {
 		}
 
 		// Implement new mounting logic based on CaSecret.Name configuration
+		opensearchHome := r.instance.Spec.General.GetOpenSearchHome()
 		switch name := tlsConfig.CaSecret.Name; name {
 		case "":
 			// If CaSecret.Name is empty, mount Secret.Name as a directory
-			mountFolder("http", "certs", tlsConfig.Secret.Name, r.reconcilerContext)
+			mountFolder("http", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
 		case tlsConfig.Secret.Name:
 			// If CaSecret.Name is same as Secret.Name, mount only Secret.Name as a directory
-			mountFolder("http", "certs", tlsConfig.Secret.Name, r.reconcilerContext)
+			mountFolder("http", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
 		default:
 			// If CaSecret.Name is different from Secret.Name, mount both secrets as directories
 			// Mount Secret.Name as tls-http/
-			mountFolder("http", "certs", tlsConfig.Secret.Name, r.reconcilerContext)
+			mountFolder("http", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
 			// Mount CaSecret.Name as tls-http-ca/
-			mountFolder("http", "ca", tlsConfig.CaSecret.Name, r.reconcilerContext)
+			mountFolder("http", "ca", tlsConfig.CaSecret.Name, opensearchHome, r.reconcilerContext)
 		}
 	}
 	// Extend opensearch.yml with appropriate file paths based on mounting logic
@@ -754,15 +756,15 @@ func (r *TLSReconciler) getReferencedCaCertOrDefault(
 	return ca, nil
 }
 
-func mountFolder(interfaceName string, name string, secretName string, reconcilerContext *ReconcilerContext) {
+func mountFolder(interfaceName string, name string, secretName string, opensearchHome string, reconcilerContext *ReconcilerContext) {
 	volume := corev1.Volume{Name: interfaceName + "-" + name, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: secretName}}}
 	reconcilerContext.Volumes = append(reconcilerContext.Volumes, volume)
 
 	var mountPath string
 	if name == "ca" {
-		mountPath = fmt.Sprintf("/usr/share/opensearch/config/tls-%s-ca", interfaceName)
+		mountPath = fmt.Sprintf("%s/config/tls-%s-ca", opensearchHome, interfaceName)
 	} else {
-		mountPath = fmt.Sprintf("/usr/share/opensearch/config/tls-%s", interfaceName)
+		mountPath = fmt.Sprintf("%s/config/tls-%s", opensearchHome, interfaceName)
 	}
 
 	mount := corev1.VolumeMount{Name: interfaceName + "-" + name, MountPath: mountPath}


### PR DESCRIPTION
### Description
Currently, opensearch home path ('/usr/share/opensearch') is hardcoded everywhere in the operator code. This PR adds the generic support for same.

### Issues Resolved
#1322

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
