### PR TITLE
Fix typos in user guide: version fields are strings

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -42,10 +42,10 @@ metadata:
 spec:
   general:
     serviceName: my-first-cluster
-    version: 3
+    version: "3"
   dashboards:
     enable: true
-    version: 3
+    version: "3"
     replicas: 1
     resources:
       requests:


### PR DESCRIPTION
### Description

This change fixes two typos in the example `OpenSearchCluster` resource in the user guide. The two `version` fields were set to the integer value `3` while the type of the field is in-fact string.

### Issues Resolved

It was simpler to create a PR than an Issue for this trivial fix.

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
