### PR TITLE
Abstract static-hardcoded paths to general config

### DIFF
--- a/opensearch-operator/api/opensearch.org/v1/opensearch_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearch_types.go
@@ -516,11 +516,63 @@ func (g GeneralConfig) GetOpenSearchHome() string {
 	return DefaultOpenSearchHome
 }
 
+func (g GeneralConfig) DataPath() string {
+	return g.GetOpenSearchHome() + "/data"
+}
+
+func (g GeneralConfig) ConfigYmlPath() string {
+	return g.GetOpenSearchHome() + "/config/opensearch.yml"
+}
+
+func (g GeneralConfig) KeystoreFilePath() string {
+	return g.GetOpenSearchHome() + "/config/opensearch.keystore"
+}
+
+func (g GeneralConfig) KeystoreBinPath() string {
+	return g.GetOpenSearchHome() + "/bin/opensearch-keystore"
+}
+
+func (g GeneralConfig) TLSPath(interfaceName string) string {
+	return g.GetOpenSearchHome() + "/config/tls-" + interfaceName
+}
+
+func (g GeneralConfig) TLSCaPath(interfaceName string) string {
+	return g.GetOpenSearchHome() + "/config/tls-" + interfaceName + "-ca"
+}
+
+func (g GeneralConfig) SecurityConfigV2Path() string {
+	return g.GetOpenSearchHome() + "/config/opensearch-security"
+}
+
+func (g GeneralConfig) SecurityConfigV1Path() string {
+	return g.GetOpenSearchHome() + "/plugins/opensearch-security/securityconfig"
+}
+
+func (g GeneralConfig) SecurityAdminPath() string {
+	return g.GetOpenSearchHome() + "/plugins/opensearch-security/tools/securityadmin.sh"
+}
+
 func (d DashboardsConfig) GetOpenSearchDashboardsHome() string {
 	if d.OpenSearchDashboardsHome != "" {
 		return strings.TrimRight(d.OpenSearchDashboardsHome, "/")
 	}
 	return DefaultOpenSearchDashboardsHome
+}
+
+func (d DashboardsConfig) ConfigFilePath() string {
+	return d.GetOpenSearchDashboardsHome() + "/config/opensearch_dashboards.yml"
+}
+
+func (d DashboardsConfig) CertsPath() string {
+	return d.GetOpenSearchDashboardsHome() + "/certs"
+}
+
+func (d DashboardsConfig) TLSKeyPath() string {
+	return d.GetOpenSearchDashboardsHome() + "/certs/tls.key"
+}
+
+func (d DashboardsConfig) TLSCertPath() string {
+	return d.GetOpenSearchDashboardsHome() + "/certs/tls.crt"
 }
 
 func (s ImageSpec) GetImagePullPolicy() (_ corev1.PullPolicy) {

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -478,11 +478,63 @@ func (g GeneralConfig) GetOpenSearchHome() string {
 	return DefaultOpenSearchHome
 }
 
+func (g GeneralConfig) DataPath() string {
+	return g.GetOpenSearchHome() + "/data"
+}
+
+func (g GeneralConfig) ConfigYmlPath() string {
+	return g.GetOpenSearchHome() + "/config/opensearch.yml"
+}
+
+func (g GeneralConfig) KeystoreFilePath() string {
+	return g.GetOpenSearchHome() + "/config/opensearch.keystore"
+}
+
+func (g GeneralConfig) KeystoreBinPath() string {
+	return g.GetOpenSearchHome() + "/bin/opensearch-keystore"
+}
+
+func (g GeneralConfig) TLSPath(interfaceName string) string {
+	return g.GetOpenSearchHome() + "/config/tls-" + interfaceName
+}
+
+func (g GeneralConfig) TLSCaPath(interfaceName string) string {
+	return g.GetOpenSearchHome() + "/config/tls-" + interfaceName + "-ca"
+}
+
+func (g GeneralConfig) SecurityConfigV2Path() string {
+	return g.GetOpenSearchHome() + "/config/opensearch-security"
+}
+
+func (g GeneralConfig) SecurityConfigV1Path() string {
+	return g.GetOpenSearchHome() + "/plugins/opensearch-security/securityconfig"
+}
+
+func (g GeneralConfig) SecurityAdminPath() string {
+	return g.GetOpenSearchHome() + "/plugins/opensearch-security/tools/securityadmin.sh"
+}
+
 func (d DashboardsConfig) GetOpenSearchDashboardsHome() string {
 	if d.OpenSearchDashboardsHome != "" {
 		return strings.TrimRight(d.OpenSearchDashboardsHome, "/")
 	}
 	return DefaultOpenSearchDashboardsHome
+}
+
+func (d DashboardsConfig) ConfigFilePath() string {
+	return d.GetOpenSearchDashboardsHome() + "/config/opensearch_dashboards.yml"
+}
+
+func (d DashboardsConfig) CertsPath() string {
+	return d.GetOpenSearchDashboardsHome() + "/certs"
+}
+
+func (d DashboardsConfig) TLSKeyPath() string {
+	return d.GetOpenSearchDashboardsHome() + "/certs/tls.key"
+}
+
+func (d DashboardsConfig) TLSCertPath() string {
+	return d.GetOpenSearchDashboardsHome() + "/certs/tls.crt"
 }
 
 func (s ImageSpec) GetImagePullPolicy() (_ corev1.PullPolicy) {

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -164,10 +164,10 @@ func NewSTSForNodePool(
 		}
 	}
 
-	opensearchHome := cr.Spec.General.GetOpenSearchHome()
+	general := cr.Spec.General
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
 		Name:      "data",
-		MountPath: opensearchHome + "/data",
+		MountPath: general.DataPath(),
 	})
 
 	labels := map[string]string{
@@ -418,14 +418,14 @@ func NewSTSForNodePool(
 			ImagePullPolicy: initHelperImage.GetImagePullPolicy(),
 			Resources:       resources,
 			Command:         []string{"sh", "-c"},
-			Args:            []string{helpers.GetChownCommand(uid, gid, opensearchHome+"/data")},
+			Args:            []string{helpers.GetChownCommand(uid, gid, general.DataPath())},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser: &runas,
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "data",
-					MountPath: opensearchHome + "/data",
+					MountPath: general.DataPath(),
 				},
 			},
 		})
@@ -444,7 +444,7 @@ func NewSTSForNodePool(
 
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "keystore",
-			MountPath: opensearchHome + "/config/opensearch.keystore",
+			MountPath: general.KeystoreFilePath(),
 			SubPath:   "opensearch.keystore",
 		})
 
@@ -496,23 +496,23 @@ func NewSTSForNodePool(
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				if [ ! -f %[1]s/config/opensearch.keystore ]; then
-				  %[1]s/bin/opensearch-keystore create
+				if [ ! -f %[1]s ]; then
+				  %[2]s create
 				fi
 				for i in /tmp/keystoreSecrets/*/*; do
 				  key=$(basename $i)
 				  echo "Adding file $i to keystore key $key"
-				  %[1]s/bin/opensearch-keystore add-file "$key" "$i" --force
+				  %[2]s add-file "$key" "$i" --force
 				done
 
 				# Add the bootstrap password since otherwise the opensearch entrypoint tries to do this on startup
 				if [ ! -z ${PASSWORD+x} ]; then
 				  echo 'Adding env $PASSWORD to keystore as key bootstrap.password'
-				  echo "$PASSWORD" | %[1]s/bin/opensearch-keystore add -x bootstrap.password
+				  echo "$PASSWORD" | %[2]s add -x bootstrap.password
 				fi
 
-				cp -a %[1]s/config/opensearch.keystore /tmp/keystore/
-				`, opensearchHome),
+				cp -a %[1]s /tmp/keystore/
+				`, general.KeystoreFilePath(), general.KeystoreBinPath()),
 			},
 			VolumeMounts:    initContainerVolumeMounts,
 			SecurityContext: securityContext,
@@ -934,10 +934,10 @@ func NewBootstrapPod(
 		},
 	})
 
-	opensearchHome := cr.Spec.General.GetOpenSearchHome()
+	general := cr.Spec.General
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
 		Name:      "data",
-		MountPath: opensearchHome + "/data",
+		MountPath: general.DataPath(),
 	})
 
 	podSecurityContext := cr.Spec.General.PodSecurityContext
@@ -1010,14 +1010,14 @@ func NewBootstrapPod(
 			ImagePullPolicy: initHelperImage.GetImagePullPolicy(),
 			Resources:       cr.Spec.InitHelper.Resources,
 			Command:         []string{"sh", "-c"},
-			Args:            []string{helpers.GetChownCommand(uid, gid, opensearchHome+"/data")},
+			Args:            []string{helpers.GetChownCommand(uid, gid, general.DataPath())},
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser: ptr.To(int64(0)),
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "data",
-					MountPath: opensearchHome + "/data",
+					MountPath: general.DataPath(),
 				},
 			},
 		})
@@ -1036,7 +1036,7 @@ func NewBootstrapPod(
 
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "keystore",
-			MountPath: opensearchHome + "/config/opensearch.keystore",
+			MountPath: general.KeystoreFilePath(),
 			SubPath:   "opensearch.keystore",
 		})
 
@@ -1088,23 +1088,23 @@ func NewBootstrapPod(
 				#!/usr/bin/env bash
 				set -euo pipefail
 
-				if [ ! -f %[1]s/config/opensearch.keystore ]; then
-				  %[1]s/bin/opensearch-keystore create
+				if [ ! -f %[1]s ]; then
+				  %[2]s create
 				fi
 				for i in /tmp/keystoreSecrets/*/*; do
 				  key=$(basename $i)
 				  echo "Adding file $i to keystore key $key"
-				  %[1]s/bin/opensearch-keystore add-file "$key" "$i" --force
+				  %[2]s add-file "$key" "$i" --force
 				done
 
 				# Add the bootstrap password since otherwise the opensearch entrypoint tries to do this on startup
 				if [ ! -z ${PASSWORD+x} ]; then
 				  echo 'Adding env $PASSWORD to keystore as key bootstrap.password'
-				  echo "$PASSWORD" | %[1]s/bin/opensearch-keystore add -x bootstrap.password
+				  echo "$PASSWORD" | %[2]s add -x bootstrap.password
 				fi
 
-				cp -a %[1]s/config/opensearch.keystore /tmp/keystore/
-				`, opensearchHome),
+				cp -a %[1]s /tmp/keystore/
+				`, general.KeystoreFilePath(), general.KeystoreBinPath()),
 			},
 			VolumeMounts:    initContainerVolumeMounts,
 			SecurityContext: securityContext,

--- a/opensearch-operator/pkg/builders/dashboards.go
+++ b/opensearch-operator/pkg/builders/dashboards.go
@@ -32,10 +32,9 @@ func NewDashboardsDeploymentForCR(cr *opensearchv1.OpenSearchCluster, volumes []
 			},
 		},
 	})
-	dashboardsHome := cr.Spec.Dashboards.GetOpenSearchDashboardsHome()
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
 		Name:      "dashboards-config",
-		MountPath: dashboardsHome + "/config/opensearch_dashboards.yml",
+		MountPath: cr.Spec.Dashboards.ConfigFilePath(),
 		SubPath:   "opensearch_dashboards.yml",
 	})
 

--- a/opensearch-operator/pkg/helpers/reconcile-helpers.go
+++ b/opensearch-operator/pkg/helpers/reconcile-helpers.go
@@ -154,13 +154,12 @@ func VersionCheck(instance *opensearchv1.OpenSearchCluster) (int32, int32, strin
 		}
 	}
 
-	opensearchHome := instance.Spec.General.GetOpenSearchHome()
 	if isVersion2OrHigher {
 		securityConfigPort = httpPort
-		securityConfigPath = opensearchHome + "/config/opensearch-security"
+		securityConfigPath = instance.Spec.General.SecurityConfigV2Path()
 	} else {
 		securityConfigPort = 9300
-		securityConfigPath = opensearchHome + "/plugins/opensearch-security/securityconfig"
+		securityConfigPath = instance.Spec.General.SecurityConfigV1Path()
 	}
 	return httpPort, securityConfigPort, securityConfigPath
 }

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -198,7 +198,7 @@ func (r *ClusterReconciler) reconcileNodeStatefulSet(nodePool opensearchv1.NodeP
 		})
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      "config",
-			MountPath: r.instance.Spec.General.GetOpenSearchHome() + "/config/opensearch.yml",
+			MountPath: r.instance.Spec.General.ConfigYmlPath(),
 			SubPath:   "opensearch.yml",
 		})
 	}

--- a/opensearch-operator/pkg/reconcilers/configuration.go
+++ b/opensearch-operator/pkg/reconcilers/configuration.go
@@ -185,7 +185,7 @@ func (r *ConfigurationReconciler) Reconcile() (ctrl.Result, error) {
 
 		mount := corev1.VolumeMount{
 			Name:      "config",
-			MountPath: r.instance.Spec.General.GetOpenSearchHome() + "/config/opensearch.yml",
+			MountPath: r.instance.Spec.General.ConfigYmlPath(),
 			SubPath:   "opensearch.yml",
 		}
 		r.reconcilerContext.VolumeMounts = append(r.reconcilerContext.VolumeMounts, mount)

--- a/opensearch-operator/pkg/reconcilers/dashboards.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards.go
@@ -178,21 +178,18 @@ func (r *DashboardsReconciler) handleTls() ([]corev1.Volume, []corev1.VolumeMoun
 		// Mount secret
 		volume := corev1.Volume{Name: "tls-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: tlsSecretName}}}
 		volumes = append(volumes, volume)
-		dashboardsHome := r.instance.Spec.Dashboards.GetOpenSearchDashboardsHome()
-		mount := corev1.VolumeMount{Name: "tls-cert", MountPath: dashboardsHome + "/certs"}
+		mount := corev1.VolumeMount{Name: "tls-cert", MountPath: r.instance.Spec.Dashboards.CertsPath()}
 		volumeMounts = append(volumeMounts, mount)
 	} else {
 		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Security", "Notice - using externally provided certificates for Dashboard Cluster")
 		volume := corev1.Volume{Name: "tls-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: tlsConfig.Secret.Name}}}
 		volumes = append(volumes, volume)
-		dashboardsHome := r.instance.Spec.Dashboards.GetOpenSearchDashboardsHome()
-		mount := corev1.VolumeMount{Name: "tls-cert", MountPath: dashboardsHome + "/certs"}
+		mount := corev1.VolumeMount{Name: "tls-cert", MountPath: r.instance.Spec.Dashboards.CertsPath()}
 		volumeMounts = append(volumeMounts, mount)
 	}
-	dashboardsHome := r.instance.Spec.Dashboards.GetOpenSearchDashboardsHome()
 	r.reconcilerContext.AddDashboardsConfig("server.ssl.enabled", "true")
-	r.reconcilerContext.AddDashboardsConfig("server.ssl.key", dashboardsHome+"/certs/tls.key")
-	r.reconcilerContext.AddDashboardsConfig("server.ssl.certificate", dashboardsHome+"/certs/tls.crt")
+	r.reconcilerContext.AddDashboardsConfig("server.ssl.key", r.instance.Spec.Dashboards.TLSKeyPath())
+	r.reconcilerContext.AddDashboardsConfig("server.ssl.certificate", r.instance.Spec.Dashboards.TLSCertPath())
 	return volumes, volumeMounts, nil
 }
 

--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -30,7 +30,7 @@ const (
 	adminKey  = "/certs/tls.key"
 	caCert    = "/certs/ca.crt"
 
-	SecurityAdminBaseCmdTmpl = `ADMIN=%s/plugins/opensearch-security/tools/securityadmin.sh;
+	SecurityAdminBaseCmdTmpl = `ADMIN=%s;
 chmod +x $ADMIN;
 until curl -k --silent https://%s:%v;
 do
@@ -197,9 +197,8 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 	// securityconfig secret was not passed, build the command to apply all yml files
 	if !r.instance.Status.Initialized || len(cmdArg) == 0 {
 		clusterHostName := BuildClusterSvcHostName(r.instance)
-		opensearchHome := r.instance.Spec.General.GetOpenSearchHome()
 		httpPort, securityConfigPort, securityconfigPath := helpers.VersionCheck(r.instance)
-		cmdArg = fmt.Sprintf(SecurityAdminBaseCmdTmpl, opensearchHome, clusterHostName, httpPort) +
+		cmdArg = fmt.Sprintf(SecurityAdminBaseCmdTmpl, r.instance.Spec.General.SecurityAdminPath(), clusterHostName, httpPort) +
 			fmt.Sprintf(ApplyAllYmlCmdTmpl, caCert, adminCert, adminKey, securityconfigPath, clusterHostName, securityConfigPort)
 	}
 
@@ -229,10 +228,9 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 // securityconfig secret. yml files which are not present in the secret are not applied/updated
 func BuildCmdArg(instance *opensearchv1.OpenSearchCluster, secret *corev1.Secret, log logr.Logger) string {
 	clusterHostName := BuildClusterSvcHostName(instance)
-	opensearchHome := instance.Spec.General.GetOpenSearchHome()
 	httpPort, securityConfigPort, securityconfigPath := helpers.VersionCheck(instance)
 
-	arg := fmt.Sprintf(SecurityAdminBaseCmdTmpl, opensearchHome, clusterHostName, httpPort)
+	arg := fmt.Sprintf(SecurityAdminBaseCmdTmpl, instance.Spec.General.SecurityAdminPath(), clusterHostName, httpPort)
 
 	// Get the list of yml files and sort them
 	// This will ensure commands are always generated in the same order

--- a/opensearch-operator/pkg/reconcilers/tls.go
+++ b/opensearch-operator/pkg/reconcilers/tls.go
@@ -436,7 +436,7 @@ func (r *TLSReconciler) handleTransportGenerate() error {
 	// Tell cluster controller to mount secrets
 	volume := corev1.Volume{Name: "transport-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: nodeSecretName}}}
 	r.reconcilerContext.Volumes = append(r.reconcilerContext.Volumes, volume)
-	mount := corev1.VolumeMount{Name: "transport-cert", MountPath: r.instance.Spec.General.GetOpenSearchHome() + "/config/tls-transport"}
+	mount := corev1.VolumeMount{Name: "transport-cert", MountPath: r.instance.Spec.General.TLSPath("transport")}
 	r.reconcilerContext.VolumeMounts = append(r.reconcilerContext.VolumeMounts, mount)
 
 	// Extend opensearch.yml
@@ -563,9 +563,9 @@ func (r *TLSReconciler) handleTransportExistingCerts() error {
 		return err
 	}
 
-	opensearchHome := r.instance.Spec.General.GetOpenSearchHome()
+	general := r.instance.Spec.General
 	if tlsConfig.PerNode {
-		mountFolder("transport", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
+		mountFolder("transport", "certs", tlsConfig.Secret.Name, general, r.reconcilerContext)
 		// Extend opensearch.yml
 		r.reconcilerContext.AddConfig("plugins.security.ssl.transport.pemcert_filepath", "tls-transport/${HOSTNAME}.crt")
 		r.reconcilerContext.AddConfig("plugins.security.ssl.transport.pemkey_filepath", "tls-transport/${HOSTNAME}.key")
@@ -575,16 +575,16 @@ func (r *TLSReconciler) handleTransportExistingCerts() error {
 		switch name := tlsConfig.CaSecret.Name; name {
 		case "":
 			// If CaSecret.Name is empty, mount Secret.Name as a directory
-			mountFolder("transport", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
+			mountFolder("transport", "certs", tlsConfig.Secret.Name, general, r.reconcilerContext)
 		case tlsConfig.Secret.Name:
 			// If CaSecret.Name is same as Secret.Name, mount only Secret.Name as a directory
-			mountFolder("transport", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
+			mountFolder("transport", "certs", tlsConfig.Secret.Name, general, r.reconcilerContext)
 		default:
 			// If CaSecret.Name is different from Secret.Name, mount both secrets as directories
 			// Mount Secret.Name as tls-transport/
-			mountFolder("transport", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
+			mountFolder("transport", "certs", tlsConfig.Secret.Name, general, r.reconcilerContext)
 			// Mount CaSecret.Name as tls-transport-ca/
-			mountFolder("transport", "ca", tlsConfig.CaSecret.Name, opensearchHome, r.reconcilerContext)
+			mountFolder("transport", "ca", tlsConfig.CaSecret.Name, general, r.reconcilerContext)
 		}
 
 		// Extend opensearch.yml with appropriate file paths based on mounting logic
@@ -683,7 +683,7 @@ func (r *TLSReconciler) handleHttp() error {
 		// Tell cluster controller to mount secrets
 		volume := corev1.Volume{Name: "http-cert", VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: nodeSecretName}}}
 		r.reconcilerContext.Volumes = append(r.reconcilerContext.Volumes, volume)
-		mount := corev1.VolumeMount{Name: "http-cert", MountPath: r.instance.Spec.General.GetOpenSearchHome() + "/config/tls-http"}
+		mount := corev1.VolumeMount{Name: "http-cert", MountPath: r.instance.Spec.General.TLSPath("http")}
 		r.reconcilerContext.VolumeMounts = append(r.reconcilerContext.VolumeMounts, mount)
 	} else {
 		if tlsConfig.Secret.Name == "" {
@@ -694,20 +694,20 @@ func (r *TLSReconciler) handleHttp() error {
 		}
 
 		// Implement new mounting logic based on CaSecret.Name configuration
-		opensearchHome := r.instance.Spec.General.GetOpenSearchHome()
+		general := r.instance.Spec.General
 		switch name := tlsConfig.CaSecret.Name; name {
 		case "":
 			// If CaSecret.Name is empty, mount Secret.Name as a directory
-			mountFolder("http", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
+			mountFolder("http", "certs", tlsConfig.Secret.Name, general, r.reconcilerContext)
 		case tlsConfig.Secret.Name:
 			// If CaSecret.Name is same as Secret.Name, mount only Secret.Name as a directory
-			mountFolder("http", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
+			mountFolder("http", "certs", tlsConfig.Secret.Name, general, r.reconcilerContext)
 		default:
 			// If CaSecret.Name is different from Secret.Name, mount both secrets as directories
 			// Mount Secret.Name as tls-http/
-			mountFolder("http", "certs", tlsConfig.Secret.Name, opensearchHome, r.reconcilerContext)
+			mountFolder("http", "certs", tlsConfig.Secret.Name, general, r.reconcilerContext)
 			// Mount CaSecret.Name as tls-http-ca/
-			mountFolder("http", "ca", tlsConfig.CaSecret.Name, opensearchHome, r.reconcilerContext)
+			mountFolder("http", "ca", tlsConfig.CaSecret.Name, general, r.reconcilerContext)
 		}
 	}
 	// Extend opensearch.yml with appropriate file paths based on mounting logic
@@ -756,15 +756,15 @@ func (r *TLSReconciler) getReferencedCaCertOrDefault(
 	return ca, nil
 }
 
-func mountFolder(interfaceName string, name string, secretName string, opensearchHome string, reconcilerContext *ReconcilerContext) {
+func mountFolder(interfaceName string, name string, secretName string, general opensearchv1.GeneralConfig, reconcilerContext *ReconcilerContext) {
 	volume := corev1.Volume{Name: interfaceName + "-" + name, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: secretName}}}
 	reconcilerContext.Volumes = append(reconcilerContext.Volumes, volume)
 
 	var mountPath string
 	if name == "ca" {
-		mountPath = fmt.Sprintf("%s/config/tls-%s-ca", opensearchHome, interfaceName)
+		mountPath = general.TLSCaPath(interfaceName)
 	} else {
-		mountPath = fmt.Sprintf("%s/config/tls-%s", opensearchHome, interfaceName)
+		mountPath = general.TLSPath(interfaceName)
 	}
 
 	mount := corev1.VolumeMount{Name: interfaceName + "-" + name, MountPath: mountPath}


### PR DESCRIPTION
### Description
Abstract directory paths in config to avoid hardcoding in multiple places and potentially avoid issues.

### Issues Resolved
#1322

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
