### PR TITLE
Add reconciler error count prometheus metric

### DIFF
--- a/opensearch-operator/controllers/opensearchController.go
+++ b/opensearch-operator/controllers/opensearchController.go
@@ -213,17 +213,21 @@ func (r *OpenSearchClusterReconciler) deleteExternalResources(ctx context.Contex
 		r.Instance,
 	)
 
-	componentReconcilers := []reconcilers.ComponentReconciler{
-		tls.DeleteResources,
-		securityconfig.DeleteResources,
-		config.DeleteResources,
-		cluster.DeleteResources,
-		dashboards.DeleteResources,
+	componentReconcilers := []reconcilers.NamedComponentReconciler{
+		{Name: tls.Name(), Func: tls.DeleteResources},
+		{Name: securityconfig.Name(), Func: securityconfig.DeleteResources},
+		{Name: config.Name(), Func: config.DeleteResources},
+		{Name: cluster.Name(), Func: cluster.DeleteResources},
+		{Name: dashboards.Name(), Func: dashboards.DeleteResources},
 	}
 	for _, rec := range componentReconcilers {
-		result, err := rec()
-		if err != nil || result.Requeue {
+		result, err := rec.Func()
+		if err != nil {
+			helpers.ReconcileErrors.WithLabelValues(r.Instance.Namespace, r.Instance.Name, rec.Name).Inc()
 			return result, err
+		}
+		if result.Requeue {
+			return result, nil
 		}
 	}
 	r.Info("Finished deleting resources")
@@ -325,21 +329,25 @@ func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context)
 		r.Instance,
 	)
 
-	componentReconcilers := []reconcilers.ComponentReconciler{
-		tls.Reconcile,
-		securityconfig.Reconcile,
-		config.Reconcile,
-		cluster.Reconcile,
-		scaler.Reconcile,
-		dashboards.Reconcile,
-		upgrade.Reconcile,
-		restart.Reconcile,
-		snapshotrepository.Reconcile,
+	componentReconcilers := []reconcilers.NamedComponentReconciler{
+		{Name: tls.Name(), Func: tls.Reconcile},
+		{Name: securityconfig.Name(), Func: securityconfig.Reconcile},
+		{Name: config.Name(), Func: config.Reconcile},
+		{Name: cluster.Name(), Func: cluster.Reconcile},
+		{Name: scaler.Name(), Func: scaler.Reconcile},
+		{Name: dashboards.Name(), Func: dashboards.Reconcile},
+		{Name: upgrade.Name(), Func: upgrade.Reconcile},
+		{Name: restart.Name(), Func: restart.Reconcile},
+		{Name: snapshotrepository.Name(), Func: snapshotrepository.Reconcile},
 	}
 	for _, rec := range componentReconcilers {
-		result, err := rec()
-		if err != nil || result.Requeue {
+		result, err := rec.Func()
+		if err != nil {
+			helpers.ReconcileErrors.WithLabelValues(r.Instance.Namespace, r.Instance.Name, rec.Name).Inc()
 			return result, err
+		}
+		if result.Requeue {
+			return result, nil
 		}
 	}
 

--- a/opensearch-operator/pkg/helpers/metrics.go
+++ b/opensearch-operator/pkg/helpers/metrics.go
@@ -42,10 +42,17 @@ var (
 		}, []string{
 			"namespace", "opensearch_cluster", "status",
 		})
+	ReconcileErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: clusterMetricsPrefix + "reconcile_error",
+			Help: "Total number of reconciliation errors.",
+		}, []string{
+			"namespace", "opensearch_cluster", "reconciler",
+		})
 )
 
 func RegisterMetrics() {
-	metrics.Registry.MustRegister(TlsCertificateDaysRemaining, ClusterInfo, ClusterHealth, ClusterShards)
+	metrics.Registry.MustRegister(TlsCertificateDaysRemaining, ClusterInfo, ClusterHealth, ClusterShards, ReconcileErrors)
 }
 
 func DeleteClusterMetrics(namespace string, clusterName string) {
@@ -53,6 +60,7 @@ func DeleteClusterMetrics(namespace string, clusterName string) {
 	ClusterInfo.Delete(prometheus.Labels{"namespace": namespace, "opensearch_cluster": clusterName})
 	ClusterHealth.Delete(prometheus.Labels{"namespace": namespace, "opensearch_cluster": clusterName})
 	ClusterShards.Delete(prometheus.Labels{"namespace": namespace, "opensearch_cluster": clusterName})
+	ReconcileErrors.DeletePartialMatch(prometheus.Labels{"namespace": namespace, "opensearch_cluster": clusterName})
 }
 
 func UpdateClusterInfo(instance *opensearchv1.OpenSearchCluster, health opensearchv1.OpenSearchHealth, healthResponse responses.ClusterHealthResponse) {

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -28,6 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const clusterReconcilerName = "cluster"
+
 type ClusterReconciler struct {
 	client            k8s.K8sClient
 	ctx               context.Context
@@ -49,7 +51,7 @@ func NewClusterReconciler(
 		client: k8s.NewK8sClient(client, ctx, append(
 			opts,
 			reconciler.WithPatchCalculateOptions(patch.IgnoreVolumeClaimTemplateTypeMetaAndStatus(), patch.IgnoreStatusFields()),
-			reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", "cluster")),
+			reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", clusterReconcilerName)),
 		)...),
 		ctx:               ctx,
 		recorder:          recorder,
@@ -58,6 +60,8 @@ func NewClusterReconciler(
 		logger:            log.FromContext(ctx),
 	}
 }
+
+func (r *ClusterReconciler) Name() string { return clusterReconcilerName }
 
 func (r *ClusterReconciler) Reconcile() (ctrl.Result, error) {
 	// lg := log.FromContext(r.ctx)

--- a/opensearch-operator/pkg/reconcilers/configuration.go
+++ b/opensearch-operator/pkg/reconcilers/configuration.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 )
 
+const configurationReconcilerName = "configuration"
+
 type ConfigurationReconciler struct {
 	client            k8s.K8sClient
 	recorder          record.EventRecorder
@@ -40,12 +42,14 @@ func NewConfigurationReconciler(
 	opts ...reconciler.ResourceReconcilerOption,
 ) *ConfigurationReconciler {
 	return &ConfigurationReconciler{
-		client:            k8s.NewK8sClient(client, ctx, append(opts, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", "configuration")))...),
+		client:            k8s.NewK8sClient(client, ctx, append(opts, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", configurationReconcilerName)))...),
 		reconcilerContext: reconcilerContext,
 		recorder:          recorder,
 		instance:          instance,
 	}
 }
+
+func (r *ConfigurationReconciler) Name() string { return configurationReconcilerName }
 
 func (r *ConfigurationReconciler) Reconcile() (ctrl.Result, error) {
 	// Check if we have any config to process

--- a/opensearch-operator/pkg/reconcilers/dashboards.go
+++ b/opensearch-operator/pkg/reconcilers/dashboards.go
@@ -21,6 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const dashboardsReconcilerName = "dashboards"
+
 type DashboardsReconciler struct {
 	client            k8s.K8sClient
 	recorder          record.EventRecorder
@@ -39,7 +41,7 @@ func NewDashboardsReconciler(
 	opts ...reconciler.ResourceReconcilerOption,
 ) *DashboardsReconciler {
 	return &DashboardsReconciler{
-		client:            k8s.NewK8sClient(client, ctx, append(opts, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", "dashboards")))...),
+		client:            k8s.NewK8sClient(client, ctx, append(opts, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", dashboardsReconcilerName)))...),
 		reconcilerContext: reconcilerContext,
 		recorder:          recorder,
 		instance:          instance,
@@ -47,6 +49,8 @@ func NewDashboardsReconciler(
 		pki:               tls.NewPKI(),
 	}
 }
+
+func (r *DashboardsReconciler) Name() string { return dashboardsReconcilerName }
 
 func (r *DashboardsReconciler) Reconcile() (ctrl.Result, error) {
 	if !r.instance.Spec.Dashboards.Enable {

--- a/opensearch-operator/pkg/reconcilers/reconcilers.go
+++ b/opensearch-operator/pkg/reconcilers/reconcilers.go
@@ -27,6 +27,11 @@ const (
 
 type ComponentReconciler func() (reconcile.Result, error)
 
+type NamedComponentReconciler struct {
+	Name string
+	Func ComponentReconciler
+}
+
 type ReconcilerOptions struct {
 	osClientTransport http.RoundTripper
 	updateStatus      *bool

--- a/opensearch-operator/pkg/reconcilers/rollingRestart.go
+++ b/opensearch-operator/pkg/reconcilers/rollingRestart.go
@@ -42,6 +42,8 @@ type candidate struct {
 	ordinal  int
 }
 
+const restartReconcilerName = "restart"
+
 type RollingRestartReconciler struct {
 	client            k8s.K8sClient
 	ctx               context.Context
@@ -61,14 +63,16 @@ func NewRollingRestartReconciler(
 	opts ...reconciler.ResourceReconcilerOption,
 ) *RollingRestartReconciler {
 	return &RollingRestartReconciler{
-		client:            k8s.NewK8sClient(client, ctx, append(opts, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", "restart")))...),
+		client:            k8s.NewK8sClient(client, ctx, append(opts, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", restartReconcilerName)))...),
 		ctx:               ctx,
 		instance:          instance,
-		logger:            log.FromContext(ctx).WithValues("reconciler", "restart"),
+		logger:            log.FromContext(ctx).WithValues("reconciler", restartReconcilerName),
 		recorder:          recorder,
 		reconcilerContext: reconcilerContext,
 	}
 }
+
+func (r *RollingRestartReconciler) Name() string { return restartReconcilerName }
 
 func (r *RollingRestartReconciler) Reconcile() (ctrl.Result, error) {
 	// We should never get to this while an upgrade is in progress

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -21,6 +21,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const scalerReconcilerName = "scaler"
+
 type ScalerReconciler struct {
 	client            k8s.K8sClient
 	ctx               context.Context
@@ -41,7 +43,7 @@ func NewScalerReconciler(
 	options := ReconcilerOptions{}
 	options.apply(opts...)
 	return &ScalerReconciler{
-		client:            k8s.NewK8sClient(client, ctx, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", "scaler"))),
+		client:            k8s.NewK8sClient(client, ctx, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", scalerReconcilerName))),
 		ctx:               ctx,
 		recorder:          recorder,
 		reconcilerContext: reconcilerContext,
@@ -49,6 +51,8 @@ func NewScalerReconciler(
 		ReconcilerOptions: options,
 	}
 }
+
+func (r *ScalerReconciler) Name() string { return scalerReconcilerName }
 
 func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 	requeue := false

--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -24,6 +24,8 @@ import (
 )
 
 const (
+	securityConfigReconcilerName = "securityconfig"
+
 	checksumAnnotation = "securityconfig/checksum"
 
 	adminCert = "/certs/tls.crt"
@@ -86,13 +88,15 @@ func NewSecurityconfigReconciler(
 	opts ...reconciler.ResourceReconcilerOption,
 ) *SecurityconfigReconciler {
 	return &SecurityconfigReconciler{
-		client:            k8s.NewK8sClient(client, ctx, append(opts, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", "securityconfig")))...),
+		client:            k8s.NewK8sClient(client, ctx, append(opts, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", securityConfigReconcilerName)))...),
 		reconcilerContext: reconcilerContext,
 		recorder:          recorder,
 		instance:          instance,
 		logger:            log.FromContext(ctx),
 	}
 }
+
+func (r *SecurityconfigReconciler) Name() string { return securityConfigReconcilerName }
 
 func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 	if !helpers.IsSecurityPluginEnabled(r.instance) {

--- a/opensearch-operator/pkg/reconcilers/snapshotrepository.go
+++ b/opensearch-operator/pkg/reconcilers/snapshotrepository.go
@@ -19,6 +19,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+const snapshotRepositoryReconcilerName = "snapshot_repository"
+
 type SnapshotRepositoryReconciler struct {
 	client k8s.K8sClient
 	ReconcilerOptions
@@ -39,14 +41,16 @@ func NewSnapshotRepositoryReconciler(
 	options := ReconcilerOptions{}
 	options.apply(opts...)
 	return &SnapshotRepositoryReconciler{
-		client:            k8s.NewK8sClient(client, ctx, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", "snapshot_repository"))),
+		client:            k8s.NewK8sClient(client, ctx, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", snapshotRepositoryReconcilerName))),
 		ReconcilerOptions: options,
 		ctx:               ctx,
 		recorder:          recorder,
 		instance:          instance,
-		logger:            log.FromContext(ctx).WithValues("reconciler", "snapshot_repository"),
+		logger:            log.FromContext(ctx).WithValues("reconciler", snapshotRepositoryReconcilerName),
 	}
 }
+
+func (r *SnapshotRepositoryReconciler) Name() string { return snapshotRepositoryReconcilerName }
 
 func (r *SnapshotRepositoryReconciler) Reconcile() (ctrl.Result, error) {
 	if len(r.instance.Spec.General.SnapshotRepositories) == 0 {

--- a/opensearch-operator/pkg/reconcilers/tls.go
+++ b/opensearch-operator/pkg/reconcilers/tls.go
@@ -33,6 +33,8 @@ import (
 type certContextType string
 
 const (
+	tlsReconcilerName = "tls"
+
 	CertContextTransport certContextType = "transport"
 	CertContextHttp      certContextType = "http"
 )
@@ -61,13 +63,15 @@ func NewTLSReconciler(
 	opts ...reconciler.ResourceReconcilerOption,
 ) *TLSReconciler {
 	return &TLSReconciler{
-		client:            k8s.NewK8sClient(client, ctx, append(opts, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", "tls")))...),
+		client:            k8s.NewK8sClient(client, ctx, append(opts, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", tlsReconcilerName)))...),
 		reconcilerContext: reconcilerContext,
 		instance:          instance,
 		logger:            log.FromContext(ctx),
 		pki:               tls.NewPKI(),
 	}
 }
+
+func (r *TLSReconciler) Name() string { return tlsReconcilerName }
 
 const (
 	CaCertKey                     = "ca.crt"

--- a/opensearch-operator/pkg/reconcilers/upgrade.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade.go
@@ -37,6 +37,8 @@ const (
 	upgradeStatusFinished   = "Finished"
 )
 
+const upgradeReconcilerName = "upgrade"
+
 type UpgradeReconciler struct {
 	client            k8s.K8sClient
 	ctx               context.Context
@@ -56,14 +58,16 @@ func NewUpgradeReconciler(
 	opts ...reconciler.ResourceReconcilerOption,
 ) *UpgradeReconciler {
 	return &UpgradeReconciler{
-		client:            k8s.NewK8sClient(client, ctx, append(opts, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", "upgrade")))...),
+		client:            k8s.NewK8sClient(client, ctx, append(opts, reconciler.WithLog(log.FromContext(ctx).WithValues("reconciler", upgradeReconcilerName)))...),
 		ctx:               ctx,
 		recorder:          recorder,
 		reconcilerContext: reconcilerContext,
 		instance:          instance,
-		logger:            log.FromContext(ctx).WithValues("reconciler", "upgrade"),
+		logger:            log.FromContext(ctx).WithValues("reconciler", upgradeReconcilerName),
 	}
 }
+
+func (r *UpgradeReconciler) Name() string { return upgradeReconcilerName }
 
 func (r *UpgradeReconciler) Reconcile() (ctrl.Result, error) {
 	// If versions are in sync do nothing


### PR DESCRIPTION
### Description
This metric can be useful for alerting on increased error count in reconcilers.

### Issues Resolved
#1335 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
