### PR TITLE
fix: fetch node name from _cat/shards api correctly

### DIFF
--- a/opensearch-operator/opensearch-gateway/services/os_data_service.go
+++ b/opensearch-operator/opensearch-gateway/services/os_data_service.go
@@ -57,18 +57,24 @@ func extractNodeName(fullNodeName string) string {
 	return trimmed
 }
 
+// hasShardsOnNodeFromResponse returns true if any shard in the response is on the given node.
+// It uses extractNodeName so that relocation format (source -> ip id target) is handled correctly.
+func hasShardsOnNodeFromResponse(response []responses.CatShardsResponse, nodeName string) bool {
+	for _, shardsData := range response {
+		if extractNodeName(shardsData.NodeName) == nodeName {
+			return true
+		}
+	}
+	return false
+}
+
 func HasShardsOnNode(service *OsClusterClient, nodeName string) (bool, error) {
 	var headers []string
 	response, err := service.CatShards(headers)
 	if err != nil {
 		return false, err
 	}
-	for _, shardsData := range response {
-		if extractNodeName(shardsData.NodeName) == nodeName {
-			return true, err
-		}
-	}
-	return false, err
+	return hasShardsOnNodeFromResponse(response, nodeName), err
 }
 
 func HasIndexPrimariesOnNode(service *OsClusterClient, nodeName string, indices []string) (bool, error) {

--- a/opensearch-operator/opensearch-gateway/services/os_data_service_test.go
+++ b/opensearch-operator/opensearch-gateway/services/os_data_service_test.go
@@ -88,3 +88,125 @@ var _ = Describe("OpensearchCLuster data service tests", func() {
 		})
 	})
 })*/
+
+import (
+	"testing"
+
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/opensearch-gateway/responses"
+)
+
+// TestExtractNodeName verifies that the source node name is correctly extracted from
+// the _cat/shards API node field, including during shard relocation when the format
+// is "sourceNode -> ip id targetNode".
+func TestExtractNodeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "plain node name",
+			input:    "opensearch-data-1",
+			expected: "opensearch-data-1",
+		},
+		{
+			name:     "shard relocation format - extracts source node",
+			input:    "opensearch-data-1 -> 172.31.233.51 4kGSHQhmRQ-83pvvBbTYow opensearch-data-8",
+			expected: "opensearch-data-1",
+		},
+		{
+			name:     "leading and trailing spaces",
+			input:    "  opensearch-data-2  ",
+			expected: "opensearch-data-2",
+		},
+		{
+			name:     "relocation format with leading space",
+			input:    "  opensearch-data-0 -> 10.0.0.1 abc123 opensearch-data-5",
+			expected: "opensearch-data-0",
+		},
+		{
+			name:     "single token",
+			input:    "node-a",
+			expected: "node-a",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractNodeName(tt.input)
+			if got != tt.expected {
+				t.Errorf("extractNodeName(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestHasShardsOnNodeFromResponse verifies that shard-to-node matching correctly uses
+// the source node name from the _cat/shards API, including during shard relocation when
+// the node field format is "sourceNode -> ip id targetNode" (fix for issue #1133).
+func TestHasShardsOnNodeFromResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		shards   []responses.CatShardsResponse
+		nodeName string
+		want     bool
+	}{
+		{
+			name:     "no shards - returns false",
+			shards:   nil,
+			nodeName: "opensearch-data-1",
+			want:     false,
+		},
+		{
+			name:     "empty shards - returns false",
+			shards:   []responses.CatShardsResponse{},
+			nodeName: "opensearch-data-1",
+			want:     false,
+		},
+		{
+			name: "plain node name match",
+			shards: []responses.CatShardsResponse{
+				{Index: "idx", Shard: "0", PrimaryOrReplica: "p", State: "STARTED", NodeName: "opensearch-data-1"},
+			},
+			nodeName: "opensearch-data-1",
+			want:     true,
+		},
+		{
+			name: "shard relocation format - match source node",
+			shards: []responses.CatShardsResponse{
+				{Index: "idx", Shard: "0", PrimaryOrReplica: "p", State: "STARTED", NodeName: "opensearch-data-1 -> 172.31.233.51 4kGSHQhmRQ-83pvvBbTYow opensearch-data-8"},
+			},
+			nodeName: "opensearch-data-1",
+			want:     true,
+		},
+		{
+			name: "shard relocation format - target node should not match when querying by name",
+			shards: []responses.CatShardsResponse{
+				{Index: "idx", Shard: "0", PrimaryOrReplica: "p", State: "STARTED", NodeName: "opensearch-data-1 -> 172.31.233.51 4kGSHQhmRQ opensearch-data-8"},
+			},
+			nodeName: "opensearch-data-8",
+			want:     false,
+		},
+		{
+			name: "multiple shards - one matches source node",
+			shards: []responses.CatShardsResponse{
+				{Index: "a", Shard: "0", PrimaryOrReplica: "p", State: "STARTED", NodeName: "other-node"},
+				{Index: "b", Shard: "0", PrimaryOrReplica: "p", State: "STARTED", NodeName: "opensearch-data-2 -> 10.0.0.1 xyz opensearch-data-9"},
+			},
+			nodeName: "opensearch-data-2",
+			want:     true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasShardsOnNodeFromResponse(tt.shards, tt.nodeName)
+			if got != tt.want {
+				t.Errorf("hasShardsOnNodeFromResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
During shard relocation, the `_cat/shards` API returns both the source and target node information within the `node` field. This change ensures that the source node name is consistently extracted and used.

**Note:** Ideally, this logic should be handled within the `os-go` library. However, the operator currently depends on an outdated client version (v1.1.0) and performs manual response serialization and deserialization. After upgrading to a newer version of the `os-go` client, we can refactor this logic into the library layer.


### Issues Resolved
fix #1133
### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
