### PR TITLE
webhook: reject duplicate node pool component names

### DIFF
--- a/opensearch-operator/webhook/opensearch_cluster_webhook.go
+++ b/opensearch-operator/webhook/opensearch_cluster_webhook.go
@@ -46,6 +46,9 @@ func (v *OpenSearchClusterValidator) SetupWithManager(mgr ctrl.Manager) error {
 
 func (v *OpenSearchClusterValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	cluster := obj.(*opensearchv1.OpenSearchCluster)
+	if err := validateNodePoolComponentUniqueness(cluster); err != nil {
+		return nil, err
+	}
 	return v.validateTlsConfig(cluster)
 }
 
@@ -57,12 +60,34 @@ func (v *OpenSearchClusterValidator) ValidateUpdate(ctx context.Context, oldObj,
 		return nil, nil
 	}
 
+	// Validate no duplicate node pool component names (component is used for K8s resource names)
+	if err := validateNodePoolComponentUniqueness(newCluster); err != nil {
+		return nil, err
+	}
+
 	// Validate storage class changes - storage class is immutable in StatefulSets
 	if err := v.validateStorageClassChanges(oldCluster, newCluster); err != nil {
 		return nil, err
 	}
 
 	return v.validateTlsConfig(newCluster)
+}
+
+// validateNodePoolComponentUniqueness ensures no two node pools share the same component name,
+// since component is used to name K8s resources (StatefulSets, Services, ConfigMaps, Secrets) per node pool.
+func validateNodePoolComponentUniqueness(cluster *opensearchv1.OpenSearchCluster) error {
+	seen := make(map[string]struct{})
+	for i := range cluster.Spec.NodePools {
+		component := cluster.Spec.NodePools[i].Component
+		if component == "" {
+			return fmt.Errorf("node pool at index %d has an empty component name", i)
+		}
+		if _, exists := seen[component]; exists {
+			return fmt.Errorf("duplicate node pool component name '%s': each node pool must have a unique component name (used for K8s resource naming)", component)
+		}
+		seen[component] = struct{}{}
+	}
+	return nil
 }
 
 func (v *OpenSearchClusterValidator) validateStorageClassChanges(oldCluster, newCluster *opensearchv1.OpenSearchCluster) error {

--- a/opensearch-operator/webhook/opensearch_cluster_webhook_test.go
+++ b/opensearch-operator/webhook/opensearch_cluster_webhook_test.go
@@ -75,6 +75,37 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 			Expect(warnings).To(BeEmpty())
 		})
 
+		It("should reject cluster with duplicate node pool component names", func() {
+			cluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "2.19.4",
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "masters",
+							Replicas:  3,
+							Roles:     []string{"master"},
+						},
+						{
+							Component: "masters",
+							Replicas:  3,
+							Roles:     []string{"data"},
+						},
+					},
+				},
+			}
+
+			warnings, err := validator.ValidateCreate(ctx, cluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("duplicate node pool component name 'masters'"))
+			Expect(warnings).To(BeEmpty())
+		})
+
 		It("should reject transport TLS enabled without generate or secret", func() {
 			enabled := true
 			cluster := &opensearchv1.OpenSearchCluster{
@@ -340,6 +371,36 @@ var _ = Describe("OpenSearchClusterValidator", func() {
 
 			warnings, err := validator.ValidateUpdate(ctx, oldCluster, newCluster)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("should reject update with duplicate node pool component names", func() {
+			oldCluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					NodePools: []opensearchv1.NodePool{
+						{Component: "masters"},
+						{Component: "data"},
+					},
+				},
+			}
+			newCluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-cluster",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					NodePools: []opensearchv1.NodePool{
+						{Component: "masters"},
+						{Component: "masters"},
+					},
+				},
+			}
+
+			warnings, err := validator.ValidateUpdate(ctx, oldCluster, newCluster)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("duplicate node pool component name 'masters'"))
 			Expect(warnings).To(BeEmpty())
 		})
 	})


### PR DESCRIPTION
### Description
fix https://github.com/opensearch-project/opensearch-k8s-operator/issues/1339

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
