### PR TITLE
fix bootstrap pod being removed before all masters are ready

### DIFF
--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -620,11 +620,19 @@ func CountRunningPodsForNodePool(k8sClient k8s.K8sClient, cr *opensearchv1.OpenS
 	numReadyPods := 0
 	for _, pod := range list.Items {
 		// If DeletionTimestamp is set the pod is terminating
-		podReady := pod.DeletionTimestamp == nil
-		// Count the pod as not ready if one of its containers is not running or not ready
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		// Pod must have container statuses (kubelet has reported); otherwise treat as not ready.
+		// This avoids counting newly created pods as ready before any container is running.
+		if len(pod.Status.ContainerStatuses) == 0 {
+			continue
+		}
+		podReady := true
 		for _, container := range pod.Status.ContainerStatuses {
 			if !container.Ready || container.State.Running == nil {
 				podReady = false
+				break
 			}
 		}
 		if podReady {


### PR DESCRIPTION
### Description
CountRunningPodsForNodePool was treating pods with no container status yet (e.g. just created) as ready because the container loop never ran. That made AllMastersReady true too early and triggered bootstrap poddeletion before the cluster had actually formed.


### Issues Resolved
partially https://github.com/opensearch-project/opensearch-k8s-operator/issues/1341

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
