### PR TITLE
fix: retry allocation exclude removal so nodes don't stay stuck

### DIFF
--- a/opensearch-operator/opensearch-gateway/services/os_data_service.go
+++ b/opensearch-operator/opensearch-gateway/services/os_data_service.go
@@ -128,6 +128,28 @@ func AppendExcludeNodeHost(service *OsClusterClient, lg logr.Logger, nodeNameToE
 	return err == nil, err
 }
 
+// GetExcludedNodeNames returns the current list of node names in cluster.routing.allocation.exclude._name.
+func GetExcludedNodeNames(service *OsClusterClient) ([]string, error) {
+	response, err := service.GetClusterSettings()
+	if err != nil {
+		return nil, err
+	}
+	val, ok := helpers.FindByPath(response.Transient, ClusterSettingsExcludeBrokenPath)
+	if !ok || val == "" {
+		return nil, nil
+	}
+	valAsString := val.(string)
+	parts := strings.Split(valAsString, ",")
+	var names []string
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			names = append(names, trimmed)
+		}
+	}
+	return names, nil
+}
+
 func RemoveExcludeNodeHost(service *OsClusterClient, lg logr.Logger, nodeNameToExclude string) (bool, error) {
 	response, err := service.GetClusterSettings()
 	if err != nil {

--- a/opensearch-operator/pkg/reconcilers/rollingRestart.go
+++ b/opensearch-operator/pkg/reconcilers/rollingRestart.go
@@ -177,6 +177,17 @@ func (r *RollingRestartReconciler) Reconcile() (ctrl.Result, error) {
 func (r *RollingRestartReconciler) globalCandidateRollingRestart() (ctrl.Result, error) {
 	r.logger.Info("Starting global candidate rolling restart")
 
+	// Clean stale allocation exclusions (e.g. node was restarted but RemoveExcludeNodeHost failed).
+	// Otherwise we never retry removing that node and the exclude list stays stuck.
+	if r.instance.Spec.General.DrainDataNodes {
+		if res, err := r.cleanStaleExclusionList(); err != nil || res.Requeue {
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			return res, nil
+		}
+	}
+
 	// Build candidate list across all node pools
 	var candidates []candidate
 
@@ -307,6 +318,11 @@ func (r *RollingRestartReconciler) globalCandidateRollingRestart() (ctrl.Result,
 	return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
 }
 
+// cleanStaleExclusionList delegates to the shared CleanStaleExclusionList.
+func (r *RollingRestartReconciler) cleanStaleExclusionList() (ctrl.Result, error) {
+	return util.CleanStaleExclusionList(r.client, r.instance, r.osClient, r.logger)
+}
+
 func parseOrdinalFromName(name string) int {
 	// expects name like <stsName>-<ordinal>
 	parts := strings.Split(name, "-")
@@ -374,8 +390,13 @@ func (r *RollingRestartReconciler) restartSpecificPod(cand interface{}) (ctrl.Re
 	}
 
 	if r.instance.Spec.General.DrainDataNodes {
-		_, err = services.RemoveExcludeNodeHost(r.osClient, r.logger, c.podName)
-		return ctrl.Result{}, err
+		ok, err := services.RemoveExcludeNodeHost(r.osClient, r.logger, c.podName)
+		if err != nil || !ok {
+			// If we fail to clean up the exclude list, log and requeue so we don't
+			// leave nodes permanently excluded and block subsequent restarts.
+			r.logger.Error(err, "Failed to remove allocation exclusion, will retry", "pod", c.podName)
+			return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+		}
 	}
 	return ctrl.Result{}, nil
 }

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -58,6 +58,19 @@ func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 	requeue := false
 	results := &reconciler.CombinedResult{}
 	var err error
+
+	// Clean stale allocation exclusions (e.g. from a failed RemoveExcludeNodeHost after scale-down or upgrade).
+	if r.instance.Spec.ConfMgmt.SmartScaler {
+		clusterClient, clientErr := util.CreateClientForCluster(r.client, r.ctx, r.instance, r.osClientTransport)
+		if clientErr == nil {
+			if res, cleanupErr := util.CleanStaleExclusionList(r.client, r.instance, clusterClient, log.FromContext(r.ctx)); cleanupErr != nil {
+				return ctrl.Result{}, cleanupErr
+			} else if res.Requeue {
+				return res, nil
+			}
+		}
+	}
+
 	for _, nodePool := range r.instance.Spec.NodePools {
 		requeue, err = r.reconcileNodePool(&nodePool)
 		if err != nil {

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -60,7 +60,9 @@ func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 	var err error
 
 	// Clean stale allocation exclusions (e.g. from a failed RemoveExcludeNodeHost after scale-down or upgrade).
-	if r.instance.Spec.ConfMgmt.SmartScaler {
+	// Skip cleanup when we are in the middle of a scale-down (Excluded or Drained), otherwise we would remove
+	// the node from the exclude list before drain completes and the scale-down would get stuck.
+	if r.instance.Spec.ConfMgmt.SmartScaler && !r.scalerHasExcludeOrDrainInProgress() {
 		clusterClient, clientErr := util.CreateClientForCluster(r.client, r.ctx, r.instance, r.osClientTransport)
 		if clientErr == nil {
 			if res, cleanupErr := util.CleanStaleExclusionList(r.client, r.instance, clusterClient, log.FromContext(r.ctx)); cleanupErr != nil {
@@ -92,6 +94,21 @@ func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 	}
 
 	return results.Result, results.Err
+}
+
+// scalerHasExcludeOrDrainInProgress returns true if any node pool is in Excluded or Drained state,
+// i.e. we are in the middle of a scale-down and should not run CleanStaleExclusionList (would remove
+// the node we are draining from the exclude list and break the flow).
+func (r *ScalerReconciler) scalerHasExcludeOrDrainInProgress() bool {
+	for _, cs := range r.instance.Status.ComponentsStatus {
+		if cs.Component != "Scaler" {
+			continue
+		}
+		if cs.Status == "Excluded" || cs.Status == "Drained" {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *ScalerReconciler) reconcileNodePool(nodePool *opensearchv1.NodePool) (bool, error) {

--- a/opensearch-operator/pkg/reconcilers/upgrade.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade.go
@@ -118,6 +118,16 @@ func (r *UpgradeReconciler) Reconcile() (ctrl.Result, error) {
 		return ctrl.Result{}, err
 	}
 
+	// Clean stale allocation exclusions so a previously failed RemoveExcludeNodeHost (e.g. after DeletePod) gets retried.
+	if r.instance.Spec.General.DrainDataNodes {
+		if res, err := util.CleanStaleExclusionList(r.client, r.instance, r.osClient, r.logger); err != nil || res.Requeue {
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			return res, nil
+		}
+	}
+
 	// Start the nodepool upgrade loop
 
 	// Fetch the working nodepool

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/opensearch-gateway/responses"
 	"k8s.io/utils/ptr"
@@ -410,4 +411,65 @@ func isDefaultNodeLifecycleToleration(t corev1.Toleration) bool {
 	}
 
 	return t.Key == "node.kubernetes.io/not-ready" || t.Key == "node.kubernetes.io/unreachable"
+}
+
+// CleanStaleExclusionList removes from the cluster exclude list any node whose pod has already
+// been restarted (updated revision) or no longer exists. Call this when DrainDataNodes or
+// SmartScaler use the exclude list, so that a failed RemoveExcludeNodeHost (e.g. connection
+// refused after DeletePod) gets retried and does not leave nodes permanently excluded.
+func CleanStaleExclusionList(k8sClient k8s.K8sClient, instance *opensearchv1.OpenSearchCluster, osClient *services.OsClusterClient, logger logr.Logger) (ctrl.Result, error) {
+	excluded, err := services.GetExcludedNodeNames(osClient)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if len(excluded) == 0 {
+		return ctrl.Result{}, nil
+	}
+	for _, name := range excluded {
+		stale, err := isPodStale(k8sClient, instance, name)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if !stale {
+			continue
+		}
+		logger.Info("Removing stale allocation exclusion (pod already restarted or gone)", "node", name)
+		ok, err := services.RemoveExcludeNodeHost(osClient, logger, name)
+		if err != nil || !ok {
+			logger.Error(err, "Failed to remove stale exclusion, will retry", "node", name)
+			return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, nil
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+// isPodStale returns true if the named pod should no longer be in the exclude list:
+// the pod does not exist, or it belongs to our cluster and has the updated revision (already restarted).
+func isPodStale(k8sClient k8s.K8sClient, instance *opensearchv1.OpenSearchCluster, podName string) (bool, error) {
+	pod, err := k8sClient.GetPod(podName, instance.Namespace)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	for i := range instance.Spec.NodePools {
+		np := instance.Spec.NodePools[i]
+		sts, err := k8sClient.GetStatefulSet(builders.StsName(instance, &np), instance.Namespace)
+		if err != nil {
+			return false, err
+		}
+		replicas := ptr.Deref(sts.Spec.Replicas, 1)
+		for ord := int32(0); ord < replicas; ord++ {
+			if helpers.ReplicaHostName(sts, ord) != podName {
+				continue
+			}
+			rev, ok := pod.Labels["controller-revision-hash"]
+			if !ok {
+				return false, fmt.Errorf("pod %s has no controller-revision-hash label", podName)
+			}
+			return rev == sts.Status.UpdateRevision, nil
+		}
+	}
+	return true, nil
 }

--- a/opensearch-operator/pkg/reconcilers/util/util_test.go
+++ b/opensearch-operator/pkg/reconcilers/util/util_test.go
@@ -7,7 +7,12 @@ import (
 	. "github.com/onsi/gomega"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("Additional volumes", func() {
@@ -324,6 +329,130 @@ var _ = Describe("OpensearchClusterURL", func() {
 			Expect(url).To(ContainSubstring("test-service"))
 			Expect(url).To(ContainSubstring("test-namespace"))
 			Expect(url).To(ContainSubstring(":9200"))
+		})
+	})
+})
+
+var _ = Describe("isPodStale", func() {
+	const ns = "default"
+	instance := &opensearchv1.OpenSearchCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: ns},
+		Spec: opensearchv1.ClusterSpec{
+			NodePools: []opensearchv1.NodePool{
+				{Component: "masters", Replicas: 3},
+			},
+		},
+	}
+	stsName := "cluster-masters"
+	replicas := int32(3)
+	updateRev := "rev-123"
+
+	When("pod is not found", func() {
+		It("returns true (stale)", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			mockClient.EXPECT().GetPod("cluster-masters-0", ns).
+				Return(v1.Pod{}, k8serrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "cluster-masters-0"))
+
+			stale, err := isPodStale(mockClient, instance, "cluster-masters-0")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stale).To(BeTrue())
+		})
+	})
+
+	When("pod exists and has updated revision", func() {
+		It("returns true (stale)", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			pod := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-masters-0",
+					Namespace: ns,
+					Labels:    map[string]string{"controller-revision-hash": updateRev},
+				},
+			}
+			sts := appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: stsName, Namespace: ns},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(replicas)},
+				Status:     appsv1.StatefulSetStatus{UpdateRevision: updateRev},
+			}
+			mockClient.EXPECT().GetPod("cluster-masters-0", ns).Return(pod, nil)
+			mockClient.EXPECT().GetStatefulSet(stsName, ns).Return(sts, nil)
+
+			stale, err := isPodStale(mockClient, instance, "cluster-masters-0")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stale).To(BeTrue())
+		})
+	})
+
+	When("pod exists and has old revision", func() {
+		It("returns false (not stale)", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			pod := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-masters-0",
+					Namespace: ns,
+					Labels:    map[string]string{"controller-revision-hash": "old-rev"},
+				},
+			}
+			sts := appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: stsName, Namespace: ns},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(replicas)},
+				Status:     appsv1.StatefulSetStatus{UpdateRevision: updateRev},
+			}
+			mockClient.EXPECT().GetPod("cluster-masters-0", ns).Return(pod, nil)
+			mockClient.EXPECT().GetStatefulSet(stsName, ns).Return(sts, nil)
+
+			stale, err := isPodStale(mockClient, instance, "cluster-masters-0")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stale).To(BeFalse())
+		})
+	})
+
+	When("pod has no controller-revision-hash label", func() {
+		It("returns error", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			pod := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-masters-0",
+					Namespace: ns,
+					Labels:    map[string]string{},
+				},
+			}
+			sts := appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: stsName, Namespace: ns},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(replicas)},
+				Status:     appsv1.StatefulSetStatus{UpdateRevision: updateRev},
+			}
+			mockClient.EXPECT().GetPod("cluster-masters-0", ns).Return(pod, nil)
+			mockClient.EXPECT().GetStatefulSet(stsName, ns).Return(sts, nil)
+
+			stale, err := isPodStale(mockClient, instance, "cluster-masters-0")
+			Expect(err).To(HaveOccurred())
+			Expect(stale).To(BeFalse())
+			Expect(err.Error()).To(ContainSubstring("controller-revision-hash"))
+		})
+	})
+
+	When("pod does not belong to any node pool STS", func() {
+		It("returns true (stale)", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			pod := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-pod-0",
+					Namespace: ns,
+					Labels:    map[string]string{"controller-revision-hash": "some-rev"},
+				},
+			}
+			sts := appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: stsName, Namespace: ns},
+				Spec:       appsv1.StatefulSetSpec{Replicas: ptr.To(replicas)},
+				Status:     appsv1.StatefulSetStatus{UpdateRevision: updateRev},
+			}
+			mockClient.EXPECT().GetPod("other-pod-0", ns).Return(pod, nil)
+			mockClient.EXPECT().GetStatefulSet(stsName, ns).Return(sts, nil)
+
+			stale, err := isPodStale(mockClient, instance, "other-pod-0")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stale).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
### Description
When drainDataNodes or smartScaler is used, the operator adds nodes to `cluster.routing.allocation.exclude._name` before deleting a pod, then calls RemoveExcludeNodeHost after the delete. If that call fails transiently (e.g. connection refused right after the pod is gone), the operator never retried for that node, so it stayed excluded and could block rolling restart or leave the cluster in a bad state.

This PR cleans the stale exclusion list at the start of rolling restart, upgrade, and scaler (when using drain/SmartScaler), remove from the exclude list any node whose pod is already restarted (updated revision) or no longer exists, so previously failed cleanup is retried on the next reconcile.

### Issues Resolved
fix https://github.com/opensearch-project/opensearch-k8s-operator/issues/1355

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
