### PR TITLE
docs: Fix DrainDataNodes typo notes --> nodes

### DIFF
--- a/charts/opensearch-cluster/README.md
+++ b/charts/opensearch-cluster/README.md
@@ -19,7 +19,7 @@ The following table lists the configurable parameters of the Helm chart.
 | `cluster.labels` | object | `{}` | cluster labels |
 | `cluster.general.additionalConfig` | object | `{}` | Extra items to add to the opensearch.yml |
 | `cluster.general.additionalVolumes` | list | `[]` | Additional volumes to mount to all pods in the cluster. Supported volume types configMap, emptyDir, secret (with default Kubernetes configuration schema) |
-| `cluster.general.drainDataNodes` | bool | `true` | Controls whether to drain data notes on rolling restart operations |
+| `cluster.general.drainDataNodes` | bool | `true` | Controls whether to drain data nodes on rolling restart operations |
 | `cluster.general.httpPort` | int | `9200` | Opensearch service http port |
 | `cluster.general.image` | string | `"docker.io/opensearchproject/opensearch"` | Opensearch image |
 | `cluster.general.imagePullPolicy` | string | `"IfNotPresent"` | Default image pull policy |

--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -41,7 +41,7 @@ cluster:
       ## Whether to restart the pods on content change
       #   restartPods: false
 
-    # -- Controls whether to drain data notes on rolling restart operations
+    # -- Controls whether to drain data nodes on rolling restart operations
     drainDataNodes: true
 
     # -- Opensearch service http port

--- a/charts/opensearch-operator/Chart.yaml
+++ b/charts/opensearch-operator/Chart.yaml
@@ -6,5 +6,5 @@ sources:
   - https://github.com/opensearch-project/OpenSearch
   - https://github.com/opensearch-project/opensearch-k8s-operator
 type: application
-version: 3.0.1
+version: 3.0.2
 appVersion: 3.0.0-alpha

--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -4441,7 +4441,7 @@ spec:
                   defaultRepo:
                     type: string
                   drainDataNodes:
-                    description: Drain data nodes controls whether to drain data notes
+                    description: Drain data nodes controls whether to drain data nodes
                       on rolling restart operations
                     type: boolean
                   hostAliases:
@@ -4463,6 +4463,10 @@ spec:
                       - ip
                       type: object
                     type: array
+                  hostNetwork:
+                    description: HostNetwork enables host networking for all pods
+                      in the cluster.
+                    type: boolean
                   httpPort:
                     default: 9200
                     format: int32

--- a/charts/opensearch-operator/files/opensearch.org_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchclusters.yaml
@@ -4481,7 +4481,7 @@ spec:
                   defaultRepo:
                     type: string
                   drainDataNodes:
-                    description: Drain data nodes controls whether to drain data notes
+                    description: Drain data nodes controls whether to drain data nodes
                       on rolling restart operations
                     type: boolean
                   grpc:

--- a/docs/designs/crd.md
+++ b/docs/designs/crd.md
@@ -506,7 +506,7 @@ _Appears in:_
 | `hostNetwork` _boolean_ | HostNetwork enables host networking for all pods in the cluster. |  |  |
 | `additionalConfig` _object (keys:string, values:string)_ | Extra items to add to the opensearch.yml |  |  |
 | `annotations` _object (keys:string, values:string)_ | Adds support for annotations in services |  |  |
-| `drainDataNodes` _boolean_ | Drain data nodes controls whether to drain data notes on rolling restart operations |  |  |
+| `drainDataNodes` _boolean_ | Drain data nodes controls whether to drain data nodes on rolling restart operations |  |  |
 | `pluginsList` _string array_ |  |  |  |
 | `command` _string_ |  |  |  |
 | `additionalVolumes` _[AdditionalVolume](#additionalvolume) array_ | Additional volumes to mount to all pods in the cluster |  |  |
@@ -2276,7 +2276,7 @@ _Appears in:_
 | `defaultRepo` _string_ |  |  |  |
 | `additionalConfig` _object (keys:string, values:string)_ | Extra items to add to the opensearch.yml |  |  |
 | `annotations` _object (keys:string, values:string)_ | Adds support for annotations in services |  |  |
-| `drainDataNodes` _boolean_ | Drain data nodes controls whether to drain data notes on rolling restart operations |  |  |
+| `drainDataNodes` _boolean_ | Drain data nodes controls whether to drain data nodes on rolling restart operations |  |  |
 | `pluginsList` _string array_ |  |  |  |
 | `command` _string_ |  |  |  |
 | `additionalVolumes` _[AdditionalVolume](#additionalvolume) array_ | Additional volumes to mount to all pods in the cluster |  |  |

--- a/opensearch-operator/api/opensearch.org/v1/opensearch_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearch_types.go
@@ -61,7 +61,7 @@ type GeneralConfig struct {
 	AdditionalConfig map[string]string `json:"additionalConfig,omitempty"`
 	// Adds support for annotations in services
 	Annotations map[string]string `json:"annotations,omitempty"`
-	// Drain data nodes controls whether to drain data notes on rolling restart operations
+	// Drain data nodes controls whether to drain data nodes on rolling restart operations
 	DrainDataNodes bool     `json:"drainDataNodes,omitempty"`
 	PluginsList    []string `json:"pluginsList,omitempty"`
 	Command        string   `json:"command,omitempty"`

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -63,7 +63,7 @@ type GeneralConfig struct {
 	AdditionalConfig map[string]string `json:"additionalConfig,omitempty"`
 	// Adds support for annotations in services
 	Annotations map[string]string `json:"annotations,omitempty"`
-	// Drain data nodes controls whether to drain data notes on rolling restart operations
+	// Drain data nodes controls whether to drain data nodes on rolling restart operations
 	DrainDataNodes bool     `json:"drainDataNodes,omitempty"`
 	PluginsList    []string `json:"pluginsList,omitempty"`
 	Command        string   `json:"command,omitempty"`

--- a/opensearch-operator/bundle/manifests/opensearch.org_opensearchclusters.yaml
+++ b/opensearch-operator/bundle/manifests/opensearch.org_opensearchclusters.yaml
@@ -4474,7 +4474,7 @@ spec:
                   defaultRepo:
                     type: string
                   drainDataNodes:
-                    description: Drain data nodes controls whether to drain data notes
+                    description: Drain data nodes controls whether to drain data nodes
                       on rolling restart operations
                     type: boolean
                   grpc:

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -4441,7 +4441,7 @@ spec:
                   defaultRepo:
                     type: string
                   drainDataNodes:
-                    description: Drain data nodes controls whether to drain data notes
+                    description: Drain data nodes controls whether to drain data nodes
                       on rolling restart operations
                     type: boolean
                   hostAliases:

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchclusters.yaml
@@ -4481,7 +4481,7 @@ spec:
                   defaultRepo:
                     type: string
                   drainDataNodes:
-                    description: Drain data nodes controls whether to drain data notes
+                    description: Drain data nodes controls whether to drain data nodes
                       on rolling restart operations
                     type: boolean
                   grpc:


### PR DESCRIPTION
### Description

Fixes a typo in the documentation for the `opensearchclusters.opensearch.org.spec.general.drainDataNodes` field.

### Issues Resolved

None.

### Check List

- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [x] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
