### PR TITLE
remove whitelist file type from security config update

### DIFF
--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -65,7 +65,7 @@ var ymlToFileType = map[string]string{
 	"action_groups.yml":  "actiongroups",
 	"tenants.yml":        "tenants",
 	"nodes_dn.yml":       "nodesdn",
-	"whitelist.yml":      "whitelist",
+	"whitelist.yml":      "allowlist",
 	"audit.yml":          "audit",
 	"allowlist.yml":      "allowlist",
 	"config.yml":         "config",


### PR DESCRIPTION
### Description
Since opensearch 2.x, `allowlist` has been introduced instead of `whitelist`. `whitelist` has been removed from 3.x.
Opensearch operator has been supporting both `allowlist` and `whitelist` based on the config file name.
This PR removes `whitelist` file type and use `allowlist` for `whitelist.yml` file name as well to make cluster version upgrade success without manual change on config file names.

### Issues Resolved
fix https://github.com/opensearch-project/opensearch-k8s-operator/issues/1105

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
