### PR TITLE
Add ready pod status check in CountRunningPodsForNodePool func

### DIFF
--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -623,15 +623,10 @@ func CountRunningPodsForNodePool(k8sClient k8s.K8sClient, cr *opensearchv1.OpenS
 		if pod.DeletionTimestamp != nil {
 			continue
 		}
-		// Pod must have container statuses (kubelet has reported); otherwise treat as not ready.
-		// This avoids counting newly created pods as ready before any container is running.
-		if len(pod.Status.ContainerStatuses) == 0 {
-			continue
-		}
-		podReady := true
-		for _, container := range pod.Status.ContainerStatuses {
-			if !container.Ready || container.State.Running == nil {
-				podReady = false
+		podReady := false
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
+				podReady = true
 				break
 			}
 		}


### PR DESCRIPTION
### Description
CountRunningPodsForNodePool func should check pod status as 'Ready' which includes existing checks of each container status as ready plus all init containers to have exited successfully. 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
