### PR TITLE
fix: remove explicit BearerTokenFile from ServiceMonitor endpoint

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -1527,7 +1527,6 @@ func NewServiceMonitor(cr *opensearchv1.OpenSearchCluster) *monitoring.ServiceMo
 					Path:            "/_prometheus/metrics",
 					Interval:        monitoring.Duration(cr.Spec.General.Monitoring.ScrapeInterval),
 					TLSConfig:       tlsconfig,
-					BearerTokenFile: "",
 					HonorLabels:     false,
 					BasicAuth:       &user,
 					Scheme:          scheme,

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1326,6 +1326,18 @@ var _ = Describe("Builders", func() {
 			result := NewServiceMonitor(&clusterObject)
 			Expect(result.Spec.Endpoints[0].Scheme).To(Equal("http"))
 		})
+
+		It("should not set BearerTokenFile when BasicAuth is configured", func() {
+			clusterObject := ClusterDescWithVersion("2.7.0")
+			clusterObject.Name = "test-cluster"
+			clusterObject.Namespace = "default"
+			clusterObject.Spec.General.Monitoring.Enable = true
+			clusterObject.Spec.General.Monitoring.ScrapeInterval = "30s"
+
+			result := NewServiceMonitor(&clusterObject)
+			Expect(result.Spec.Endpoints[0].BasicAuth).ToNot(BeNil())
+			Expect(result.Spec.Endpoints[0].BearerTokenFile).To(BeEmpty()) //nolint:staticcheck // SA1019 intentionally testing deprecated field is not set
+		})
 	})
 
 	When("Configuring InitHelper Resources", func() {


### PR DESCRIPTION
### Description

The NewServiceMonitor() function in pkg/builders/cluster.go explicitly sets BearerTokenFile: "" on the ServiceMonitor endpoint alongside BasicAuth. When serialized and applied to the cluster, Kubernetes server-side apply can default the related bearerTokenSecret CRD field to {key: "", name: ""}. Since prometheus-operator v0.88.0, stricter validation rejects endpoints that have both basicAuth and bearerTokenSecret configured simultaneously, even when the bearer token field is effectively empty. This causes the prometheus-operator to silently skip the ServiceMonitor, resulting in all OpenSearch metrics being absent from Prometheus.

This PR removes the explicit BearerTokenFile: "" assignment. The MonitoringConfig CRD API only supports basicAuth via MonitoringUserSecret, there is no bearer token option, so this field was never functional.

### Issues Resolved

Closes #1267

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
