### PR TITLE
feat: allow custom liveness probe command for OpenSearch nodes

### DIFF
--- a/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.opster.io_opensearchclusters.yaml
@@ -6260,6 +6260,10 @@ spec:
                       properties:
                         liveness:
                           properties:
+                            command:
+                              items:
+                                type: string
+                              type: array
                             failureThreshold:
                               format: int32
                               type: integer

--- a/charts/opensearch-operator/files/opensearch.org_opensearchclusters.yaml
+++ b/charts/opensearch-operator/files/opensearch.org_opensearchclusters.yaml
@@ -6369,6 +6369,10 @@ spec:
                       properties:
                         liveness:
                           properties:
+                            command:
+                              items:
+                                type: string
+                              type: array
                             failureThreshold:
                               format: int32
                               type: integer

--- a/docs/designs/crd.md
+++ b/docs/designs/crd.md
@@ -1311,24 +1311,6 @@ _Appears in:_
 | `hostPath` _[HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#hostpathvolumesource-v1-core)_ |  |  |  |
 
 
-#### ProbeConfig
-
-
-
-
-
-
-
-_Appears in:_
-- [ProbesConfig](#probesconfig)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `initialDelaySeconds` _integer_ |  |  |  |
-| `periodSeconds` _integer_ |  |  |  |
-| `timeoutSeconds` _integer_ |  |  |  |
-| `successThreshold` _integer_ |  |  |  |
-| `failureThreshold` _integer_ |  |  |  |
 
 
 #### ProbesConfig
@@ -3111,24 +3093,6 @@ _Appears in:_
 | `hostPath` _[HostPathVolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#hostpathvolumesource-v1-core)_ |  |  |  |
 
 
-#### ProbeConfig
-
-
-
-
-
-
-
-_Appears in:_
-- [ProbesConfig](#probesconfig)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `initialDelaySeconds` _integer_ |  |  |  |
-| `periodSeconds` _integer_ |  |  |  |
-| `timeoutSeconds` _integer_ |  |  |  |
-| `successThreshold` _integer_ |  |  |  |
-| `failureThreshold` _integer_ |  |  |  |
 
 
 #### ProbesConfig
@@ -3579,4 +3543,5 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `conditions` _[Condition](#condition)_ | conditions for the transition. |  |  |
 | `stateName` _string_ | The name of the state to transition to if the conditions are met. |  |  |
+
 

--- a/docs/designs/crd.md
+++ b/docs/designs/crd.md
@@ -1344,7 +1344,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `liveness` _[ProbeConfig](#probeconfig)_ |  |  |  |
+| `liveness` _[CommandProbeConfig](#commandprobeconfig)_ |  |  |  |
 | `readiness` _[CommandProbeConfig](#commandprobeconfig)_ |  |  |  |
 | `startup` _[CommandProbeConfig](#commandprobeconfig)_ |  |  |  |
 
@@ -3144,7 +3144,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `liveness` _[ProbeConfig](#probeconfig)_ |  |  |  |
+| `liveness` _[CommandProbeConfig](#commandprobeconfig)_ |  |  |  |
 | `readiness` _[CommandProbeConfig](#commandprobeconfig)_ |  |  |  |
 | `startup` _[CommandProbeConfig](#commandprobeconfig)_ |  |  |  |
 
@@ -3579,5 +3579,4 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `conditions` _[Condition](#condition)_ | conditions for the transition. |  |  |
 | `stateName` _string_ | The name of the state to transition to if the conditions are met. |  |  |
-
 

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -1237,11 +1237,11 @@ spec:
           failureThreshold: 5
 ```
 
-### Customize startup and readiness probe command
+### Customize startup, readiness and liveness probe command
 
-While liveness probe is a TCP check the startup and readiness probes use the OpenSearch API with curl.
+By default, the liveness probe is a TCP check while startup and readiness use the OpenSearch API with curl.
 
-If you need to customize the startup or readiness probe commands you can override it as shown below:
+If you need to customize the startup, readiness or liveness probe commands you can override them as shown below:
 
 ```yaml
 apiVersion: opensearch.org/v1
@@ -1252,6 +1252,11 @@ spec:
     - component: masters
       ...
       probes:
+        liveness:
+          command:
+            - /bin/bash
+            - -c
+            - curl -k -s -o /dev/null https://localhost:9200
         startup:
           command:
             - echo

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -1243,11 +1243,11 @@ spec:
           failureThreshold: 5
 ```
 
-### Customize startup and readiness probe command
+### Customize startup, readiness and liveness probe command
 
-While liveness probe is a TCP check the startup and readiness probes use the OpenSearch API with curl.
+By default, the liveness probe is a TCP check while startup and readiness use the OpenSearch API with curl.
 
-If you need to customize the startup or readiness probe commands you can override it as shown below:
+If you need to customize the startup, readiness or liveness probe commands you can override them as shown below:
 
 ```yaml
 apiVersion: opensearch.org/v1
@@ -1258,6 +1258,11 @@ spec:
     - component: masters
       ...
       probes:
+        liveness:
+          command:
+            - /bin/bash
+            - -c
+            - curl -k -s -o /dev/null https://localhost:9200
         startup:
           command:
             - echo

--- a/opensearch-operator/api/opensearch.org/v1/opensearch_types.go
+++ b/opensearch-operator/api/opensearch.org/v1/opensearch_types.go
@@ -100,7 +100,7 @@ type InitHelperConfig struct {
 }
 
 type ProbesConfig struct {
-	Liveness  *ProbeConfig        `json:"liveness,omitempty"`
+	Liveness  *CommandProbeConfig `json:"liveness,omitempty"`
 	Readiness *CommandProbeConfig `json:"readiness,omitempty"`
 	Startup   *CommandProbeConfig `json:"startup,omitempty"`
 }

--- a/opensearch-operator/api/opensearch.org/v1/zz_generated.deepcopy.go
+++ b/opensearch-operator/api/opensearch.org/v1/zz_generated.deepcopy.go
@@ -2713,8 +2713,8 @@ func (in *ProbesConfig) DeepCopyInto(out *ProbesConfig) {
 	*out = *in
 	if in.Liveness != nil {
 		in, out := &in.Liveness, &out.Liveness
-		*out = new(ProbeConfig)
-		**out = **in
+		*out = new(CommandProbeConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Readiness != nil {
 		in, out := &in.Readiness, &out.Readiness

--- a/opensearch-operator/api/v1/opensearch_types.go
+++ b/opensearch-operator/api/v1/opensearch_types.go
@@ -98,7 +98,7 @@ type InitHelperConfig struct {
 }
 
 type ProbesConfig struct {
-	Liveness  *ProbeConfig        `json:"liveness,omitempty"`
+	Liveness  *CommandProbeConfig `json:"liveness,omitempty"`
 	Readiness *CommandProbeConfig `json:"readiness,omitempty"`
 	Startup   *CommandProbeConfig `json:"startup,omitempty"`
 }

--- a/opensearch-operator/api/v1/zz_generated.deepcopy.go
+++ b/opensearch-operator/api/v1/zz_generated.deepcopy.go
@@ -2648,8 +2648,8 @@ func (in *ProbesConfig) DeepCopyInto(out *ProbesConfig) {
 	*out = *in
 	if in.Liveness != nil {
 		in, out := &in.Liveness, &out.Liveness
-		*out = new(ProbeConfig)
-		**out = **in
+		*out = new(CommandProbeConfig)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Readiness != nil {
 		in, out := &in.Readiness, &out.Readiness

--- a/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.opster.io_opensearchclusters.yaml
@@ -6264,6 +6264,10 @@ spec:
                       properties:
                         liveness:
                           properties:
+                            command:
+                              items:
+                                type: string
+                              type: array
                             failureThreshold:
                               format: int32
                               type: integer

--- a/opensearch-operator/config/crd/bases/opensearch.org_opensearchclusters.yaml
+++ b/opensearch-operator/config/crd/bases/opensearch.org_opensearchclusters.yaml
@@ -6369,6 +6369,10 @@ spec:
                       properties:
                         liveness:
                           properties:
+                            command:
+                              items:
+                                type: string
+                              type: array
                             failureThreshold:
                               format: int32
                               type: integer

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -254,6 +254,11 @@ func NewSTSForNodePool(
 	livenessProbeFailureThreshold := int32(10)
 	livenessProbeSuccessThreshold := int32(1)
 	livenessProbeInitialDelaySeconds := int32(10)
+	livenessProbeCommand := []string{
+		"/bin/bash",
+		"-c",
+		fmt.Sprintf("curl -k -s -o /dev/null '%s://localhost:%d'", probeProtocol, PortForCluster(cr)),
+	}
 
 	if node.Probes != nil {
 		if node.Probes.Liveness != nil {
@@ -275,6 +280,10 @@ func NewSTSForNodePool(
 
 			if node.Probes.Liveness.SuccessThreshold > 0 {
 				livenessProbeSuccessThreshold = node.Probes.Liveness.SuccessThreshold
+			}
+
+			if len(node.Probes.Liveness.Command) > 0 {
+				livenessProbeCommand = node.Probes.Liveness.Command
 			}
 		}
 
@@ -338,6 +347,13 @@ func NewSTSForNodePool(
 		SuccessThreshold:    livenessProbeSuccessThreshold,
 		InitialDelaySeconds: livenessProbeInitialDelaySeconds,
 		ProbeHandler:        corev1.ProbeHandler{TCPSocket: &corev1.TCPSocketAction{Port: intstr.IntOrString{IntVal: cr.Spec.General.HttpPort}}},
+	}
+	if node.Probes != nil && node.Probes.Liveness != nil && len(node.Probes.Liveness.Command) > 0 {
+		livenessProbe.ProbeHandler = corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
+				Command: livenessProbeCommand,
+			},
+		}
 	}
 
 	startupProbe := corev1.Probe{

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1243,6 +1243,10 @@ var _ = Describe("Builders", func() {
 				To(Equal([]string{"/bin/bash", "-c", "curl -k -u \"$(cat /mnt/admin-credentials/username):$(cat /mnt/admin-credentials/password)\" --silent --fail 'http://localhost:9200'"}))
 			Expect(result.Spec.Template.Spec.Containers[0].ReadinessProbe.ProbeHandler.Exec.Command).
 				To(Equal([]string{"/bin/bash", "-c", "curl -k -u \"$(cat /mnt/admin-credentials/username):$(cat /mnt/admin-credentials/password)\" --silent --fail 'http://localhost:9200'"}))
+			Expect(result.Spec.Template.Spec.Containers[0].LivenessProbe.ProbeHandler.TCPSocket).
+				NotTo(BeNil())
+			Expect(result.Spec.Template.Spec.Containers[0].LivenessProbe.ProbeHandler.Exec).
+				To(BeNil())
 		})
 
 		It("should have custom command when set", func() {
@@ -1251,6 +1255,9 @@ var _ = Describe("Builders", func() {
 				Component: "masters",
 				Roles:     []string{"search"},
 				Probes: &opensearchv1.ProbesConfig{
+					Liveness: &opensearchv1.CommandProbeConfig{
+						Command: []string{"/bin/bash", "-c", "echo 'live'"},
+					},
 					Startup: &opensearchv1.CommandProbeConfig{
 						Command: []string{"/bin/bash", "-c", "echo 'startup'"},
 					},
@@ -1260,6 +1267,8 @@ var _ = Describe("Builders", func() {
 				},
 			}
 			result := NewSTSForNodePool("foobar", &clusterObject, nodePool, "foobar", nil, nil)
+			Expect(result.Spec.Template.Spec.Containers[0].LivenessProbe.ProbeHandler.Exec.Command).
+				To(Equal([]string{"/bin/bash", "-c", "echo 'live'"}))
 			Expect(result.Spec.Template.Spec.Containers[0].StartupProbe.ProbeHandler.Exec.Command).
 				To(Equal([]string{"/bin/bash", "-c", "echo 'startup'"}))
 			Expect(result.Spec.Template.Spec.Containers[0].ReadinessProbe.ProbeHandler.Exec.Command).

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1150,7 +1150,7 @@ var _ = Describe("Builders", func() {
 				Component: "masters",
 				Roles:     []string{"search"},
 				Probes: &opensearchv1.ProbesConfig{
-					Liveness: &opensearchv1.ProbeConfig{
+					Liveness: &opensearchv1.CommandProbeConfig{
 						FailureThreshold: 15,
 					},
 					Startup: &opensearchv1.CommandProbeConfig{
@@ -1187,7 +1187,7 @@ var _ = Describe("Builders", func() {
 				Component: "masters",
 				Roles:     []string{"search"},
 				Probes: &opensearchv1.ProbesConfig{
-					Liveness: &opensearchv1.ProbeConfig{
+					Liveness: &opensearchv1.CommandProbeConfig{
 						InitialDelaySeconds: 12,
 						TimeoutSeconds:      6,
 						PeriodSeconds:       25,


### PR DESCRIPTION
### Description

This change adds support for spec.nodePools[].probes.liveness.command in the OpenSearchCluster CRD.

The current liveness behavior is preserved by default:

- if liveness.command is not set, the operator continues to render the existing tcpSocket liveness probe
- if liveness.command is set, the operator renders an exec liveness probe using the provided command

This makes liveness configurable in the same way as startup and readiness, while remaining backward-compatible for existing users.

The main motivation is TLS-enabled clusters where kubelet’s raw TCP liveness probe hits a TLS-only REST port and generates repeated TLS handshake warnings
in OpenSearch logs. With this change, users can opt into a TLS-aware liveness probe without changing default operator behavior.

Example:

```
spec:
  nodePools:
    - component: data
      probes:
        liveness:
          command:
            - /bin/bash
            - -c
            - curl -k -s -o /dev/null https://localhost:9200
```

### Issues Resolved

No existing GitHub issue was linked for this change.

### Check List

- [x] Commits are signed per the DCO using --signoff
- [x] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (make lint)

If CRDs are changed:

- [x] CRD YAMLs updated (make manifests) and also copied into the helm chart
- [x] Changes to CRDs documented

Please refer to the PR guidelines (https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before subm
itting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check here
(https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).