### PR TITLE
fix(upgrade): skip empty unsupported-cluster-settings update on 2.x u…

### DIFF
--- a/opensearch-operator/opensearch-gateway/services/os_data_service.go
+++ b/opensearch-operator/opensearch-gateway/services/os_data_service.go
@@ -727,6 +727,9 @@ func DeleteUnsupportedClusterSettings(service *OsClusterClient, newVersion strin
 	if err != nil {
 		return err
 	}
+	if len(settingsToDelete.Persistent) == 0 && len(settingsToDelete.Transient) == 0 {
+		return nil
+	}
 
 	_, err = service.PutClusterSettings(settingsToDelete)
 	return err

--- a/opensearch-operator/opensearch-gateway/services/os_data_service_test.go
+++ b/opensearch-operator/opensearch-gateway/services/os_data_service_test.go
@@ -210,3 +210,48 @@ func TestHasShardsOnNodeFromResponse(t *testing.T) {
 		})
 	}
 }
+
+func TestDetermineUnsupportedClusterSettings(t *testing.T) {
+	tests := []struct {
+		name                string
+		newVersion          string
+		wantTransientCount  int
+		wantPersistentCount int
+	}{
+		{
+			name:                "2.x upgrade has no settings to delete",
+			newVersion:          "2.19.5",
+			wantTransientCount:  0,
+			wantPersistentCount: 0,
+		},
+		{
+			name:                "3.x upgrade includes archived ISM settings",
+			newVersion:          "3.0.0",
+			wantTransientCount:  6,
+			wantPersistentCount: 6,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := DetermineUnsupportedClusterSettings(tt.newVersion)
+			if err != nil {
+				t.Fatalf("DetermineUnsupportedClusterSettings(%q) returned error: %v", tt.newVersion, err)
+			}
+
+			if got.Transient == nil {
+				t.Fatalf("Transient settings map is nil")
+			}
+			if got.Persistent == nil {
+				t.Fatalf("Persistent settings map is nil")
+			}
+
+			if len(got.Transient) != tt.wantTransientCount {
+				t.Fatalf("len(Transient) = %d, want %d", len(got.Transient), tt.wantTransientCount)
+			}
+			if len(got.Persistent) != tt.wantPersistentCount {
+				t.Fatalf("len(Persistent) = %d, want %d", len(got.Persistent), tt.wantPersistentCount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…pgrades

### Description
fix https://github.com/opensearch-project/opensearch-k8s-operator/issues/1386

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
