### PR TITLE
docs: clarify setVMMaxMapCount upgrade behavior before 3.0.0-alpha

### DIFF
--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -436,6 +436,12 @@ spec:
 
 By default the init container uses a busybox image. If you want to change that (for example to use an image from a private registry), see [Custom init helper](#custom-init-helper).
 
+> **Upgrade note:** In operator versions before `3.0.0-alpha`, `setVMMaxMapCount` was a non-pointer boolean and explicit `false` could be dropped from stored objects (because of `omitempty`). This is fixed in operator versions `3.0.0-alpha` and later, which use a pointer boolean so explicit `false` is preserved. If you upgrade from an older version and your existing `OpenSearchCluster` was created with `setVMMaxMapCount: false` but the field is now missing in `spec`, patch it explicitly:
+>
+> ```bash
+> kubectl patch opensearchcluster <name> -n <namespace> --type merge -p '{"spec":{"general":{"setVMMaxMapCount":false}}}'
+> ```
+
 ### Configuring Snapshot Repositories
 
 You can configure the snapshot repositories for the OpenSearch cluster through the operator. Using `general.snapshotRepositories` settings you can configure multiple snapshot repositories. Once the snapshot repository is configured a user can create custom `_ism` policies through dashboard to backup indexes.


### PR DESCRIPTION
### Description
This is the classic CRD bool + omitempty problem where explicit false is indistinguishable from “unset”. `spec.general.setVMMaxMapCount` has been changed to bool pointer already in 3.0.0-alpha. Btw, need the manual patch before upgrade.

### Issues Resolved
fix https://github.com/opensearch-project/opensearch-k8s-operator/issues/1378

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
