### PR TITLE
fix: correctly parse comma-separated watch namespaces

### DIFF
--- a/opensearch-operator/main.go
+++ b/opensearch-operator/main.go
@@ -58,6 +58,18 @@ var (
 	setupLog = ctrl.Log.WithName("setup")
 )
 
+func parseWatchNamespaces(watchNamespace string) map[string]cache.Config {
+	namespaces := map[string]cache.Config{}
+	for watchNs := range strings.SplitSeq(watchNamespace, ",") {
+		trimmed := strings.TrimSpace(watchNs)
+		if trimmed == "" {
+			continue
+		}
+		namespaces[trimmed] = cache.Config{}
+	}
+	return namespaces
+}
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(opsterv1.AddToScheme(scheme))
@@ -102,11 +114,9 @@ func main() {
 
 	var cacheOpts cache.Options
 	if watchNamespace != "" {
-		cacheOpts.DefaultNamespaces = map[string]cache.Config{
-			watchNamespace: {},
-		}
-		for watchNs := range strings.SplitSeq(watchNamespace, ",") {
-			cacheOpts.DefaultNamespaces[watchNs] = cache.Config{}
+		namespaces := parseWatchNamespaces(watchNamespace)
+		if len(namespaces) > 0 {
+			cacheOpts.DefaultNamespaces = namespaces
 		}
 	}
 

--- a/opensearch-operator/main_test.go
+++ b/opensearch-operator/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseWatchNamespacesSingle(t *testing.T) {
+	result := parseWatchNamespaces("namespace1")
+	if len(result) != 1 {
+		t.Fatalf("expected 1 namespace, got %d", len(result))
+	}
+	if _, ok := result["namespace1"]; !ok {
+		t.Fatalf("expected namespace1 to be present")
+	}
+}
+
+func TestParseWatchNamespacesMultiple(t *testing.T) {
+	result := parseWatchNamespaces("namespace1,namespace2")
+	if len(result) != 2 {
+		t.Fatalf("expected 2 namespaces, got %d", len(result))
+	}
+	if _, ok := result["namespace1"]; !ok {
+		t.Fatalf("expected namespace1 to be present")
+	}
+	if _, ok := result["namespace2"]; !ok {
+		t.Fatalf("expected namespace2 to be present")
+	}
+	if _, ok := result["namespace1,namespace2"]; ok {
+		t.Fatalf("did not expect unsplit namespace key to be present")
+	}
+}
+
+func TestParseWatchNamespacesTrimAndSkipEmpty(t *testing.T) {
+	result := parseWatchNamespaces(" namespace1, ,namespace2 ,")
+	if len(result) != 2 {
+		t.Fatalf("expected 2 namespaces, got %d", len(result))
+	}
+	if _, ok := result["namespace1"]; !ok {
+		t.Fatalf("expected namespace1 to be present")
+	}
+	if _, ok := result["namespace2"]; !ok {
+		t.Fatalf("expected namespace2 to be present")
+	}
+}


### PR DESCRIPTION
### Description
fix https://github.com/opensearch-project/opensearch-k8s-operator/issues/1399

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
