### PR TITLE
fix: honor tls caSecret in securityconfig-update job

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -1317,6 +1317,7 @@ func NewSecurityconfigUpdateJob(
 	namespace string,
 	checksum string,
 	adminCertName string,
+	adminCASecretName string,
 	cmdArg string,
 	volumes []corev1.Volume,
 	volumeMounts []corev1.VolumeMount,
@@ -1326,10 +1327,41 @@ func NewSecurityconfigUpdateJob(
 		Component: "securityconfig",
 	}
 
-	volumes = append(volumes, corev1.Volume{
-		Name:         "admin-cert",
-		VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: adminCertName}},
-	})
+	adminCertVolume := corev1.Volume{
+		Name: "admin-cert",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{SecretName: adminCertName},
+		},
+	}
+	if adminCASecretName != "" {
+		adminCertVolume = corev1.Volume{
+			Name: "admin-cert",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
+						{
+							Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: adminCertName},
+								Items: []corev1.KeyToPath{
+									{Key: corev1.TLSCertKey, Path: corev1.TLSCertKey},
+									{Key: corev1.TLSPrivateKeyKey, Path: corev1.TLSPrivateKeyKey},
+								},
+							},
+						},
+						{
+							Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: adminCASecretName},
+								Items: []corev1.KeyToPath{
+									{Key: "ca.crt", Path: "ca.crt"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+	volumes = append(volumes, adminCertVolume)
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
 		Name:      "admin-cert",
 		MountPath: "/certs",

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1061,7 +1061,7 @@ var _ = Describe("Builders", func() {
 			sts := NewSTSForNodePool("foobar", &clusterObject, nodePool, "foobar", nil, nil)
 			Expect(sts.Spec.Template.Spec.ServiceAccountName).To(Equal(serviceAccount))
 
-			job := NewSecurityconfigUpdateJob(&clusterObject, "foobar", "foobar", "foobar", "admin-cert", "cmd", nil, nil)
+			job := NewSecurityconfigUpdateJob(&clusterObject, "foobar", "foobar", "foobar", "admin-cert", "", "cmd", nil, nil)
 			Expect(job.Spec.Template.Spec.ServiceAccountName).To(Equal(serviceAccount))
 		})
 	})
@@ -1386,7 +1386,7 @@ var _ = Describe("Builders", func() {
 				},
 			}
 
-			job := NewSecurityconfigUpdateJob(&clusterObject, "dummy", "dummy", "dummy", "dummy", "dummy", nil, nil)
+			job := NewSecurityconfigUpdateJob(&clusterObject, "dummy", "dummy", "dummy", "dummy", "", "dummy", nil, nil)
 			Expect(job.Spec.Template.Spec.Containers[0].Resources).To(Equal(clusterObject.Spec.Security.Config.UpdateJob.Resources))
 		})
 
@@ -1404,8 +1404,22 @@ var _ = Describe("Builders", func() {
 				},
 			}
 
-			job := NewSecurityconfigUpdateJob(&clusterObject, "dummy", "dummy", "dummy", "dummy", "dummy", nil, nil)
+			job := NewSecurityconfigUpdateJob(&clusterObject, "dummy", "dummy", "dummy", "dummy", "", "dummy", nil, nil)
 			Expect(job.Spec.Template.Spec.Containers[0].Resources).To(Equal(clusterObject.Spec.Security.Config.UpdateJob.Resources))
+		})
+
+		It("should project CA cert into admin-cert mount when configured separately", func() {
+			clusterObject := ClusterDescWithVersion("2.2.1")
+			job := NewSecurityconfigUpdateJob(&clusterObject, "dummy", "dummy", "dummy", "admin-cert", "http-ca", "dummy", nil, nil)
+
+			adminVolume := job.Spec.Template.Spec.Volumes[0]
+			Expect(adminVolume.Name).To(Equal("admin-cert"))
+			Expect(adminVolume.Projected).ToNot(BeNil())
+			Expect(adminVolume.Projected.Sources).To(HaveLen(2))
+			Expect(adminVolume.Projected.Sources[0].Secret).ToNot(BeNil())
+			Expect(adminVolume.Projected.Sources[0].Secret.Name).To(Equal("admin-cert"))
+			Expect(adminVolume.Projected.Sources[1].Secret).ToNot(BeNil())
+			Expect(adminVolume.Projected.Sources[1].Secret.Name).To(Equal("http-ca"))
 		})
 	})
 
@@ -1458,7 +1472,7 @@ var _ = Describe("Builders", func() {
 			clusterObject := ClusterDescWithVersion("2.2.1")
 			clusterObject.Spec.General.HostNetwork = true
 
-			job := NewSecurityconfigUpdateJob(&clusterObject, "foobar", "foobar", "foobar", "admin-cert", "cmd", nil, nil)
+			job := NewSecurityconfigUpdateJob(&clusterObject, "foobar", "foobar", "foobar", "admin-cert", "", "cmd", nil, nil)
 			Expect(job.Spec.Template.Spec.HostNetwork).To(BeTrue())
 		})
 	})
@@ -1482,7 +1496,7 @@ var _ = Describe("Builders", func() {
 				},
 			}
 
-			job := NewSecurityconfigUpdateJob(&clusterObject, "dummy", "dummy", "dummy", "dummy", "dummy", nil, nil)
+			job := NewSecurityconfigUpdateJob(&clusterObject, "dummy", "dummy", "dummy", "dummy", "", "dummy", nil, nil)
 			Expect(job.Spec.Template.Spec.Tolerations).To(Equal(tolerations))
 		})
 
@@ -1499,7 +1513,7 @@ var _ = Describe("Builders", func() {
 				},
 			}
 
-			job := NewSecurityconfigUpdateJob(&clusterObject, "dummy", "dummy", "dummy", "dummy", "dummy", nil, nil)
+			job := NewSecurityconfigUpdateJob(&clusterObject, "dummy", "dummy", "dummy", "dummy", "", "dummy", nil, nil)
 			Expect(job.Spec.Template.Spec.NodeSelector).To(Equal(nodeSelector))
 		})
 
@@ -1530,7 +1544,7 @@ var _ = Describe("Builders", func() {
 				},
 			}
 
-			job := NewSecurityconfigUpdateJob(&clusterObject, "dummy", "dummy", "dummy", "dummy", "dummy", nil, nil)
+			job := NewSecurityconfigUpdateJob(&clusterObject, "dummy", "dummy", "dummy", "dummy", "", "dummy", nil, nil)
 			Expect(job.Spec.Template.Spec.Affinity).To(Equal(affinity))
 		})
 	})

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1408,6 +1408,17 @@ var _ = Describe("Builders", func() {
 			Expect(job.Spec.Template.Spec.Containers[0].Resources).To(Equal(clusterObject.Spec.Security.Config.UpdateJob.Resources))
 		})
 
+		It("should mount admin cert as a secret volume when no separate CA secret is configured", func() {
+			clusterObject := ClusterDescWithVersion("2.2.1")
+			job := NewSecurityconfigUpdateJob(&clusterObject, "dummy", "dummy", "dummy", "admin-cert", "", "dummy", nil, nil)
+
+			adminVolume := job.Spec.Template.Spec.Volumes[0]
+			Expect(adminVolume.Name).To(Equal("admin-cert"))
+			Expect(adminVolume.Secret).ToNot(BeNil())
+			Expect(adminVolume.Secret.SecretName).To(Equal("admin-cert"))
+			Expect(adminVolume.Projected).To(BeNil())
+		})
+
 		It("should project CA cert into admin-cert mount when configured separately", func() {
 			clusterObject := ClusterDescWithVersion("2.2.1")
 			job := NewSecurityconfigUpdateJob(&clusterObject, "dummy", "dummy", "dummy", "admin-cert", "http-ca", "dummy", nil, nil)
@@ -1418,8 +1429,15 @@ var _ = Describe("Builders", func() {
 			Expect(adminVolume.Projected.Sources).To(HaveLen(2))
 			Expect(adminVolume.Projected.Sources[0].Secret).ToNot(BeNil())
 			Expect(adminVolume.Projected.Sources[0].Secret.Name).To(Equal("admin-cert"))
+			Expect(adminVolume.Projected.Sources[0].Secret.Items).To(ConsistOf(
+				corev1.KeyToPath{Key: corev1.TLSCertKey, Path: corev1.TLSCertKey},
+				corev1.KeyToPath{Key: corev1.TLSPrivateKeyKey, Path: corev1.TLSPrivateKeyKey},
+			))
 			Expect(adminVolume.Projected.Sources[1].Secret).ToNot(BeNil())
 			Expect(adminVolume.Projected.Sources[1].Secret.Name).To(Equal("http-ca"))
+			Expect(adminVolume.Projected.Sources[1].Secret.Items).To(ConsistOf(
+				corev1.KeyToPath{Key: "ca.crt", Path: "ca.crt"},
+			))
 		})
 	})
 

--- a/opensearch-operator/pkg/helpers/helpers.go
+++ b/opensearch-operator/pkg/helpers/helpers.go
@@ -120,6 +120,24 @@ func SecurityChangeVersion(cluster *opensearchv1.OpenSearchCluster) bool {
 	)
 }
 
+// TlsCASecretRef returns the CA secret reference for admin and security operations.
+// OpenSearch 2.x uses the HTTP CA; earlier versions use the transport CA.
+func TlsCASecretRef(cluster *opensearchv1.OpenSearchCluster) corev1.LocalObjectReference {
+	if cluster == nil || cluster.Spec.Security == nil || cluster.Spec.Security.Tls == nil {
+		return corev1.LocalObjectReference{}
+	}
+	if SecurityChangeVersion(cluster) {
+		if cluster.Spec.Security.Tls.Http != nil {
+			return cluster.Spec.Security.Tls.Http.CaSecret
+		}
+		return corev1.LocalObjectReference{}
+	}
+	if cluster.Spec.Security.Tls.Transport != nil {
+		return cluster.Spec.Security.Tls.Transport.CaSecret
+	}
+	return corev1.LocalObjectReference{}
+}
+
 func SupportsHotReload(cluster *opensearchv1.OpenSearchCluster) bool {
 	return CheckVersionConstraint(
 		cluster,

--- a/opensearch-operator/pkg/helpers/helpers_test.go
+++ b/opensearch-operator/pkg/helpers/helpers_test.go
@@ -293,3 +293,53 @@ var _ = Describe("JVM Heap Size Functions", func() {
 		})
 	})
 })
+
+var _ = Describe("TlsCASecretRef", func() {
+	It("should return HTTP caSecret for OpenSearch 2.x", func() {
+		cluster := &opensearchv1.OpenSearchCluster{
+			Spec: opensearchv1.ClusterSpec{
+				General: opensearchv1.GeneralConfig{Version: "2.3.0"},
+				Security: &opensearchv1.Security{
+					Tls: &opensearchv1.TlsConfig{
+						Http: &opensearchv1.TlsConfigHttp{
+							TlsCertificateConfig: opensearchv1.TlsCertificateConfig{
+								CaSecret: corev1.LocalObjectReference{Name: "http-ca"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(TlsCASecretRef(cluster).Name).To(Equal("http-ca"))
+	})
+
+	It("should return transport caSecret for OpenSearch 1.x", func() {
+		cluster := &opensearchv1.OpenSearchCluster{
+			Spec: opensearchv1.ClusterSpec{
+				General: opensearchv1.GeneralConfig{Version: "1.3.0"},
+				Security: &opensearchv1.Security{
+					Tls: &opensearchv1.TlsConfig{
+						Transport: &opensearchv1.TlsConfigTransport{
+							TlsCertificateConfig: opensearchv1.TlsCertificateConfig{
+								CaSecret: corev1.LocalObjectReference{Name: "transport-ca"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(TlsCASecretRef(cluster).Name).To(Equal("transport-ca"))
+	})
+
+	It("should return empty when TLS is not configured", func() {
+		cluster := &opensearchv1.OpenSearchCluster{
+			Spec: opensearchv1.ClusterSpec{
+				General: opensearchv1.GeneralConfig{Version: "2.3.0"},
+			},
+		}
+
+		Expect(TlsCASecretRef(cluster).Name).To(BeEmpty())
+	})
+})

--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -216,6 +216,7 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 		namespace,
 		checksumval,
 		adminCertName,
+		r.determineAdminCASecret(adminCertName),
 		cmdArg,
 		r.reconcilerContext.Volumes,
 		r.reconcilerContext.VolumeMounts,
@@ -301,6 +302,27 @@ func (r *SecurityconfigReconciler) determineAdminSecret() string {
 	}
 	// Security plugin is not enabled, no admin cert needed
 	return ""
+}
+
+func (r *SecurityconfigReconciler) determineAdminCASecret(adminSecretName string) string {
+	if r.instance.Spec.Security == nil || r.instance.Spec.Security.Tls == nil {
+		return ""
+	}
+
+	var caSecretName string
+	if helpers.SecurityChangeVersion(r.instance) {
+		if r.instance.Spec.Security.Tls.Http != nil {
+			caSecretName = r.instance.Spec.Security.Tls.Http.CaSecret.Name
+		}
+	} else if r.instance.Spec.Security.Tls.Transport != nil {
+		caSecretName = r.instance.Spec.Security.Tls.Transport.CaSecret.Name
+	}
+
+	// If CA comes from the same secret, keep single-secret mounting behavior.
+	if caSecretName == "" || caSecretName == adminSecretName {
+		return ""
+	}
+	return caSecretName
 }
 
 func (r *SecurityconfigReconciler) DeleteResources() (ctrl.Result, error) {

--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -305,19 +305,7 @@ func (r *SecurityconfigReconciler) determineAdminSecret() string {
 }
 
 func (r *SecurityconfigReconciler) determineAdminCASecret(adminSecretName string) string {
-	if r.instance.Spec.Security == nil || r.instance.Spec.Security.Tls == nil {
-		return ""
-	}
-
-	var caSecretName string
-	if helpers.SecurityChangeVersion(r.instance) {
-		if r.instance.Spec.Security.Tls.Http != nil {
-			caSecretName = r.instance.Spec.Security.Tls.Http.CaSecret.Name
-		}
-	} else if r.instance.Spec.Security.Tls.Transport != nil {
-		caSecretName = r.instance.Spec.Security.Tls.Transport.CaSecret.Name
-	}
-
+	caSecretName := helpers.TlsCASecretRef(r.instance).Name
 	// If CA comes from the same secret, keep single-secret mounting behavior.
 	if caSecretName == "" || caSecretName == adminSecretName {
 		return ""

--- a/opensearch-operator/pkg/reconcilers/securityconfig_test.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig_test.go
@@ -366,4 +366,46 @@ done;`
 			Expect(createdJob.Spec.Template.Spec.Containers[0].Args[0]).To(Equal(cmdArg))
 		})
 	})
+
+	When("Determining admin CA secret for securityconfig update job", func() {
+		It("should use HTTP caSecret for security change versions", func() {
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "ca-http", Namespace: "ca-http", UID: "dummyuid"},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "2.3.0",
+					},
+					Security: &opensearchv1.Security{
+						Tls: &opensearchv1.TlsConfig{
+							Http: &opensearchv1.TlsConfigHttp{
+								CaSecret: corev1.LocalObjectReference{Name: "http-ca"},
+							},
+						},
+					},
+				},
+			}
+			underTest := &SecurityconfigReconciler{instance: &spec}
+			Expect(underTest.determineAdminCASecret("admin-secret")).To(Equal("http-ca"))
+		})
+
+		It("should return empty when CA secret equals admin secret", func() {
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "same-ca", Namespace: "same-ca", UID: "dummyuid"},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "2.3.0",
+					},
+					Security: &opensearchv1.Security{
+						Tls: &opensearchv1.TlsConfig{
+							Http: &opensearchv1.TlsConfigHttp{
+								CaSecret: corev1.LocalObjectReference{Name: "admin-secret"},
+							},
+						},
+					},
+				},
+			}
+			underTest := &SecurityconfigReconciler{instance: &spec}
+			Expect(underTest.determineAdminCASecret("admin-secret")).To(BeEmpty())
+		})
+	})
 })

--- a/opensearch-operator/pkg/reconcilers/securityconfig_test.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig_test.go
@@ -378,7 +378,9 @@ done;`
 					Security: &opensearchv1.Security{
 						Tls: &opensearchv1.TlsConfig{
 							Http: &opensearchv1.TlsConfigHttp{
-								CaSecret: corev1.LocalObjectReference{Name: "http-ca"},
+								TlsCertificateConfig: opensearchv1.TlsCertificateConfig{
+									CaSecret: corev1.LocalObjectReference{Name: "http-ca"},
+								},
 							},
 						},
 					},
@@ -398,7 +400,9 @@ done;`
 					Security: &opensearchv1.Security{
 						Tls: &opensearchv1.TlsConfig{
 							Http: &opensearchv1.TlsConfigHttp{
-								CaSecret: corev1.LocalObjectReference{Name: "admin-secret"},
+								TlsCertificateConfig: opensearchv1.TlsCertificateConfig{
+									CaSecret: corev1.LocalObjectReference{Name: "admin-secret"},
+								},
 							},
 						},
 					},

--- a/opensearch-operator/pkg/reconcilers/securityconfig_test.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig_test.go
@@ -411,5 +411,150 @@ done;`
 			underTest := &SecurityconfigReconciler{instance: &spec}
 			Expect(underTest.determineAdminCASecret("admin-secret")).To(BeEmpty())
 		})
+
+		It("should use transport caSecret for pre-2.0 versions", func() {
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "ca-transport", Namespace: "ca-transport", UID: "dummyuid"},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "1.3.0",
+					},
+					Security: &opensearchv1.Security{
+						Tls: &opensearchv1.TlsConfig{
+							Transport: &opensearchv1.TlsConfigTransport{
+								TlsCertificateConfig: opensearchv1.TlsCertificateConfig{
+									CaSecret: corev1.LocalObjectReference{Name: "transport-ca"},
+								},
+							},
+						},
+					},
+				},
+			}
+			underTest := &SecurityconfigReconciler{instance: &spec}
+			Expect(underTest.determineAdminCASecret("admin-secret")).To(Equal("transport-ca"))
+		})
+	})
+
+	When("Reconciling with external TLS certs and separate caSecret", func() {
+		const (
+			externalClusterName = "external-tls"
+			tlsSecretName       = "my-tls-secret"
+			caSecretName        = "my-ca-secret"
+		)
+
+		findJobVolume := func(job batchv1.Job, name string) corev1.Volume {
+			for _, volume := range job.Spec.Template.Spec.Volumes {
+				if volume.Name == name {
+					return volume
+				}
+			}
+			return corev1.Volume{}
+		}
+
+		It("should project admin-cert from TLS secret and caSecret when reconciling", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+
+			adminCredSecret := newAdminCredentialsSecret(externalClusterName)
+			securityConfigSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "securityconfig-secret", Namespace: externalClusterName},
+				Type:       corev1.SecretType("Opaque"),
+				Data: map[string][]byte{
+					"config.yml": []byte(configYAML),
+				},
+			}
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: externalClusterName, Namespace: externalClusterName, UID: "dummyuid"},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						ServiceName: externalClusterName,
+						Version:     "3.5.0",
+					},
+					Security: &opensearchv1.Security{
+						Config: &opensearchv1.SecurityConfig{
+							SecurityconfigSecret:   corev1.LocalObjectReference{Name: "securityconfig-secret"},
+							AdminCredentialsSecret: corev1.LocalObjectReference{Name: adminCredsName},
+							AdminSecret:            corev1.LocalObjectReference{Name: tlsSecretName},
+						},
+						Tls: &opensearchv1.TlsConfig{
+							Transport: &opensearchv1.TlsConfigTransport{
+								Generate: false,
+								TlsCertificateConfig: opensearchv1.TlsCertificateConfig{
+									Secret:   corev1.LocalObjectReference{Name: tlsSecretName},
+									CaSecret: corev1.LocalObjectReference{Name: caSecretName},
+								},
+							},
+							Http: &opensearchv1.TlsConfigHttp{
+								Generate: false,
+								TlsCertificateConfig: opensearchv1.TlsCertificateConfig{
+									Secret:   corev1.LocalObjectReference{Name: tlsSecretName},
+									CaSecret: corev1.LocalObjectReference{Name: caSecretName},
+								},
+							},
+						},
+					},
+				},
+				Status: opensearchv1.ClusterStatus{
+					Initialized: true,
+				},
+			}
+			generatedConfigName := helpers.GeneratedSecurityConfigSecretName(&spec)
+			mockClient.EXPECT().GetSecret(adminCredsName, externalClusterName).Return(adminCredSecret, nil)
+			mockClient.EXPECT().GetSecret("securityconfig-secret", externalClusterName).Return(*securityConfigSecret, nil)
+			setupDashboardsCredentialsSecretMocks(mockClient, externalClusterName)
+			mockClient.EXPECT().GetJob(externalClusterName+"-securityconfig-update", externalClusterName).Return(batchv1.Job{}, NotFoundError())
+			mockClient.EXPECT().Scheme().Return(scheme.Scheme)
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything).Return(nil).Maybe()
+			mockClient.On("GetSecret", generatedConfigName, externalClusterName).Return(corev1.Secret{}, NotFoundError()).Once()
+
+			var generatedConfigSecret *corev1.Secret
+			mockClient.On("ReconcileResource", mock.AnythingOfType("*v1.Secret"), mock.Anything).
+				Return(&ctrl.Result{}, nil).
+				Run(func(args mock.Arguments) {
+					if secret, ok := args[0].(*corev1.Secret); ok && secret.Name == generatedConfigName {
+						generatedConfigSecret = secret.DeepCopy()
+					}
+				})
+			mockClient.On("GetSecret", generatedConfigName, externalClusterName).
+				Return(func(string, string) corev1.Secret {
+					Expect(generatedConfigSecret).ToNot(BeNil())
+					return *generatedConfigSecret
+				}, nil).Once()
+
+			var createdJob *batchv1.Job
+			mockClient.On("CreateJob", mock.Anything).
+				Return(func(job *batchv1.Job) (*ctrl.Result, error) {
+					createdJob = job
+					return &ctrl.Result{}, nil
+				})
+
+			reconcilerContext := NewReconcilerContext(&record.FakeRecorder{}, &spec, spec.Spec.NodePools)
+			underTest := newSecurityconfigReconciler(
+				mockClient,
+				context.Background(),
+				&reconcilerContext,
+				&spec,
+			)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createdJob).ToNot(BeNil())
+
+			adminVolume := findJobVolume(*createdJob, "admin-cert")
+			Expect(adminVolume.Projected).ToNot(BeNil())
+			Expect(adminVolume.Projected.Sources).To(HaveLen(2))
+			Expect(adminVolume.Projected.Sources[0].Secret.Name).To(Equal(tlsSecretName))
+			Expect(adminVolume.Projected.Sources[0].Secret.Items).To(ConsistOf(
+				corev1.KeyToPath{Key: corev1.TLSCertKey, Path: corev1.TLSCertKey},
+				corev1.KeyToPath{Key: corev1.TLSPrivateKeyKey, Path: corev1.TLSPrivateKeyKey},
+			))
+			Expect(adminVolume.Projected.Sources[1].Secret.Name).To(Equal(caSecretName))
+			Expect(adminVolume.Projected.Sources[1].Secret.Items).To(ConsistOf(
+				corev1.KeyToPath{Key: "ca.crt", Path: "ca.crt"},
+			))
+
+			cmdArg := createdJob.Spec.Template.Spec.Containers[0].Args[0]
+			Expect(cmdArg).To(ContainSubstring("-cacert /certs/ca.crt"))
+			Expect(cmdArg).To(ContainSubstring("-cert /certs/tls.crt"))
+			Expect(cmdArg).To(ContainSubstring("-key /certs/tls.key"))
+		})
 	})
 })

--- a/opensearch-operator/pkg/reconcilers/tls.go
+++ b/opensearch-operator/pkg/reconcilers/tls.go
@@ -214,10 +214,7 @@ func (r *TLSReconciler) handleAdminCertificate() (*ctrl.Result, error) {
 }
 
 func (r *TLSReconciler) adminCAConfig() corev1.LocalObjectReference {
-	if helpers.SecurityChangeVersion(r.instance) {
-		return r.instance.Spec.Security.Tls.Http.CaSecret
-	}
-	return r.instance.Spec.Security.Tls.Transport.CaSecret
+	return helpers.TlsCASecretRef(r.instance)
 }
 
 func (r *TLSReconciler) shouldCreateAdminCert(ca tls.Cert) (bool, error) {


### PR DESCRIPTION
### Description
fix #1396

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
