### PR TITLE
Add josedev-union as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @prudhvigodithi @synhershko
+* @prudhvigodithi @synhershko @josedev-union

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,9 +1,10 @@
 # Maintainers
 
-| Maintainer | GitHub ID | Affiliation  |
-| --------------- | --------- |--------------|
-| Prudhvi Godithi | [prudhvigodithi](https://github.com/prudhvigodithi) | Amazon       |
-| Itamar Syn-Hershko | [synhershko](https://github.com/synhershko) | BigData Boutique       |
+| Maintainer | GitHub ID | Affiliation |
+| ---- | --------- |--------|
+| Prudhvi Godithi | [prudhvigodithi](https://github.com/prudhvigodithi) | Amazon |
+| Itamar Syn-Hershko | [synhershko](https://github.com/synhershko) | BigData Boutique |
+| Jose Barato | [josedev-union](https://github.com/josedev-union) | NexGen Cloud       |
 
 # Emeritus
 | Maintainer            | GitHub ID                                               | Affiliation      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,7 +4,7 @@
 | ---- | --------- |--------|
 | Prudhvi Godithi | [prudhvigodithi](https://github.com/prudhvigodithi) | Amazon |
 | Itamar Syn-Hershko | [synhershko](https://github.com/synhershko) | BigData Boutique |
-| Jose Barato | [josedev-union](https://github.com/josedev-union) | NexGen Cloud       |
+| Jose Barato | [josedev-union](https://github.com/josedev-union) | BigData Boutique       |
 
 # Emeritus
 | Maintainer            | GitHub ID                                               | Affiliation      |


### PR DESCRIPTION
### Description
Note - this should not be merged until https://github.com/opensearch-project/.github/issues/507 is closed.

Following the nomination process, I have nominated and other maintainers have agreed to add @josedev-union as a co-maintainer of the opensearch-k8s-operator repository. He has graciously accepted the invitation.

@josedev-union has closed [24 issues](https://github.com/opensearch-project/opensearch-k8s-operator/issues?q=is%3Aissue%20state%3Aclosed%20author%3Ajosedev-union) and [77 pull requests ](https://github.com/opensearch-project/opensearch-k8s-operator/issues?q=is%3Apr%20state%3Aclosed%20author%3Ajosedev-union )in the OpenSearch Kubernetes Operator repository, demonstrating consistent and impactful contributions.

@josedev-union is also a key contributor to the [3.0.0 alpha release](https://github.com/opensearch-project/opensearch-k8s-operator/releases/tag/v3.0.0-alpha), with over 40 contributions toward this milestone.

@josedev-union actively [reviews pull requests](https://github.com/opensearch-project/opensearch-k8s-operator/pulls?q=is%3Apr+reviewed-by%3A%40josedev-union+), playing a key role in maintaining code quality and collaboration

According to the [Linux Foundation Insights dashboard](https://insights.linuxfoundation.org/project/opensearch-foundation/contributors?timeRange=past365days&start=2025-04-22&end=2026-04-22&auth=success&repos=opensearch-project-opensearch,opensearch-project_opensearch-k8s-operator), @josedev-union has been the top contributor over the past year.

<img width="1504" height="677" alt="Screenshot 2026-04-22 at 8 43 12 AM" src="https://github.com/user-attachments/assets/a18277e5-1cad-4124-aca6-accefda89077" />






