### PR TITLE
helm(cluster): Use appVersion as image tag by default

### DIFF
--- a/charts/opensearch-cluster/Chart.yaml
+++ b/charts/opensearch-cluster/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for OpenSearch Cluster
 type: application
 
 ## The opensearch-cluster Helm Chart version
-version: 3.3.0
+version: 3.3.1
 
 ## The operator version
 appVersion: 2.8.0

--- a/charts/opensearch-cluster/README.md
+++ b/charts/opensearch-cluster/README.md
@@ -40,7 +40,7 @@ The following table lists the configurable parameters of the Helm chart.
 | `cluster.general.setVMMaxMapCount` | bool | `true` | Enable setVMMaxMapCount. OpenSearch requires the Linux kernel vm.max_map_count option to be set to at least 262144 |
 | `cluster.general.snapshotRepositories` | list | `[]` | Opensearch snapshot repositories configuration |
 | `cluster.general.vendor` | string | `"Opensearch"` |  |
-| `cluster.general.version` | string | `"2.3.0"` | Opensearch version |
+| `cluster.general.version` | string | `""` | Opensearch version |
 | `cluster.bootstrap.env` | list | `[]` | bootstrap pod env variables |
 | `cluster.bootstrap.affinity` | object | `{}` | bootstrap pod affinity rules |
 | `cluster.bootstrap.annotations` | object | `{}` | bootstrap pod annotations |
@@ -75,7 +75,7 @@ The following table lists the configurable parameters of the Helm chart.
 | `cluster.dashboards.tls.secret` | string | `nil` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
 | `cluster.dashboards.tls.duration` | string | `"8760h"` | Duration controls the validity period of generated certificates (e.g. "8760h", "720h"). This is used only when generate is true. |
 | `cluster.dashboards.tolerations` | list | `[]` | dashboards pod tolerations |
-| `cluster.dashboards.version` | string | `"2.3.0"` | dashboards version |
+| `cluster.dashboards.version` | string | `""` | dashboards version |
 | `cluster.initHelper.image` | string | `"docker.io/busybox"` | initHelper image |
 | `cluster.initHelper.imagePullPolicy` | string | `"IfNotPresent"` | initHelper image pull policy |
 | `cluster.initHelper.imagePullSecrets` | list | `[]` | initHelper image pull secret |
@@ -125,4 +125,4 @@ The following table lists the configurable parameters of the Helm chart.
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
-Opensearch-cluster Helm Chart version: `3.3.0`
+Opensearch-cluster Helm Chart version: `3.3.1`

--- a/charts/opensearch-cluster/templates/cluster.yaml
+++ b/charts/opensearch-cluster/templates/cluster.yaml
@@ -19,14 +19,16 @@ spec:
   {{- end }}
   {{- with .Values.cluster.dashboards }}
   dashboards:
-    {{- omit . "image" | toYaml | nindent 4 }}
-    image: {{ .image }}:{{ .version }}
+    {{- omit . "image" "version" | toYaml | nindent 4 }}
+    image: {{ .image }}:{{ default $.Chart.AppVersion .version }}
+    version: {{ default $.Chart.AppVersion .version }}
   {{- end }}
   {{- with .Values.cluster.general }}
   general:
-    {{- omit . "image" "serviceName" | toYaml | nindent 4 }}
-    image: {{ .image }}:{{ .version }}
+    {{- omit . "image" "serviceName" "version" | toYaml | nindent 4 }}
+    image: {{ .image }}:{{ default $.Chart.AppVersion .version }}
     serviceName: {{ .serviceName | default $clusterName }}
+    version: {{ default $.Chart.AppVersion .version }}
   {{- end }}
   {{- with .Values.cluster.initHelper }}
   initHelper:

--- a/charts/opensearch-cluster/values.yaml
+++ b/charts/opensearch-cluster/values.yaml
@@ -127,7 +127,7 @@ cluster:
     vendor: Opensearch
 
     # -- Opensearch version
-    version: 2.3.0
+    version: ""
 
     # -- OpenSearch installation directory inside the container.
     # If not set, defaults to /usr/share/opensearch.
@@ -251,7 +251,7 @@ cluster:
     tolerations: []
 
     # -- dashboards version
-    version: 2.3.0
+    version: ""
 
     # -- OpenSearch Dashboards installation directory inside the container.
     # If not set, defaults to /usr/share/opensearch-dashboards.


### PR DESCRIPTION
### Description

The `appVersion` field of the cluster chart indicated that version 2.8.0 of OpenSearch was used, but actually version 2.3.0 was hard-coded in the `values.yaml` file.
This change unsets the version field in `values.yaml` and defaults to using `appVersion` as the image tag for the respective component. Setting `.Values.cluster.general.version` or
`.Values.cluster.dashboards.version` will override the version used in the image tag.

### Issues Resolved

No issue filed.

### Check List
- [x] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [x] Customer-visible features documented
- [x] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
