### PR TITLE
fix: avoid finalizer deadlock when resources are being deleted

### DIFF
--- a/opensearch-operator/controllers/migration_controller.go
+++ b/opensearch-operator/controllers/migration_controller.go
@@ -77,19 +77,17 @@ func (r *ClusterMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	newCluster := &opensearchv1.OpenSearchCluster{}
 	err := r.Get(ctx, req.NamespacedName, newCluster)
 	if err == nil {
-		// Add migration finalizer to new cluster if not present
-		// This ensures we can handle deletion even after main reconciler removes its finalizer
-		if !containsString(newCluster.Finalizers, MigrationFinalizer) {
-			newCluster.Finalizers = append(newCluster.Finalizers, MigrationFinalizer)
-			if err := r.Update(ctx, newCluster); err != nil {
-				return ctrl.Result{}, err
-			}
-			// Requeue to process deletion if needed
-			return ctrl.Result{Requeue: true}, nil
-		}
-
-		// This is a new cluster - check if it's being deleted
+		// Handle deletion first. We must never attempt to add a finalizer to an
+		// object that is already being deleted: the API server rejects this with
+		// "no new finalizers can be added if the object is being deleted", which
+		// would otherwise cause an endless reconcile error loop (see #1417).
 		if !newCluster.DeletionTimestamp.IsZero() {
+			// If our migration finalizer is not present there is nothing for us to
+			// clean up, so let the deletion proceed without re-adding it.
+			if !containsString(newCluster.Finalizers, MigrationFinalizer) {
+				return ctrl.Result{}, nil
+			}
+
 			// Check if the main reconciler has finished cleanup (finalizer removed)
 			// The main reconciler removes the "Opensearch" finalizer after cleanup
 			hasMainFinalizer := false
@@ -117,6 +115,17 @@ func (r *ClusterMigrationReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			// Requeue to wait for cleanup to complete
 			logger.Info("New cluster deletion in progress, waiting for main reconciler to finish cleanup", "name", newCluster.Name)
 			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+
+		// Add migration finalizer to new cluster if not present
+		// This ensures we can handle deletion even after main reconciler removes its finalizer
+		if !containsString(newCluster.Finalizers, MigrationFinalizer) {
+			newCluster.Finalizers = append(newCluster.Finalizers, MigrationFinalizer)
+			if err := r.Update(ctx, newCluster); err != nil {
+				return ctrl.Result{}, err
+			}
+			// Requeue to process deletion if needed
+			return ctrl.Result{Requeue: true}, nil
 		}
 		// If new cluster exists and is not being deleted, continue to check old cluster
 	}
@@ -647,19 +656,17 @@ func reconcileGenericMigration[OldType, NewType any, OldPtr interface {
 	newResource := NewPtr(new(NewType))
 	err := c.Get(ctx, req.NamespacedName, newResource)
 	if err == nil {
-		// Add migration finalizer to new resource if not present
-		// This ensures we can handle deletion even after main reconciler removes its finalizer
-		if !containsString(newResource.GetFinalizers(), MigrationFinalizer) {
-			newResource.SetFinalizers(append(newResource.GetFinalizers(), MigrationFinalizer))
-			if err := c.Update(ctx, newResource); err != nil {
-				return ctrl.Result{}, err
-			}
-			// Requeue to process deletion if needed
-			return ctrl.Result{Requeue: true}, nil
-		}
-
-		// This is a new resource - check if it's being deleted
+		// Handle deletion first. We must never attempt to add a finalizer to an
+		// object that is already being deleted: the API server rejects this with
+		// "no new finalizers can be added if the object is being deleted", which
+		// would otherwise cause an endless reconcile error loop (see #1417).
 		if !newResource.GetDeletionTimestamp().IsZero() {
+			// If our migration finalizer is not present there is nothing for us to
+			// clean up, so let the deletion proceed without re-adding it.
+			if !containsString(newResource.GetFinalizers(), MigrationFinalizer) {
+				return ctrl.Result{}, nil
+			}
+
 			// Check if the resource still has other finalizers (cleanup in progress)
 			// Only delete old resource if new resource has no other finalizers (only migration finalizer remains)
 			otherFinalizers := false
@@ -687,6 +694,17 @@ func reconcileGenericMigration[OldType, NewType any, OldPtr interface {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{}, nil
+		}
+
+		// Add migration finalizer to new resource if not present
+		// This ensures we can handle deletion even after main reconciler removes its finalizer
+		if !containsString(newResource.GetFinalizers(), MigrationFinalizer) {
+			newResource.SetFinalizers(append(newResource.GetFinalizers(), MigrationFinalizer))
+			if err := c.Update(ctx, newResource); err != nil {
+				return ctrl.Result{}, err
+			}
+			// Requeue to process deletion if needed
+			return ctrl.Result{Requeue: true}, nil
 		}
 		// If new resource exists and is not being deleted, continue to check old resource
 	}

--- a/opensearch-operator/controllers/migration_controller_test.go
+++ b/opensearch-operator/controllers/migration_controller_test.go
@@ -84,6 +84,101 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedCluster)).To(Succeed())
 			Expect(containsString(updatedCluster.Finalizers, MigrationFinalizer)).To(BeTrue())
 		})
+
+		It("should not add migration finalizer to a new cluster that is being deleted", func() {
+			// Reproduces #1417: the migration controller must not attempt to add a
+			// finalizer to an object that is already being deleted, otherwise the API
+			// server rejects the update with "no new finalizers can be added if the
+			// object is being deleted" and the controller loops forever.
+			now := metav1.Now()
+			newCluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					// Some other finalizer keeps the object around but the migration
+					// finalizer is intentionally absent.
+					Finalizers: []string{"Opensearch"},
+				},
+			}
+			Expect(fakeClient.Create(ctx, newCluster)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+
+			// Verify the migration finalizer was NOT added to the deleting object
+			updatedCluster := &opensearchv1.OpenSearchCluster{}
+			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedCluster)).To(Succeed())
+			Expect(containsString(updatedCluster.Finalizers, MigrationFinalizer)).To(BeFalse())
+		})
+
+		It("should wait while the main reconciler is still cleaning up", func() {
+			// When the new cluster is being deleted but the main "Opensearch"
+			// finalizer is still present, the migration controller must wait for the
+			// main reconciler to finish external cleanup before removing its own
+			// finalizer.
+			now := metav1.Now()
+			newCluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{"Opensearch", MigrationFinalizer},
+				},
+			}
+			Expect(fakeClient.Create(ctx, newCluster)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+
+			// Both finalizers must still be present (cleanup not finished)
+			updatedCluster := &opensearchv1.OpenSearchCluster{}
+			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedCluster)).To(Succeed())
+			Expect(containsString(updatedCluster.Finalizers, MigrationFinalizer)).To(BeTrue())
+			Expect(containsString(updatedCluster.Finalizers, "Opensearch")).To(BeTrue())
+		})
+
+		It("should remove the migration finalizer once the main reconciler is done", func() {
+			// When the new cluster is being deleted and only the migration finalizer
+			// remains, the migration controller deletes the old CR and removes its
+			// finalizer, allowing the new CR to be garbage collected.
+			now := metav1.Now()
+			newCluster := &opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{MigrationFinalizer},
+				},
+			}
+			Expect(fakeClient.Create(ctx, newCluster)).To(Succeed())
+
+			oldCluster := &opsterv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, oldCluster)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			// The migration finalizer was the only one left, so removing it allows the
+			// fake client to garbage collect the new cluster.
+			updatedCluster := &opensearchv1.OpenSearchCluster{}
+			err = fakeClient.Get(ctx, req.NamespacedName, updatedCluster)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+
+			// The corresponding old cluster should have been deleted as well.
+			updatedOld := &opsterv1.OpenSearchCluster{}
+			err = fakeClient.Get(ctx, req.NamespacedName, updatedOld)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+		})
 	})
 
 	Describe("Reconcile - Old Cluster Migration", func() {
@@ -320,6 +415,115 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 				Status: opsterv1.ClusterStatus{},
 			}
 			Expect(isClusterReady(cluster)).To(BeFalse())
+		})
+	})
+
+	Describe("Generic Migration Reconciler - New Resource Deletion", func() {
+		It("should not add migration finalizer to a new resource that is being deleted", func() {
+			// Reproduces #1417 for the generic migration reconciler (used by
+			// usermigration / userrolebindingmigration / etc.): adding a finalizer
+			// to an object that is already being deleted is rejected by the API
+			// server and causes a reconcile error loop.
+			now := metav1.Now()
+			newUser := &opensearchv1.OpensearchUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{OpensearchFinalizer},
+				},
+			}
+			Expect(fakeClient.Create(ctx, newUser)).To(Succeed())
+
+			userMigration := &UserMigrationReconciler{Client: fakeClient, Scheme: scheme}
+			result, err := userMigration.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+
+			updatedUser := &opensearchv1.OpensearchUser{}
+			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedUser)).To(Succeed())
+			Expect(containsString(updatedUser.Finalizers, MigrationFinalizer)).To(BeFalse())
+		})
+
+		It("should add migration finalizer to a new resource that is not being deleted", func() {
+			newUser := &opensearchv1.OpensearchUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, newUser)).To(Succeed())
+
+			userMigration := &UserMigrationReconciler{Client: fakeClient, Scheme: scheme}
+			result, err := userMigration.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue())
+
+			updatedUser := &opensearchv1.OpensearchUser{}
+			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedUser)).To(Succeed())
+			Expect(containsString(updatedUser.Finalizers, MigrationFinalizer)).To(BeTrue())
+		})
+
+		It("should wait while other finalizers are still present on a deleting resource", func() {
+			// The migration controller must not remove its finalizer (and delete the
+			// old resource) until the main reconciler has removed its own finalizer.
+			now := metav1.Now()
+			newUser := &opensearchv1.OpensearchUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{OpensearchFinalizer, MigrationFinalizer},
+				},
+			}
+			Expect(fakeClient.Create(ctx, newUser)).To(Succeed())
+
+			userMigration := &UserMigrationReconciler{Client: fakeClient, Scheme: scheme}
+			result, err := userMigration.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(5 * time.Second))
+
+			updatedUser := &opensearchv1.OpensearchUser{}
+			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedUser)).To(Succeed())
+			Expect(containsString(updatedUser.Finalizers, MigrationFinalizer)).To(BeTrue())
+			Expect(containsString(updatedUser.Finalizers, OpensearchFinalizer)).To(BeTrue())
+		})
+
+		It("should remove the migration finalizer once only it remains on a deleting resource", func() {
+			now := metav1.Now()
+			newUser := &opensearchv1.OpensearchUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-cluster",
+					Namespace:         "default",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{MigrationFinalizer},
+				},
+			}
+			Expect(fakeClient.Create(ctx, newUser)).To(Succeed())
+
+			oldUser := &opsterv1.OpensearchUser{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+			}
+			Expect(fakeClient.Create(ctx, oldUser)).To(Succeed())
+
+			userMigration := &UserMigrationReconciler{Client: fakeClient, Scheme: scheme}
+			result, err := userMigration.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			// Migration finalizer was the only one left, so the new resource is removed.
+			updatedUser := &opensearchv1.OpensearchUser{}
+			err = fakeClient.Get(ctx, req.NamespacedName, updatedUser)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+
+			// The corresponding old resource should have been deleted as well.
+			updatedOld := &opsterv1.OpensearchUser{}
+			err = fakeClient.Get(ctx, req.NamespacedName, updatedOld)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
 		})
 	})
 

--- a/opensearch-operator/controllers/migration_controller_test.go
+++ b/opensearch-operator/controllers/migration_controller_test.go
@@ -90,18 +90,18 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 			// finalizer to an object that is already being deleted, otherwise the API
 			// server rejects the update with "no new finalizers can be added if the
 			// object is being deleted" and the controller loops forever.
-			now := metav1.Now()
 			newCluster := &opensearchv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-cluster",
-					Namespace:         "default",
-					DeletionTimestamp: &now,
-					// Some other finalizer keeps the object around but the migration
+					Name:      "test-cluster",
+					Namespace: "default",
+					// Some other finalizer keeps the object around (so deletion sets a
+					// DeletionTimestamp instead of removing it) but the migration
 					// finalizer is intentionally absent.
 					Finalizers: []string{"Opensearch"},
 				},
 			}
 			Expect(fakeClient.Create(ctx, newCluster)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, newCluster)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
@@ -110,6 +110,7 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 			// Verify the migration finalizer was NOT added to the deleting object
 			updatedCluster := &opensearchv1.OpenSearchCluster{}
 			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedCluster)).To(Succeed())
+			Expect(updatedCluster.DeletionTimestamp.IsZero()).To(BeFalse())
 			Expect(containsString(updatedCluster.Finalizers, MigrationFinalizer)).To(BeFalse())
 		})
 
@@ -118,16 +119,15 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 			// finalizer is still present, the migration controller must wait for the
 			// main reconciler to finish external cleanup before removing its own
 			// finalizer.
-			now := metav1.Now()
 			newCluster := &opensearchv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-cluster",
-					Namespace:         "default",
-					DeletionTimestamp: &now,
-					Finalizers:        []string{"Opensearch", MigrationFinalizer},
+					Name:       "test-cluster",
+					Namespace:  "default",
+					Finalizers: []string{"Opensearch", MigrationFinalizer},
 				},
 			}
 			Expect(fakeClient.Create(ctx, newCluster)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, newCluster)).To(Succeed())
 
 			result, err := reconciler.Reconcile(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
@@ -144,16 +144,15 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 			// When the new cluster is being deleted and only the migration finalizer
 			// remains, the migration controller deletes the old CR and removes its
 			// finalizer, allowing the new CR to be garbage collected.
-			now := metav1.Now()
 			newCluster := &opensearchv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-cluster",
-					Namespace:         "default",
-					DeletionTimestamp: &now,
-					Finalizers:        []string{MigrationFinalizer},
+					Name:       "test-cluster",
+					Namespace:  "default",
+					Finalizers: []string{MigrationFinalizer},
 				},
 			}
 			Expect(fakeClient.Create(ctx, newCluster)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, newCluster)).To(Succeed())
 
 			oldCluster := &opsterv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{
@@ -424,16 +423,15 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 			// usermigration / userrolebindingmigration / etc.): adding a finalizer
 			// to an object that is already being deleted is rejected by the API
 			// server and causes a reconcile error loop.
-			now := metav1.Now()
 			newUser := &opensearchv1.OpensearchUser{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-cluster",
-					Namespace:         "default",
-					DeletionTimestamp: &now,
-					Finalizers:        []string{OpensearchFinalizer},
+					Name:       "test-cluster",
+					Namespace:  "default",
+					Finalizers: []string{OpensearchFinalizer},
 				},
 			}
 			Expect(fakeClient.Create(ctx, newUser)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, newUser)).To(Succeed())
 
 			userMigration := &UserMigrationReconciler{Client: fakeClient, Scheme: scheme}
 			result, err := userMigration.Reconcile(ctx, req)
@@ -442,6 +440,7 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 
 			updatedUser := &opensearchv1.OpensearchUser{}
 			Expect(fakeClient.Get(ctx, req.NamespacedName, updatedUser)).To(Succeed())
+			Expect(updatedUser.DeletionTimestamp.IsZero()).To(BeFalse())
 			Expect(containsString(updatedUser.Finalizers, MigrationFinalizer)).To(BeFalse())
 		})
 
@@ -467,16 +466,15 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 		It("should wait while other finalizers are still present on a deleting resource", func() {
 			// The migration controller must not remove its finalizer (and delete the
 			// old resource) until the main reconciler has removed its own finalizer.
-			now := metav1.Now()
 			newUser := &opensearchv1.OpensearchUser{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-cluster",
-					Namespace:         "default",
-					DeletionTimestamp: &now,
-					Finalizers:        []string{OpensearchFinalizer, MigrationFinalizer},
+					Name:       "test-cluster",
+					Namespace:  "default",
+					Finalizers: []string{OpensearchFinalizer, MigrationFinalizer},
 				},
 			}
 			Expect(fakeClient.Create(ctx, newUser)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, newUser)).To(Succeed())
 
 			userMigration := &UserMigrationReconciler{Client: fakeClient, Scheme: scheme}
 			result, err := userMigration.Reconcile(ctx, req)
@@ -490,16 +488,15 @@ var _ = Describe("ClusterMigrationReconciler", func() {
 		})
 
 		It("should remove the migration finalizer once only it remains on a deleting resource", func() {
-			now := metav1.Now()
 			newUser := &opensearchv1.OpensearchUser{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:              "test-cluster",
-					Namespace:         "default",
-					DeletionTimestamp: &now,
-					Finalizers:        []string{MigrationFinalizer},
+					Name:       "test-cluster",
+					Namespace:  "default",
+					Finalizers: []string{MigrationFinalizer},
 				},
 			}
 			Expect(fakeClient.Create(ctx, newUser)).To(Succeed())
+			Expect(fakeClient.Delete(ctx, newUser)).To(Succeed())
 
 			oldUser := &opsterv1.OpensearchUser{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### Description
_Describe what this change achieves._

### Issues Resolved
fix #1417

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
