### PR TITLE
fix: bump go 1.25.11 to address CVE-2026-42504

### DIFF
--- a/docs/developing.md
+++ b/docs/developing.md
@@ -4,7 +4,7 @@ This page provides information how to develop changes for the operator code. Ple
 
 ## Needed environment and tools
 
-The operator is developed in Go, as such you need a current Go toolkit (for Linux most distributions provide packages, otherwise get it from the [go homepage](https://go.dev/)). Please use version 1.25.10 as this version is used by the CI pipelines. You also need an editor/IDE, ideally with Go support. We recommend either [VS Code](https://code.visualstudio.com/) with the official Go extension or [GoLand](https://www.jetbrains.com/go/).
+The operator is developed in Go, as such you need a current Go toolkit (for Linux most distributions provide packages, otherwise get it from the [go homepage](https://go.dev/)). Please use version 1.25.11 as this version is used by the CI pipelines. You also need an editor/IDE, ideally with Go support. We recommend either [VS Code](https://code.visualstudio.com/) with the official Go extension or [GoLand](https://www.jetbrains.com/go/).
 
 Additional tools you will need:
 

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.25.10
+go 1.25.11
 
 use (
 	./opensearch-operator

--- a/opensearch-operator/Dockerfile
+++ b/opensearch-operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.25.10 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25.11 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/opensearch-operator/functionaltests/go.mod
+++ b/opensearch-operator/functionaltests/go.mod
@@ -1,6 +1,6 @@
 module github.com/opensearch-project/opensearch-k8s-operator/functionaltests
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/opensearch-operator/go.mod
+++ b/opensearch-operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator
 
-go 1.25.10
+go 1.25.11
 
 require (
 	emperror.dev/errors v0.8.1


### PR DESCRIPTION
### Description
bump go 1.25.11 to address CVE-2026-42504

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
