### PR TITLE
feat(helm): allow disabling legacy API

### DIFF
--- a/charts/opensearch-operator/Chart.yaml
+++ b/charts/opensearch-operator/Chart.yaml
@@ -6,5 +6,5 @@ sources:
   - https://github.com/opensearch-project/OpenSearch
   - https://github.com/opensearch-project/opensearch-k8s-operator
 type: application
-version: 3.0.4
+version: 3.0.5
 appVersion: 3.0.0-alpha

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -79,6 +79,7 @@ The following table lists the configurable parameters of the Helm chart.
 | `manager.watchNamespace` | string | `nil` |  |
 | `manager.metricsBindAddress` | string | `"127.0.0.1:8080"` |  |
 | `installCRDs` | bool | `true` |  |
+| `legacyAPI.enabled` | bool | `true` | Enable support for the deprecated `opensearch.opster.io/v1` API group. When false, deprecated CRDs, webhooks, RBAC rules, and manager watches are skipped. |
 | `serviceAccount.create` | bool | `true` |  |
 | `serviceAccount.name` | string | `""` |  |
 | `useRoleBindings` | bool | `false` |  |
@@ -135,4 +136,4 @@ subjects:
   namespace: <monitoring-namespace>
 ```
 
-Opensearch-operator Helm Chart version: `3.0.4`
+Opensearch-operator Helm Chart version: `3.0.5`

--- a/charts/opensearch-operator/README.md
+++ b/charts/opensearch-operator/README.md
@@ -34,6 +34,27 @@ helm repo update
 helm upgrade [RELEASE_NAME] opensearch-operator/opensearch-operator
 ```
 
+#### Disabling the legacy API
+
+> **Warning:** Helm manages the legacy CRDs as regular Helm resources.
+> Upgrading with `legacyAPI.enabled=false` removes those CRDs from the release.
+> Deleting a CRD also deletes every custom resource stored under it across the
+> cluster.
+
+Before disabling the legacy API, follow the
+[migration guide](../../docs/userguide/migration-guide.md) to migrate every
+legacy custom resource, verify the replacement `opensearch.org` resources, and
+delete all remaining `opensearch.opster.io` resources. Only then upgrade with
+the legacy API disabled:
+
+```shell
+helm upgrade [RELEASE_NAME] opensearch-operator/opensearch-operator \
+  --set legacyAPI.enabled=false
+```
+
+If you are installing the chart for the first time, you can safely disable the
+legacy API during installation to not include the legacy opster.io CRDs in the release.
+
 ## Values
 
 The following table lists the configurable parameters of the Helm chart.

--- a/charts/opensearch-operator/README.md.gotmpl
+++ b/charts/opensearch-operator/README.md.gotmpl
@@ -34,6 +34,27 @@ helm repo update
 helm upgrade [RELEASE_NAME] opensearch-operator/opensearch-operator
 ```
 
+#### Disabling the legacy API
+
+> **Warning:** Helm manages the legacy CRDs as regular Helm resources.
+> Upgrading with `legacyAPI.enabled=false` removes those CRDs from the release.
+> Deleting a CRD also deletes every custom resource stored under it across the
+> cluster.
+
+Before disabling the legacy API, follow the
+[migration guide](../../docs/userguide/migration-guide.md) to migrate every
+legacy custom resource, verify the replacement `opensearch.org` resources, and
+delete all remaining `opensearch.opster.io` resources. Only then upgrade with
+the legacy API disabled:
+
+```shell
+helm upgrade [RELEASE_NAME] opensearch-operator/opensearch-operator \
+  --set legacyAPI.enabled=false
+```
+
+If you are installing the chart for the first time, you can safely disable the
+legacy API during installation to not include the legacy opster.io CRDs in the release.
+
 {{ define "chart.valuesTableHtml" }}
 
 The following table lists the configurable parameters of the Helm chart.

--- a/charts/opensearch-operator/templates/_helpers.tpl
+++ b/charts/opensearch-operator/templates/_helpers.tpl
@@ -60,3 +60,19 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return whether deprecated opensearch.opster.io/v1 API support is enabled.
+Missing legacyAPI values default to true for upgrade compatibility.
+*/}}
+{{- define "opensearch-operator.legacyAPIEnabled" -}}
+{{- if hasKey .Values "legacyAPI" -}}
+{{- if .Values.legacyAPI -}}
+{{- ne .Values.legacyAPI.enabled false -}}
+{{- else -}}
+true
+{{- end -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end }}

--- a/charts/opensearch-operator/templates/crds.yaml
+++ b/charts/opensearch-operator/templates/crds.yaml
@@ -1,5 +1,8 @@
 {{- if .Values.installCRDs -}}
+{{- $legacyAPIEnabled := eq (include "opensearch-operator.legacyAPIEnabled" .) "true" -}}
 {{- range $path, $_ := .Files.Glob "files/*.yaml" }}
+	{{- $isLegacyCRD := contains "opensearch.opster.io" $path -}}
+	{{- if or $legacyAPIEnabled (not $isLegacyCRD) }}
 	{{- $raw := $.Files.Get $path -}}
 	{{- $docs := splitList "\n---\n" $raw -}}
 	{{- range $doc := $docs }}
@@ -14,6 +17,7 @@
 ---
 			{{- end }}
 		{{- end }}
+	{{- end }}
 	{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/opensearch-operator/templates/deployment.yaml
+++ b/charts/opensearch-operator/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         - --metrics-bind-address={{ .Values.manager.metricsBindAddress }}
         - --leader-elect
         - --enable-webhooks={{ .Values.webhook.enabled }}
+        - --enable-legacy-api={{ include "opensearch-operator.legacyAPIEnabled" . }}
         - --webhook-port={{ .Values.webhook.port }}
         {{- if .Values.manager.watchNamespace }}
         {{- if kindIs "slice" .Values.manager.watchNamespace }}

--- a/charts/opensearch-operator/templates/opensearch-operator-validating-webhook-configuration.yaml
+++ b/charts/opensearch-operator/templates/opensearch-operator-validating-webhook-configuration.yaml
@@ -8,6 +8,7 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "opensearch-operator.fullname" . }}-serving-cert
   {{- end }}
 webhooks:
+{{- if eq (include "opensearch-operator.legacyAPIEnabled" .) "true" }}
 - name: vopensearchactiongroup.opensearch.opster.io
   admissionReviewVersions:
   - v1
@@ -208,6 +209,7 @@ webhooks:
     resources:
     - opensearchuserrolebindings
   sideEffects: None
+{{- end }}
 # New API group: opensearch.org webhooks
 - name: vopensearchactiongroup.opensearch.org
   admissionReviewVersions:
@@ -410,4 +412,3 @@ webhooks:
     - opensearchuserrolebindings
   sideEffects: None
 {{- end }}
-

--- a/charts/opensearch-operator/templates/rbac.yaml
+++ b/charts/opensearch-operator/templates/rbac.yaml
@@ -83,7 +83,9 @@ rules:
   - update
   - watch
 - apiGroups:
+  {{- if eq (include "opensearch-operator.legacyAPIEnabled" .) "true" }}
   - opensearch.opster.io
+  {{- end }}
   - opensearch.org
   resources:
   - opensearchactiongroups
@@ -105,7 +107,9 @@ rules:
   - update
   - watch
 - apiGroups:
+  {{- if eq (include "opensearch-operator.legacyAPIEnabled" .) "true" }}
   - opensearch.opster.io
+  {{- end }}
   - opensearch.org
   resources:
   - opensearchactiongroups/finalizers
@@ -121,7 +125,9 @@ rules:
   verbs:
   - update
 - apiGroups:
+  {{- if eq (include "opensearch-operator.legacyAPIEnabled" .) "true" }}
   - opensearch.opster.io
+  {{- end }}
   - opensearch.org
   resources:
   - opensearchactiongroups/status

--- a/charts/opensearch-operator/values.yaml
+++ b/charts/opensearch-operator/values.yaml
@@ -74,6 +74,10 @@ manager:
 # Install the Custom Resource Definitions with Helm
 installCRDs: true
 
+legacyAPI:
+  # -- Enable support for the deprecated `opensearch.opster.io/v1` API group. When false, deprecated CRDs, webhooks, RBAC rules, and manager watches are skipped.
+  enabled: true
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/docs/userguide/main.md
+++ b/docs/userguide/main.md
@@ -108,6 +108,24 @@ manager:
   #    value: somevalue
 ```
 
+### Legacy API support
+
+Support for the deprecated `opensearch.opster.io/v1` API group is enabled by
+default. After migrating to `opensearch.org/v1`, it can be disabled in the
+operator Helm values:
+
+```yaml
+legacyAPI:
+  enabled: false
+```
+
+> **Warning:** Do not disable legacy API support while
+> `opensearch.opster.io` resources still exist. The legacy CRDs are managed as
+> regular Helm release resources, so disabling the legacy API during an upgrade
+> removes those CRDs and deletes all remaining custom resources stored under
+> them. Follow the [migration guide](./migration-guide.md) to migrate, verify,
+> and delete every legacy resource before changing this setting.
+
 ### Pprof endpoints
 
 There have been situations reported where the operator is leaking memory. To help diagnose these situations the standard go [pprof](https://pkg.go.dev/net/http/pprof) endpoints can be enabled by adding the following to your `values.yaml`:

--- a/docs/userguide/migration-guide.md
+++ b/docs/userguide/migration-guide.md
@@ -175,6 +175,41 @@ kubectl delete opensearchclusters.opensearch.opster.io <cluster-name>
 - Deleting the old resource will not affect the new resource - they operate independently after migration.
 - The migration controller automatically handles the deletion of old resources when new resources are deleted.
 
+### Step 8: Disable Legacy API Support
+
+Complete this step only after every legacy resource has migrated, its
+`opensearch.org` replacement has been verified, and the legacy resource has
+been deleted.
+
+> **Warning:** Helm manages the legacy CRDs as regular Helm resources.
+> Setting `legacyAPI.enabled=false` during an upgrade removes the
+> `opensearch.opster.io` CRDs. Kubernetes then deletes every remaining custom
+> resource stored under those CRDs across the cluster.
+
+Check every legacy resource type and namespace before disabling support:
+
+```bash
+kubectl api-resources --api-group=opensearch.opster.io -o name |
+  while read -r resource; do
+    kubectl get "$resource" --all-namespaces
+  done
+```
+
+If the command reports any resources, finish migrating and deleting them as
+described in the preceding steps. When no legacy resources remain, disable
+legacy API support:
+
+```bash
+helm upgrade <release-name> opensearch-operator/opensearch-operator \
+  --namespace <operator-namespace> \
+  --reuse-values \
+  --set legacyAPI.enabled=false
+```
+
+This also disables the legacy migration controllers, validation webhooks, and
+RBAC rules. Continue using only `opensearch.org/v1` resources after the
+upgrade.
+
 ## Resource Mapping
 
 All CRDs have equivalent types in the new API group:

--- a/opensearch-operator/main.go
+++ b/opensearch-operator/main.go
@@ -70,6 +70,12 @@ func parseWatchNamespaces(watchNamespace string) map[string]cache.Config {
 	return namespaces
 }
 
+func registerLegacyAPIComponents(enabled bool, register func()) {
+	if enabled {
+		register()
+	}
+}
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(opsterv1.AddToScheme(scheme))
@@ -255,7 +261,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if enableLegacyAPI {
+	registerLegacyAPIComponents(enableLegacyAPI, func() {
 		// Migration controllers for opensearch.opster.io -> opensearch.org migration
 		if err = (&controllers.ClusterMigrationReconciler{
 			Client: mgr.GetClient(),
@@ -327,7 +333,8 @@ func main() {
 			setupLog.Error(err, "unable to create controller", "controller", "ComponentTemplateMigration")
 			os.Exit(1)
 		}
-	} else {
+	})
+	if !enableLegacyAPI {
 		setupLog.Info("Legacy API disabled; skipping opensearch.opster.io migration controllers")
 	}
 
@@ -375,7 +382,7 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchCluster")
 			os.Exit(1)
 		}
-		if enableLegacyAPI {
+		registerLegacyAPIComponents(enableLegacyAPI, func() {
 			// Register legacy webhooks to deny user updates to old CRs (only operator can update for sync)
 			if err = (&opsterwebhook.OpenSearchClusterLegacyValidator{}).SetupWithManager(mgr); err != nil {
 				setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchClusterLegacy")
@@ -417,7 +424,8 @@ func main() {
 				setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchUserRoleBindingLegacy")
 				os.Exit(1)
 			}
-		} else {
+		})
+		if !enableLegacyAPI {
 			setupLog.Info("Legacy API disabled; skipping opensearch.opster.io webhooks")
 		}
 	} else {

--- a/opensearch-operator/main.go
+++ b/opensearch-operator/main.go
@@ -82,6 +82,7 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var enableWebhooks bool
+	var enableLegacyAPI bool
 	var webhookPort int
 	var probeAddr string
 	var watchNamespace string
@@ -92,6 +93,7 @@ func main() {
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableWebhooks, "enable-webhooks", true, "Enable validating webhooks for OpenSearch custom resources.")
+	flag.BoolVar(&enableLegacyAPI, "enable-legacy-api", true, "Enable support for the deprecated opensearch.opster.io/v1 API group.")
 	flag.IntVar(&webhookPort, "webhook-port", 9443, "Port used by the validating webhook server.")
 	flag.StringVar(&watchNamespace, "watch-namespace", "",
 		"The comma-separated list of namespaces that the controller manager is restricted to watch. If not set, default is to watch all namespaces.")
@@ -253,76 +255,80 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Migration controllers for opensearch.opster.io -> opensearch.org migration
-	if err = (&controllers.ClusterMigrationReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ClusterMigration")
-		os.Exit(1)
-	}
-	if err = (&controllers.UserMigrationReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "UserMigration")
-		os.Exit(1)
-	}
-	if err = (&controllers.RoleMigrationReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "RoleMigration")
-		os.Exit(1)
-	}
-	if err = (&controllers.UserRoleBindingMigrationReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "UserRoleBindingMigration")
-		os.Exit(1)
-	}
-	if err = (&controllers.TenantMigrationReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "TenantMigration")
-		os.Exit(1)
-	}
-	if err = (&controllers.ActionGroupMigrationReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ActionGroupMigration")
-		os.Exit(1)
-	}
-	if err = (&controllers.ISMPolicyMigrationReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ISMPolicyMigration")
-		os.Exit(1)
-	}
-	if err = (&controllers.SnapshotPolicyMigrationReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "SnapshotPolicyMigration")
-		os.Exit(1)
-	}
-	if err = (&controllers.IndexTemplateMigrationReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "IndexTemplateMigration")
-		os.Exit(1)
-	}
-	if err = (&controllers.ComponentTemplateMigrationReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ComponentTemplateMigration")
-		os.Exit(1)
+	if enableLegacyAPI {
+		// Migration controllers for opensearch.opster.io -> opensearch.org migration
+		if err = (&controllers.ClusterMigrationReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "ClusterMigration")
+			os.Exit(1)
+		}
+		if err = (&controllers.UserMigrationReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "UserMigration")
+			os.Exit(1)
+		}
+		if err = (&controllers.RoleMigrationReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "RoleMigration")
+			os.Exit(1)
+		}
+		if err = (&controllers.UserRoleBindingMigrationReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "UserRoleBindingMigration")
+			os.Exit(1)
+		}
+		if err = (&controllers.TenantMigrationReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "TenantMigration")
+			os.Exit(1)
+		}
+		if err = (&controllers.ActionGroupMigrationReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "ActionGroupMigration")
+			os.Exit(1)
+		}
+		if err = (&controllers.ISMPolicyMigrationReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "ISMPolicyMigration")
+			os.Exit(1)
+		}
+		if err = (&controllers.SnapshotPolicyMigrationReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "SnapshotPolicyMigration")
+			os.Exit(1)
+		}
+		if err = (&controllers.IndexTemplateMigrationReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "IndexTemplateMigration")
+			os.Exit(1)
+		}
+		if err = (&controllers.ComponentTemplateMigrationReconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "ComponentTemplateMigration")
+			os.Exit(1)
+		}
+	} else {
+		setupLog.Info("Legacy API disabled; skipping opensearch.opster.io migration controllers")
 	}
 
 	//+kubebuilder:scaffold:builder
@@ -369,46 +375,50 @@ func main() {
 			setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchCluster")
 			os.Exit(1)
 		}
-		// Register legacy webhooks to deny user updates to old CRs (only operator can update for sync)
-		if err = (&opsterwebhook.OpenSearchClusterLegacyValidator{}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchClusterLegacy")
-			os.Exit(1)
-		}
-		if err = (&opsterwebhook.OpenSearchUserLegacyValidator{}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchUserLegacy")
-			os.Exit(1)
-		}
-		if err = (&opsterwebhook.OpenSearchRoleLegacyValidator{}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchRoleLegacy")
-			os.Exit(1)
-		}
-		if err = (&opsterwebhook.OpenSearchTenantLegacyValidator{}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchTenantLegacy")
-			os.Exit(1)
-		}
-		if err = (&opsterwebhook.OpenSearchActionGroupLegacyValidator{}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchActionGroupLegacy")
-			os.Exit(1)
-		}
-		if err = (&opsterwebhook.OpenSearchComponentTemplateLegacyValidator{}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchComponentTemplateLegacy")
-			os.Exit(1)
-		}
-		if err = (&opsterwebhook.OpenSearchIndexTemplateLegacyValidator{}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchIndexTemplateLegacy")
-			os.Exit(1)
-		}
-		if err = (&opsterwebhook.OpenSearchISMPolicyLegacyValidator{}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchISMPolicyLegacy")
-			os.Exit(1)
-		}
-		if err = (&opsterwebhook.OpenSearchSnapshotPolicyLegacyValidator{}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchSnapshotPolicyLegacy")
-			os.Exit(1)
-		}
-		if err = (&opsterwebhook.OpenSearchUserRoleBindingLegacyValidator{}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchUserRoleBindingLegacy")
-			os.Exit(1)
+		if enableLegacyAPI {
+			// Register legacy webhooks to deny user updates to old CRs (only operator can update for sync)
+			if err = (&opsterwebhook.OpenSearchClusterLegacyValidator{}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchClusterLegacy")
+				os.Exit(1)
+			}
+			if err = (&opsterwebhook.OpenSearchUserLegacyValidator{}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchUserLegacy")
+				os.Exit(1)
+			}
+			if err = (&opsterwebhook.OpenSearchRoleLegacyValidator{}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchRoleLegacy")
+				os.Exit(1)
+			}
+			if err = (&opsterwebhook.OpenSearchTenantLegacyValidator{}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchTenantLegacy")
+				os.Exit(1)
+			}
+			if err = (&opsterwebhook.OpenSearchActionGroupLegacyValidator{}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchActionGroupLegacy")
+				os.Exit(1)
+			}
+			if err = (&opsterwebhook.OpenSearchComponentTemplateLegacyValidator{}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchComponentTemplateLegacy")
+				os.Exit(1)
+			}
+			if err = (&opsterwebhook.OpenSearchIndexTemplateLegacyValidator{}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchIndexTemplateLegacy")
+				os.Exit(1)
+			}
+			if err = (&opsterwebhook.OpenSearchISMPolicyLegacyValidator{}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchISMPolicyLegacy")
+				os.Exit(1)
+			}
+			if err = (&opsterwebhook.OpenSearchSnapshotPolicyLegacyValidator{}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchSnapshotPolicyLegacy")
+				os.Exit(1)
+			}
+			if err = (&opsterwebhook.OpenSearchUserRoleBindingLegacyValidator{}).SetupWithManager(mgr); err != nil {
+				setupLog.Error(err, "unable to create webhook", "webhook", "OpenSearchUserRoleBindingLegacy")
+				os.Exit(1)
+			}
+		} else {
+			setupLog.Info("Legacy API disabled; skipping opensearch.opster.io webhooks")
 		}
 	} else {
 		setupLog.Info("Webhooks disabled; skipping webhook registration")

--- a/opensearch-operator/main_test.go
+++ b/opensearch-operator/main_test.go
@@ -42,3 +42,35 @@ func TestParseWatchNamespacesTrimAndSkipEmpty(t *testing.T) {
 		t.Fatalf("expected namespace2 to be present")
 	}
 }
+
+func TestRegisterLegacyAPIComponents(t *testing.T) {
+	tests := []struct {
+		name          string
+		enabled       bool
+		expectedCalls int
+	}{
+		{
+			name:          "enabled",
+			enabled:       true,
+			expectedCalls: 1,
+		},
+		{
+			name:          "disabled",
+			enabled:       false,
+			expectedCalls: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			calls := 0
+			registerLegacyAPIComponents(test.enabled, func() {
+				calls++
+			})
+
+			if calls != test.expectedCalls {
+				t.Fatalf("expected %d registrations, got %d", test.expectedCalls, calls)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
Add a Helm value that controls whether the deprecated opensearch.opster.io CRDs, webhooks, and RBAC rules are rendered.

Pass the same setting to the manager so it can skip legacy migration controllers and legacy webhook registration when those CRDs are not installed.

### Issues Resolved
Fixes #1411

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
