### PR TITLE
fix: add client-side timeouts to the OpenSearch HTTP transport

### DIFF
--- a/opensearch-operator/opensearch-gateway/services/os_client.go
+++ b/opensearch-operator/opensearch-gateway/services/os_client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -91,6 +92,16 @@ func NewOsClusterClient(clusterUrl string, username string, password string, opt
 			}
 			return &http.Transport{
 				TLSClientConfig: tlsCfg,
+				// Bound every phase of a request so that an unresponsive endpoint
+				// (e.g. a node that died without closing connections, or a wedged
+				// load balancer) cannot block a reconcile worker indefinitely.
+				// GetClusterHealth's Timeout parameter is a server-side master
+				// timeout and does not protect the client.
+				DialContext: (&net.Dialer{
+					Timeout: 5 * time.Second,
+				}).DialContext,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ResponseHeaderTimeout: 30 * time.Second,
 				// These options are needed as otherwise connections would be kept and leak memory
 				// Connection reuse is not really possible due to each reconcile run being independent
 				DisableKeepAlives: true,


### PR DESCRIPTION
### Description

The operator's OpenSearch HTTP client had no client-side timeouts at all: the hand-built `http.Transport` set no dial, TLS handshake, or response-header timeout, and every request method in `os_client.go` uses `context.Background()`, so no deadline ever applies. (`GetClusterHealth`'s `Timeout` field is the server-side cluster-manager timeout parameter, not a client timeout.)

A single unresponsive endpoint — a node that died without closing connections, a wedged load balancer — blocks the reconcile worker indefinitely, and with the default of one concurrent reconcile per controller that stalls reconciliation of **every** cluster the operator manages.

This bounds each phase of a request at the transport level, which covers all call sites without touching method signatures:

- dial: 5s
- TLS handshake: 10s
- response headers: 30s (comfortably above the 10s server-side master timeout used by the health calls)

### Issues Resolved

Addresses the timeout portion of #1452; also relevant to the worker-stall discussion in #1333.
