### PR TITLE
fix: render gRPC transport settings as valid opensearch.yml

### DIFF
--- a/opensearch-operator/pkg/reconcilers/configuration.go
+++ b/opensearch-operator/pkg/reconcilers/configuration.go
@@ -308,15 +308,18 @@ func (r *ConfigurationReconciler) processGrpcConfig() {
 		return
 	}
 
-	// Set aux.transport.types to use transport-grpc
-	r.reconcilerContext.AddConfig("aux.transport.types", "[transport-grpc]")
+	// Set aux.transport.types to use transport-grpc.
+	// Values are passed in JSON form so buildConfigString's parseConfigValue
+	// turns them into real YAML types; hand-quoting here would end up inside
+	// the marshalled string values.
+	r.reconcilerContext.AddConfig("aux.transport.types", `["transport-grpc"]`)
 
 	// Set port if specified, otherwise use default
 	port := grpcConfig.Port
 	if port == "" {
 		port = "9400-9500"
 	}
-	r.reconcilerContext.AddConfig("aux.transport.transport-grpc.port", fmt.Sprintf("'%s'", port))
+	r.reconcilerContext.AddConfig("aux.transport.transport-grpc.port", port)
 
 	// Set host addresses
 	if len(grpcConfig.Host) > 0 {

--- a/opensearch-operator/pkg/reconcilers/configuration_test.go
+++ b/opensearch-operator/pkg/reconcilers/configuration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/goccy/go-yaml"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
@@ -130,6 +131,70 @@ var _ = Describe("Configuration Controller", func() {
 			Expect(strings.Contains(data, "foo:") || strings.Contains(data, "foo :")).To(BeTrue())
 			Expect(strings.Contains(data, "bar:") || strings.Contains(data, "bar :")).To(BeTrue())
 			Expect(strings.Contains(data, "baz")).To(BeTrue())
+		})
+	})
+
+	Context("When Reconciling with General.Grpc enabled", func() {
+		It("should render valid gRPC settings in opensearch.yml", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName,
+					Namespace: clusterName,
+					UID:       "dummyuid",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Grpc: &opensearchv1.GrpcConfig{
+							Enable: true,
+						},
+					},
+					NodePools: []opensearchv1.NodePool{
+						{
+							Component: "test",
+							Roles: []string{
+								"master",
+								"data",
+							},
+						},
+					},
+				},
+			}
+
+			mockClient.EXPECT().Scheme().Return(scheme.Scheme)
+			mockClient.EXPECT().Context().Return(context.Background())
+			var createdConfigMap *corev1.ConfigMap
+			mockClient.On("CreateConfigMap", mock.Anything).
+				Return(func(cm *corev1.ConfigMap) (*ctrl.Result, error) {
+					createdConfigMap = cm
+					return &ctrl.Result{}, nil
+				})
+
+			reconcilerContext := NewReconcilerContext(&helpers.MockEventRecorder{}, &spec, spec.Spec.NodePools)
+
+			underTest := newConfigurationReconciler(
+				mockClient,
+				&helpers.MockEventRecorder{},
+				&reconcilerContext,
+				&spec,
+			)
+			// In the real reconcile chain earlier reconcilers (e.g. TLS) always
+			// populate the context; an empty context short-circuits Reconcile.
+			reconcilerContext.AddConfig("foo", "bar")
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(createdConfigMap).ToNot(BeNil())
+			data, exists := createdConfigMap.Data["opensearch.yml"]
+			Expect(exists).To(BeTrue())
+
+			var parsed map[string]interface{}
+			Expect(yaml.Unmarshal([]byte(data), &parsed)).To(Succeed())
+			// types must be a real YAML list, not a quoted "[transport-grpc]" string
+			Expect(parsed["aux.transport.types"]).To(Equal([]interface{}{"transport-grpc"}))
+			// port must be the plain range without embedded quotes
+			Expect(parsed["aux.transport.transport-grpc.port"]).To(Equal("9400-9500"))
 		})
 	})
 


### PR DESCRIPTION
### Description

`processGrpcConfig` hand-quoted the values it registered, but `buildConfigString` YAML-marshals every config value, so the quoting ended up *inside* the emitted strings:

```yaml
aux.transport.types: "[transport-grpc]"          # a string with literal brackets, not a list
aux.transport.transport-grpc.port: "'9400-9500'" # embedded single quotes
```

OpenSearch rejects both at startup, so enabling `general.grpc` produced a config every node fails on — and because the change flows through the config checksum into a rolling restart, it crash-loops a running cluster pool by pool.

The fix passes the values in the same convention the rest of the config pipeline uses: the types value as JSON (so `parseConfigValue` emits a real YAML list) and the port range raw (so it marshals as a plain scalar):

```yaml
aux.transport.types:
- transport-grpc
aux.transport.transport-grpc.port: 9400-9500
```

Includes a regression test that reconciles a cluster with `grpc.enable: true` and asserts the rendered `opensearch.yml` parses back with the correct types.

### Issues Resolved

Fixes #1457
