### PR TITLE
fix: retry failed securityconfig-update jobs

### DIFF
--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -1408,8 +1408,8 @@ func NewSecurityconfigUpdateJob(
 			Labels:      jobLabels,
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit:            &backoffLimit,
-			ActiveDeadlineSeconds:   &activeDeadlineSeconds,
+			BackoffLimit:          &backoffLimit,
+			ActiveDeadlineSeconds: &activeDeadlineSeconds,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   jobName,

--- a/opensearch-operator/pkg/builders/cluster.go
+++ b/opensearch-operator/pkg/builders/cluster.go
@@ -1371,7 +1371,8 @@ func NewSecurityconfigUpdateJob(
 		securityconfigChecksumAnnotation: checksum,
 	}
 	terminationGracePeriodSeconds := int64(5)
-	backoffLimit := int32(0)
+	backoffLimit := int32(1)
+	activeDeadlineSeconds := int64(2400)
 
 	image := helpers.ResolveImage(instance, &node)
 	securityContext := instance.Spec.General.SecurityContext
@@ -1407,7 +1408,8 @@ func NewSecurityconfigUpdateJob(
 			Labels:      jobLabels,
 		},
 		Spec: batchv1.JobSpec{
-			BackoffLimit: &backoffLimit,
+			BackoffLimit:            &backoffLimit,
+			ActiveDeadlineSeconds:   &activeDeadlineSeconds,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   jobName,

--- a/opensearch-operator/pkg/builders/cluster_test.go
+++ b/opensearch-operator/pkg/builders/cluster_test.go
@@ -1535,6 +1535,14 @@ var _ = Describe("Builders", func() {
 			job := NewSecurityconfigUpdateJob(&clusterObject, "foobar", "foobar", "foobar", "admin-cert", "", "cmd", nil, nil)
 			Expect(job.Spec.Template.Spec.HostNetwork).To(BeTrue())
 		})
+
+		It("should retry failed securityconfig update jobs and enforce a deadline", func() {
+			clusterObject := ClusterDescWithVersion("2.2.1")
+
+			job := NewSecurityconfigUpdateJob(&clusterObject, "foobar", "foobar", "foobar", "admin-cert", "", "cmd", nil, nil)
+			Expect(*job.Spec.BackoffLimit).To(Equal(int32(1)))
+			Expect(*job.Spec.ActiveDeadlineSeconds).To(Equal(int64(2400)))
+		})
 	})
 
 	When("Configuring Security Config UpdateJob Tolerations", func() {

--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -36,7 +36,7 @@ const (
 	securityConfigStatusRunning = "Running"
 	securityConfigStatusFailed  = "Failed"
 
-	securityConfigRetryConditionPrefix    = "retry:"
+	securityConfigRetryConditionPrefix     = "retry:"
 	securityConfigLastRetryConditionPrefix = "lastRetry:"
 
 	securityConfigInitialRetryDelay = 30 * time.Second

--- a/opensearch-operator/pkg/reconcilers/securityconfig.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -15,6 +17,7 @@ import (
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconciler"
 	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
@@ -25,8 +28,21 @@ import (
 
 const (
 	securityConfigReconcilerName = "securityconfig"
+	securityConfigComponentName  = "Securityconfig"
 
 	checksumAnnotation = "securityconfig/checksum"
+
+	securityConfigStatusReady   = "Ready"
+	securityConfigStatusRunning = "Running"
+	securityConfigStatusFailed  = "Failed"
+
+	securityConfigRetryConditionPrefix    = "retry:"
+	securityConfigLastRetryConditionPrefix = "lastRetry:"
+
+	securityConfigInitialRetryDelay = 30 * time.Second
+	securityConfigMaxRetryDelay     = 15 * time.Minute
+
+	securityConfigConnectWaitAttempts = 60
 
 	adminCert = "/certs/tls.crt"
 	adminKey  = "/certs/tls.key"
@@ -34,9 +50,14 @@ const (
 
 	SecurityAdminBaseCmdTmpl = `ADMIN=%s/plugins/opensearch-security/tools/securityadmin.sh;
 chmod +x $ADMIN;
+wait_count=0;
 until curl -k --silent https://%s:%v;
 do
-echo 'Waiting to connect to the cluster'; sleep 20;
+  if (( wait_count++ >= %d )); then
+    echo "Failed to connect to cluster after %d attempts";
+    exit 1;
+  fi;
+  echo 'Waiting to connect to the cluster'; sleep 20;
 done;`
 
 	ApplyAllYmlCmdTmpl = `count=0;
@@ -183,11 +204,20 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 	cmdArg = BuildCmdArg(r.instance, &configSecret, r.logger)
 
 	job, err := r.client.GetJob(jobName, namespace)
+	resetRetryCount := false
 	if err == nil {
 		value, exists := job.Annotations[checksumAnnotation]
 		if exists && value == checksumval {
-			// Nothing to do, current securityconfig already applied
-			return ctrl.Result{}, nil
+			result, done, handleErr := r.handleExistingSecurityConfigJob(job, annotations)
+			if handleErr != nil {
+				return ctrl.Result{}, handleErr
+			}
+			if done {
+				return result, nil
+			}
+			// Failed job past backoff window: delete and recreate below.
+		} else {
+			resetRetryCount = true
 		}
 		// Delete old job
 		r.logger.Info("Deleting old update job")
@@ -196,6 +226,15 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 			return ctrl.Result{}, err
 		}
 	}
+	if resetRetryCount {
+		if err := r.updateSecurityConfigComponentStatus(securityConfigStatusRunning, "", r.securityConfigRetryConditions(0, time.Time{})); err != nil {
+			r.logger.Error(err, "Unable to reset securityconfig retry status")
+			return ctrl.Result{}, err
+		}
+	} else if err := r.updateSecurityConfigComponentStatus(securityConfigStatusRunning, "", r.currentSecurityConfigRetryConditions()); err != nil {
+		r.logger.Error(err, "Unable to update securityconfig status")
+		return ctrl.Result{}, err
+	}
 
 	// If the cluster has not yet initialized or
 	// securityconfig secret was not passed, build the command to apply all yml files
@@ -203,7 +242,7 @@ func (r *SecurityconfigReconciler) Reconcile() (ctrl.Result, error) {
 		clusterHostName := BuildClusterSvcHostName(r.instance)
 		opensearchHome := r.instance.Spec.General.GetOpenSearchHome()
 		httpPort, securityConfigPort, securityconfigPath := helpers.VersionCheck(r.instance)
-		cmdArg = fmt.Sprintf(SecurityAdminBaseCmdTmpl, opensearchHome, clusterHostName, httpPort) +
+		cmdArg = fmt.Sprintf(SecurityAdminBaseCmdTmpl, opensearchHome, clusterHostName, httpPort, securityConfigConnectWaitAttempts, securityConfigConnectWaitAttempts) +
 			fmt.Sprintf(ApplyAllYmlCmdTmpl, caCert, adminCert, adminKey, securityconfigPath, clusterHostName, securityConfigPort)
 	}
 
@@ -237,7 +276,7 @@ func BuildCmdArg(instance *opensearchv1.OpenSearchCluster, secret *corev1.Secret
 	opensearchHome := instance.Spec.General.GetOpenSearchHome()
 	httpPort, securityConfigPort, securityconfigPath := helpers.VersionCheck(instance)
 
-	arg := fmt.Sprintf(SecurityAdminBaseCmdTmpl, opensearchHome, clusterHostName, httpPort)
+	arg := fmt.Sprintf(SecurityAdminBaseCmdTmpl, opensearchHome, clusterHostName, httpPort, securityConfigConnectWaitAttempts, securityConfigConnectWaitAttempts)
 
 	// Get the list of yml files and sort them
 	// This will ensure commands are always generated in the same order
@@ -349,4 +388,141 @@ func (r *SecurityconfigReconciler) securityconfigSubpaths(instance *opensearchv1
 // BuildClusterSvcHostName builds the cluster host name as {svc-name}.{namespace}.svc.{dns-base}
 func BuildClusterSvcHostName(instance *opensearchv1.OpenSearchCluster) string {
 	return fmt.Sprintf("%s.svc.%s", builders.DnsOfService(instance), helpers.ClusterDnsBase())
+}
+
+func (r *SecurityconfigReconciler) handleExistingSecurityConfigJob(
+	job batchv1.Job,
+	annotations map[string]string,
+) (ctrl.Result, bool, error) {
+	if job.Status.Succeeded > 0 {
+		if err := r.updateSecurityConfigComponentStatus(securityConfigStatusReady, "", nil); err != nil {
+			return ctrl.Result{}, true, err
+		}
+		return ctrl.Result{}, true, nil
+	}
+
+	if job.Status.Active > 0 {
+		if err := r.updateSecurityConfigComponentStatus(securityConfigStatusRunning, "", nil); err != nil {
+			return ctrl.Result{}, true, err
+		}
+		return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, true, nil
+	}
+
+	if job.Status.Failed > 0 {
+		retryCount := r.securityConfigRetryCount()
+		delay := securityConfigRetryDelay(retryCount)
+		lastRetry := r.securityConfigLastRetry()
+		if !lastRetry.IsZero() && time.Since(lastRetry) < delay {
+			remaining := delay - time.Since(lastRetry)
+			if err := r.updateSecurityConfigComponentStatus(
+				securityConfigStatusFailed,
+				"securityconfig update job failed",
+				r.securityConfigRetryConditions(retryCount, lastRetry),
+			); err != nil {
+				return ctrl.Result{}, true, err
+			}
+			return ctrl.Result{Requeue: true, RequeueAfter: remaining}, true, nil
+		}
+
+		retryCount++
+		now := time.Now().UTC()
+		r.recorder.AnnotatedEventf(
+			r.instance,
+			annotations,
+			"Warning",
+			"Security",
+			"Securityconfig update job failed, retrying (attempt %d)",
+			retryCount,
+		)
+		if err := r.updateSecurityConfigComponentStatus(
+			securityConfigStatusFailed,
+			"securityconfig update job failed",
+			r.securityConfigRetryConditions(retryCount, now),
+		); err != nil {
+			return ctrl.Result{}, true, err
+		}
+		return ctrl.Result{}, false, nil
+	}
+
+	if err := r.updateSecurityConfigComponentStatus(securityConfigStatusRunning, "", nil); err != nil {
+		return ctrl.Result{}, true, err
+	}
+	return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, true, nil
+}
+
+func (r *SecurityconfigReconciler) updateSecurityConfigComponentStatus(status, description string, conditions []string) error {
+	return UpdateComponentStatus(r.client, r.instance, &opensearchv1.ComponentStatus{
+		Component:   securityConfigComponentName,
+		Status:      status,
+		Description: description,
+		Conditions:  conditions,
+	})
+}
+
+func (r *SecurityconfigReconciler) securityConfigComponentStatus() (opensearchv1.ComponentStatus, bool) {
+	for _, componentStatus := range r.instance.Status.ComponentsStatus {
+		if componentStatus.Component == securityConfigComponentName {
+			return componentStatus, true
+		}
+	}
+	return opensearchv1.ComponentStatus{}, false
+}
+
+func (r *SecurityconfigReconciler) securityConfigRetryCount() int {
+	componentStatus, found := r.securityConfigComponentStatus()
+	if !found {
+		return 0
+	}
+	for _, condition := range componentStatus.Conditions {
+		if strings.HasPrefix(condition, securityConfigRetryConditionPrefix) {
+			retryCount, err := strconv.Atoi(strings.TrimPrefix(condition, securityConfigRetryConditionPrefix))
+			if err == nil {
+				return retryCount
+			}
+		}
+	}
+	return 0
+}
+
+func (r *SecurityconfigReconciler) securityConfigLastRetry() time.Time {
+	componentStatus, found := r.securityConfigComponentStatus()
+	if !found {
+		return time.Time{}
+	}
+	for _, condition := range componentStatus.Conditions {
+		if strings.HasPrefix(condition, securityConfigLastRetryConditionPrefix) {
+			lastRetry, err := time.Parse(time.RFC3339, strings.TrimPrefix(condition, securityConfigLastRetryConditionPrefix))
+			if err == nil {
+				return lastRetry
+			}
+		}
+	}
+	return time.Time{}
+}
+
+func (r *SecurityconfigReconciler) securityConfigRetryConditions(retryCount int, lastRetry time.Time) []string {
+	conditions := []string{fmt.Sprintf("%s%d", securityConfigRetryConditionPrefix, retryCount)}
+	if !lastRetry.IsZero() {
+		conditions = append(conditions, fmt.Sprintf("%s%s", securityConfigLastRetryConditionPrefix, lastRetry.Format(time.RFC3339)))
+	}
+	return conditions
+}
+
+func (r *SecurityconfigReconciler) currentSecurityConfigRetryConditions() []string {
+	componentStatus, found := r.securityConfigComponentStatus()
+	if found {
+		return componentStatus.Conditions
+	}
+	return nil
+}
+
+func securityConfigRetryDelay(retryCount int) time.Duration {
+	delay := securityConfigInitialRetryDelay
+	for i := 0; i < retryCount; i++ {
+		delay *= 2
+		if delay >= securityConfigMaxRetryDelay {
+			return securityConfigMaxRetryDelay
+		}
+	}
+	return delay
 }

--- a/opensearch-operator/pkg/reconcilers/securityconfig_test.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig_test.go
@@ -3,6 +3,7 @@ package reconcilers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -351,9 +352,14 @@ config:
 
 			cmdArg := `ADMIN=/usr/share/opensearch/plugins/opensearch-security/tools/securityadmin.sh;
 chmod +x $ADMIN;
+wait_count=0;
 until curl -k --silent https://no-securityconfig-tls-configured.no-securityconfig-tls-configured.svc.cluster.local:9200;
 do
-echo 'Waiting to connect to the cluster'; sleep 20;
+  if (( wait_count++ >= 60 )); then
+    echo "Failed to connect to cluster after 60 attempts";
+    exit 1;
+  fi;
+  echo 'Waiting to connect to the cluster'; sleep 20;
 done;count=0;
 until $ADMIN -cacert /certs/ca.crt -cert /certs/tls.crt -key /certs/tls.key -cd /usr/share/opensearch/config/opensearch-security -icl -nhnv -h no-securityconfig-tls-configured.no-securityconfig-tls-configured.svc.cluster.local -p 9200; do
   if (( count++ >= 20 )); then
@@ -364,6 +370,145 @@ until $ADMIN -cacert /certs/ca.crt -cert /certs/tls.crt -key /certs/tls.key -cd 
 done;`
 
 			Expect(createdJob.Spec.Template.Spec.Containers[0].Args[0]).To(Equal(cmdArg))
+		})
+	})
+
+	When("Reconciling with a failed securityconfig update job", func() {
+		buildReconcileFixture := func(mockClient *k8s.MockK8sClient) (*opensearchv1.OpenSearchCluster, *corev1.Secret) {
+			adminCredSecret := newAdminCredentialsSecret(clusterName)
+			securityConfigSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "securityconfig-secret", Namespace: clusterName},
+				Type:       corev1.SecretType("Opaque"),
+				Data: map[string][]byte{
+					"config.yml":         []byte(configYAML),
+					"internal_users.yml": internalUsersYAML("", ""),
+				},
+			}
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: clusterName, UID: "dummyuid"},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						ServiceName: clusterName,
+						Version:     "2.3",
+					},
+					Security: &opensearchv1.Security{
+						Config: &opensearchv1.SecurityConfig{
+							SecurityconfigSecret:   corev1.LocalObjectReference{Name: "securityconfig-secret"},
+							AdminCredentialsSecret: corev1.LocalObjectReference{Name: adminCredsName},
+						},
+						Tls: &opensearchv1.TlsConfig{
+							Transport: &opensearchv1.TlsConfigTransport{Generate: true},
+							Http:      &opensearchv1.TlsConfigHttp{Generate: true},
+						},
+					},
+				},
+				Status: opensearchv1.ClusterStatus{
+					Initialized:          true,
+					ContextSecretCreated: true,
+				},
+			}
+			generatedConfigName := helpers.GeneratedSecurityConfigSecretName(&spec)
+
+			mockClient.EXPECT().GetSecret(adminCredsName, clusterName).Return(adminCredSecret, nil)
+			mockClient.EXPECT().GetSecret("securityconfig-secret", clusterName).Return(*securityConfigSecret, nil)
+			setupDashboardsCredentialsSecretMocks(mockClient, clusterName)
+			mockClient.On("GetSecret", generatedConfigName, clusterName).
+				Return(corev1.Secret{}, NotFoundError()).Once()
+			mockClient.EXPECT().Scheme().Return(scheme.Scheme)
+			mockClient.On("UpdateOpenSearchClusterStatus", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+			var generatedConfigSecret *corev1.Secret
+			mockClient.On("ReconcileResource", mock.AnythingOfType("*v1.Secret"), mock.Anything).
+				Return(&ctrl.Result{}, nil).
+				Run(func(args mock.Arguments) {
+					if secret, ok := args[0].(*corev1.Secret); ok && secret.Name == generatedConfigName {
+						generatedConfigSecret = secret.DeepCopy()
+					}
+				})
+			mockClient.On("GetSecret", generatedConfigName, clusterName).
+				Return(func(string, string) corev1.Secret {
+					Expect(generatedConfigSecret).ToNot(BeNil())
+					return *generatedConfigSecret
+				}, nil).Once()
+
+			return &spec, generatedConfigSecret
+		}
+
+		jobWithStatus := func(generatedConfigSecret *corev1.Secret, status batchv1.JobStatus) batchv1.Job {
+			Expect(generatedConfigSecret).ToNot(BeNil())
+			checksumval, err := checksum(generatedConfigSecret.Data)
+			Expect(err).ToNot(HaveOccurred())
+			return batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "securityconfig-securityconfig-update",
+					Namespace:   clusterName,
+					Annotations: map[string]string{checksumAnnotation: checksumval},
+				},
+				Status: status,
+			}
+		}
+
+		It("should not recreate the job when it already succeeded", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			spec, generatedConfigSecret := buildReconcileFixture(mockClient)
+			mockClient.EXPECT().GetJob("securityconfig-securityconfig-update", clusterName).
+				RunAndReturn(func(string, string) (batchv1.Job, error) {
+					return jobWithStatus(generatedConfigSecret, batchv1.JobStatus{Succeeded: 1}), nil
+				})
+
+			reconcilerContext := NewReconcilerContext(&record.FakeRecorder{}, spec, spec.Spec.NodePools)
+			underTest := newSecurityconfigReconciler(mockClient, context.Background(), &reconcilerContext, spec)
+			result, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IsZero()).To(BeTrue())
+		})
+
+		It("should requeue while the update job is still running", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			spec, generatedConfigSecret := buildReconcileFixture(mockClient)
+			mockClient.EXPECT().GetJob("securityconfig-securityconfig-update", clusterName).
+				RunAndReturn(func(string, string) (batchv1.Job, error) {
+					return jobWithStatus(generatedConfigSecret, batchv1.JobStatus{Active: 1}), nil
+				})
+
+			reconcilerContext := NewReconcilerContext(&record.FakeRecorder{}, spec, spec.Spec.NodePools)
+			underTest := newSecurityconfigReconciler(mockClient, context.Background(), &reconcilerContext, spec)
+			result, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue())
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+		})
+
+		It("should delete and recreate the job when it failed with a matching checksum", func() {
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			spec, generatedConfigSecret := buildReconcileFixture(mockClient)
+			mockClient.EXPECT().GetJob("securityconfig-securityconfig-update", clusterName).
+				RunAndReturn(func(string, string) (batchv1.Job, error) {
+					return jobWithStatus(generatedConfigSecret, batchv1.JobStatus{Failed: 1}), nil
+				})
+			mockClient.EXPECT().DeleteJob(mock.AnythingOfType("*v1.Job")).Return(nil)
+
+			var createdJob *batchv1.Job
+			mockClient.On("CreateJob", mock.Anything).
+				Return(func(job *batchv1.Job) (*ctrl.Result, error) {
+					createdJob = job
+					return &ctrl.Result{}, nil
+				})
+
+			reconcilerContext := NewReconcilerContext(&record.FakeRecorder{}, spec, spec.Spec.NodePools)
+			underTest := newSecurityconfigReconciler(mockClient, context.Background(), &reconcilerContext, spec)
+			_, err := underTest.Reconcile()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createdJob).ToNot(BeNil())
+		})
+	})
+
+	Describe("securityConfigRetryDelay", func() {
+		It("should use exponential backoff capped at the maximum delay", func() {
+			Expect(securityConfigRetryDelay(0)).To(Equal(30 * time.Second))
+			Expect(securityConfigRetryDelay(1)).To(Equal(60 * time.Second))
+			Expect(securityConfigRetryDelay(2)).To(Equal(120 * time.Second))
+			Expect(securityConfigRetryDelay(10)).To(Equal(15 * time.Minute))
 		})
 	})
 

--- a/opensearch-operator/pkg/reconcilers/securityconfig_test.go
+++ b/opensearch-operator/pkg/reconcilers/securityconfig_test.go
@@ -374,7 +374,7 @@ done;`
 	})
 
 	When("Reconciling with a failed securityconfig update job", func() {
-		buildReconcileFixture := func(mockClient *k8s.MockK8sClient) (*opensearchv1.OpenSearchCluster, *corev1.Secret) {
+		buildReconcileFixture := func(mockClient *k8s.MockK8sClient) (*opensearchv1.OpenSearchCluster, **corev1.Secret) {
 			adminCredSecret := newAdminCredentialsSecret(clusterName)
 			securityConfigSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "securityconfig-secret", Namespace: clusterName},
@@ -431,12 +431,12 @@ done;`
 					return *generatedConfigSecret
 				}, nil).Once()
 
-			return &spec, generatedConfigSecret
+			return &spec, &generatedConfigSecret
 		}
 
-		jobWithStatus := func(generatedConfigSecret *corev1.Secret, status batchv1.JobStatus) batchv1.Job {
-			Expect(generatedConfigSecret).ToNot(BeNil())
-			checksumval, err := checksum(generatedConfigSecret.Data)
+		jobWithStatus := func(generatedConfigSecret **corev1.Secret, status batchv1.JobStatus) batchv1.Job {
+			Expect(*generatedConfigSecret).ToNot(BeNil())
+			checksumval, err := checksum((*generatedConfigSecret).Data)
 			Expect(err).ToNot(HaveOccurred())
 			return batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### Description
stop treating a matching checksum as success when the job failed, and retry with backoff so password rotation cannot wedge the cluster

fix #1456

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
