### PR TITLE
Fix RollingRestart findStatus returning wrong ComponentsStatus entry

### DIFF
--- a/opensearch-operator/pkg/reconcilers/rollingRestart.go
+++ b/opensearch-operator/pkg/reconcilers/rollingRestart.go
@@ -411,11 +411,11 @@ func (r *RollingRestartReconciler) updateStatus(status string) error {
 
 func (r *RollingRestartReconciler) findStatus() *opensearchv1.ComponentStatus {
 	comp := r.instance.Status.ComponentsStatus
-	_, found := helpers.FindFirstPartial(comp, opensearchv1.ComponentStatus{
+	found, ok := helpers.FindFirstPartial(comp, opensearchv1.ComponentStatus{
 		Component: componentName,
 	}, helpers.GetByComponent)
-	if found {
-		return &comp[0]
+	if ok {
+		return &found
 	}
 	return nil
 }

--- a/opensearch-operator/pkg/reconcilers/rollingRestart_test.go
+++ b/opensearch-operator/pkg/reconcilers/rollingRestart_test.go
@@ -91,4 +91,41 @@ var _ = Describe("RollingRestart Reconciler", func() {
 			})
 		})
 	})
+
+	Describe("findStatus", func() {
+		Context("when ComponentsStatus has a non-RollingRestart entry at index 0", func() {
+			It("should return the matched RollingRestart entry, not comp[0]", func() {
+				instance := &opensearchv1.OpenSearchCluster{
+					Status: opensearchv1.ClusterStatus{
+						ComponentsStatus: []opensearchv1.ComponentStatus{
+							{Component: "Scaler", Status: statusInProgress},
+							{Component: componentName, Status: statusInProgress},
+						},
+					},
+				}
+				r := &RollingRestartReconciler{instance: instance}
+
+				found := r.findStatus()
+
+				Expect(found).NotTo(BeNil())
+				Expect(found.Component).To(Equal(componentName))
+				Expect(found.Status).To(Equal(statusInProgress))
+			})
+		})
+
+		Context("when there is no RollingRestart entry", func() {
+			It("should return nil", func() {
+				instance := &opensearchv1.OpenSearchCluster{
+					Status: opensearchv1.ClusterStatus{
+						ComponentsStatus: []opensearchv1.ComponentStatus{
+							{Component: "Scaler", Status: statusInProgress},
+						},
+					},
+				}
+				r := &RollingRestartReconciler{instance: instance}
+
+				Expect(r.findStatus()).To(BeNil())
+			})
+		})
+	})
 })


### PR DESCRIPTION
## What / Why
`RollingRestartReconciler.findStatus` discarded the item returned by `helpers.FindFirstPartial` and instead returned `&comp[0]` (whatever happened to be first in `Status.ComponentsStatus`). Because that list also carries `Scaler`/`Upgrader` entries (and leftover `RollingRestart: Finished` entries), index 0 is frequently not the `RollingRestart` entry that was searched for.

Closes #1450

## Effect
The restart completion branch in `Reconcile` (`status != nil && status.Status == statusInProgress`) then read the wrong component, so `ReactivateShardAllocation` never ran and `cluster.routing.allocation.enable: primaries` was left set after a restart, leaving the cluster yellow (reported in #293).

## Fix
Use the matched item returned by `FindFirstPartial` instead of `comp[0]`.

## Verification
- Added a regression test in `rollingRestart_test.go` covering (a) a non-RollingRestart entry at index 0 and (b) no RollingRestart entry at all.
- `go build ./pkg/reconcilers/...`, `go vet ./pkg/reconcilers/...`, and the reconcilers test suite pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.