### PR TITLE
fix: stop one failing sub-reconciler from freezing cluster maintenance

### DIFF
--- a/opensearch-operator/controllers/cluster_test.go
+++ b/opensearch-operator/controllers/cluster_test.go
@@ -462,7 +462,7 @@ var _ = Describe("Cluster Reconciler", Ordered, func() {
 				_ = MarkStsReady(k8sClient, OpensearchCluster.Namespace)
 
 				stsList := &appsv1.StatefulSetList{}
-				err := k8sClient.List(context.Background(), stsList, client.InNamespace(OpensearchCluster.Name))
+				err := k8sClient.List(context.Background(), stsList, client.InNamespace(OpensearchCluster.Namespace))
 				if err != nil {
 					return false
 				}

--- a/opensearch-operator/controllers/opensearchController.go
+++ b/opensearch-operator/controllers/opensearchController.go
@@ -340,17 +340,42 @@ func (r *OpenSearchClusterReconciler) reconcilePhaseRunning(ctx context.Context)
 		{Name: restart.Name(), Func: restart.Reconcile},
 		{Name: snapshotrepository.Name(), Func: snapshotrepository.Reconcile},
 	}
+
+	const defaultRequeueAfter = 30 * time.Second
+	var minRequeueAfter time.Duration
+
 	for _, rec := range componentReconcilers {
 		result, err := rec.Func()
 		if err != nil {
+			if reconcilers.IsTerminal(err) {
+				// Permanent config/validation failure: surface via metrics/logs but
+				// keep running later reconcilers (e.g. bad version must not block restart).
+				helpers.ReconcileErrors.WithLabelValues(r.Instance.Namespace, r.Instance.Name, rec.Name).Inc()
+				r.Info("terminal reconciler error, continuing chain", "reconciler", rec.Name, "error", err.Error())
+				continue
+			}
 			helpers.ReconcileErrors.WithLabelValues(r.Instance.Namespace, r.Instance.Name, rec.Name).Inc()
 			return result, err
 		}
+		// Requeue=true short-circuits so in-progress scaler/upgrade work is exclusive.
 		if result.Requeue {
 			return result, nil
 		}
+		// RequeueAfter-only is valid controller-runtime semantics; CombinedResult
+		// often produces it. Track the soonest requested delay instead of always
+		// falling through to the fixed 30s tick.
+		if result.RequeueAfter > 0 {
+			if minRequeueAfter == 0 || result.RequeueAfter < minRequeueAfter {
+				minRequeueAfter = result.RequeueAfter
+			}
+		}
+	}
+
+	requeueAfter := defaultRequeueAfter
+	if minRequeueAfter > 0 && minRequeueAfter < defaultRequeueAfter {
+		requeueAfter = minRequeueAfter
 	}
 
 	// -------- all resources has been created -----------
-	return ctrl.Result{Requeue: true, RequeueAfter: 30 * time.Second}, nil
+	return ctrl.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
 }

--- a/opensearch-operator/pkg/reconciler/result_test.go
+++ b/opensearch-operator/pkg/reconciler/result_test.go
@@ -1,0 +1,39 @@
+package reconciler
+
+import (
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var _ = Describe("CombinedResult", func() {
+	It("keeps the minimum RequeueAfter across sub-results", func() {
+		results := &CombinedResult{}
+		results.Combine(&ctrl.Result{RequeueAfter: 30 * time.Second}, nil)
+		results.Combine(&ctrl.Result{RequeueAfter: 10 * time.Second}, nil)
+		results.Combine(&ctrl.Result{RequeueAfter: 20 * time.Second}, nil)
+
+		Expect(results.Result.RequeueAfter).To(Equal(10 * time.Second))
+		Expect(results.Result.Requeue).To(BeFalse())
+	})
+
+	It("ORs Requeue flags so an earlier pool requeue is not lost", func() {
+		results := &CombinedResult{}
+		results.Combine(&ctrl.Result{Requeue: true}, nil)
+		results.Combine(&ctrl.Result{Requeue: false}, nil)
+
+		Expect(results.Result.Requeue).To(BeTrue())
+	})
+
+	It("combines errors", func() {
+		results := &CombinedResult{}
+		results.Combine(&ctrl.Result{}, errors.New("first"))
+		results.Combine(&ctrl.Result{Requeue: true}, errors.New("second"))
+
+		Expect(results.Err).To(HaveOccurred())
+		Expect(results.Result.Requeue).To(BeTrue())
+	})
+})

--- a/opensearch-operator/pkg/reconciler/suite_test.go
+++ b/opensearch-operator/pkg/reconciler/suite_test.go
@@ -1,0 +1,13 @@
+package reconciler
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestReconciler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Reconciler Result Suite")
+}

--- a/opensearch-operator/pkg/reconcilers/cluster.go
+++ b/opensearch-operator/pkg/reconcilers/cluster.go
@@ -494,11 +494,15 @@ func (r *ClusterReconciler) handlePDB(nodePool *opensearchv1.NodePool) (*ctrl.Re
 	pdb := policyv1.PodDisruptionBudget{}
 
 	if nodePool.Pdb != nil && nodePool.Pdb.Enable {
-		// Check if provided parameters are valid
+		// Check if provided parameters are valid. Invalid PDB config is a
+		// permanent spec error — skip PDB creation and continue so scaler /
+		// upgrade / restart are not blocked indefinitely.
 		if (nodePool.Pdb.MinAvailable != nil && nodePool.Pdb.MaxUnavailable != nil) || (nodePool.Pdb.MinAvailable == nil && nodePool.Pdb.MaxUnavailable == nil) {
-			r.logger.Info("Please provide only one parameter (minAvailable OR maxUnavailable) in order to configure a PodDisruptionBudget")
-			return &ctrl.Result{}, fmt.Errorf("please provide only one parameter (minAvailable OR maxUnavailable) in order to configure a PodDisruptionBudget")
-
+			msg := "please provide only one parameter (minAvailable OR maxUnavailable) in order to configure a PodDisruptionBudget"
+			r.logger.Info(msg, "nodePool", nodePool.Component)
+			annotations := map[string]string{"cluster-name": r.instance.GetName()}
+			r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "PDB", "%s (nodePool %s)", msg, nodePool.Component)
+			return &ctrl.Result{}, nil
 		}
 		pdb = helpers.ComposePDB(r.instance, nodePool)
 		if err := ctrl.SetControllerReference(r.instance, &pdb, r.client.Scheme()); err != nil {

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -56,37 +56,41 @@ func (r *ScalerReconciler) Name() string { return scalerReconcilerName }
 
 func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 	results := &reconciler.CombinedResult{}
+	lg := log.FromContext(r.ctx)
 
-	// Do not scale while an upgrade is changing versions — mirrors the
+	upgradeInProgress := r.instance.Status.Version != "" && r.instance.Status.Version != r.instance.Spec.General.Version
+
+	// Skip replica scaling while an upgrade is changing versions — mirrors the
 	// rolling-restart guard so scaler and upgrader do not delete pods at once.
-	if r.instance.Status.Version != "" && r.instance.Status.Version != r.instance.Spec.General.Version {
-		lg := log.FromContext(r.ctx)
-		lg.V(1).Info("Upgrade in progress, skipping scaler")
-		return ctrl.Result{}, nil
-	}
-
-	// Clean stale allocation exclusions (e.g. from a failed RemoveExcludeNodeHost after scale-down or upgrade).
-	// CleanStaleExclusionList itself skips when a scale-down drain is in progress.
-	if r.instance.Spec.ConfMgmt.SmartScaler {
-		clusterClient, clientErr := util.CreateClientForCluster(r.client, r.ctx, r.instance, r.osClientTransport)
-		if clientErr == nil {
-			if res, cleanupErr := util.CleanStaleExclusionList(r.client, r.instance, clusterClient, log.FromContext(r.ctx)); cleanupErr != nil {
-				return ctrl.Result{}, cleanupErr
-			} else if res.Requeue {
-				return res, nil
+	// Cleanup of entirely removed node pools still runs below.
+	if !upgradeInProgress {
+		// Clean stale allocation exclusions (e.g. from a failed RemoveExcludeNodeHost after scale-down or upgrade).
+		// CleanStaleExclusionList itself skips when a scale-down drain is in progress.
+		if r.instance.Spec.ConfMgmt.SmartScaler {
+			clusterClient, clientErr := util.CreateClientForCluster(r.client, r.ctx, r.instance, r.osClientTransport)
+			if clientErr == nil {
+				if res, cleanupErr := util.CleanStaleExclusionList(r.client, r.instance, clusterClient, lg); cleanupErr != nil {
+					return ctrl.Result{}, cleanupErr
+				} else if res.Requeue {
+					return res, nil
+				}
 			}
 		}
+
+		// Accumulate requeue across all pools — previously only the last pool's
+		// value was kept, so a drain on a non-last pool failed to short-circuit
+		// the main reconcile chain before upgrade/restart.
+		for _, nodePool := range r.instance.Spec.NodePools {
+			requeue, poolErr := r.reconcileNodePool(&nodePool)
+			results.Combine(&ctrl.Result{Requeue: requeue}, poolErr)
+		}
+	} else {
+		lg.V(1).Info("Upgrade in progress, skipping replica scaling")
 	}
 
-	// Accumulate requeue across all pools — previously only the last pool's
-	// value was kept, so a drain on a non-last pool failed to short-circuit
-	// the main reconcile chain before upgrade/restart.
-	for _, nodePool := range r.instance.Spec.NodePools {
-		requeue, poolErr := r.reconcileNodePool(&nodePool)
-		results.Combine(&ctrl.Result{Requeue: requeue}, poolErr)
-	}
-
-	// Check readiness of current NodePools before cleaning up old node pools
+	// Check readiness of current NodePools before cleaning up old node pools.
+	// Cleanup of removed pools must happen even during upgrades so that
+	// deleted node pools do not linger.
 	ready, err := r.nodePoolsReady()
 	if err != nil {
 		results.Combine(&ctrl.Result{}, err)

--- a/opensearch-operator/pkg/reconcilers/scaler.go
+++ b/opensearch-operator/pkg/reconcilers/scaler.go
@@ -55,14 +55,19 @@ func NewScalerReconciler(
 func (r *ScalerReconciler) Name() string { return scalerReconcilerName }
 
 func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
-	requeue := false
 	results := &reconciler.CombinedResult{}
-	var err error
+
+	// Do not scale while an upgrade is changing versions — mirrors the
+	// rolling-restart guard so scaler and upgrader do not delete pods at once.
+	if r.instance.Status.Version != "" && r.instance.Status.Version != r.instance.Spec.General.Version {
+		lg := log.FromContext(r.ctx)
+		lg.V(1).Info("Upgrade in progress, skipping scaler")
+		return ctrl.Result{}, nil
+	}
 
 	// Clean stale allocation exclusions (e.g. from a failed RemoveExcludeNodeHost after scale-down or upgrade).
-	// Skip cleanup when we are in the middle of a scale-down (Excluded or Drained), otherwise we would remove
-	// the node from the exclude list before drain completes and the scale-down would get stuck.
-	if r.instance.Spec.ConfMgmt.SmartScaler && !r.scalerHasExcludeOrDrainInProgress() {
+	// CleanStaleExclusionList itself skips when a scale-down drain is in progress.
+	if r.instance.Spec.ConfMgmt.SmartScaler {
 		clusterClient, clientErr := util.CreateClientForCluster(r.client, r.ctx, r.instance, r.osClientTransport)
 		if clientErr == nil {
 			if res, cleanupErr := util.CleanStaleExclusionList(r.client, r.instance, clusterClient, log.FromContext(r.ctx)); cleanupErr != nil {
@@ -73,13 +78,13 @@ func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 		}
 	}
 
+	// Accumulate requeue across all pools — previously only the last pool's
+	// value was kept, so a drain on a non-last pool failed to short-circuit
+	// the main reconcile chain before upgrade/restart.
 	for _, nodePool := range r.instance.Spec.NodePools {
-		requeue, err = r.reconcileNodePool(&nodePool)
-		if err != nil {
-			results.Combine(&ctrl.Result{Requeue: requeue}, err)
-		}
+		requeue, poolErr := r.reconcileNodePool(&nodePool)
+		results.Combine(&ctrl.Result{Requeue: requeue}, poolErr)
 	}
-	results.Combine(&ctrl.Result{Requeue: requeue}, nil)
 
 	// Check readiness of current NodePools before cleaning up old node pools
 	ready, err := r.nodePoolsReady()
@@ -94,21 +99,6 @@ func (r *ScalerReconciler) Reconcile() (ctrl.Result, error) {
 	}
 
 	return results.Result, results.Err
-}
-
-// scalerHasExcludeOrDrainInProgress returns true if any node pool is in Excluded or Drained state,
-// i.e. we are in the middle of a scale-down and should not run CleanStaleExclusionList (would remove
-// the node we are draining from the exclude list and break the flow).
-func (r *ScalerReconciler) scalerHasExcludeOrDrainInProgress() bool {
-	for _, cs := range r.instance.Status.ComponentsStatus {
-		if cs.Component != "Scaler" {
-			continue
-		}
-		if cs.Status == "Excluded" || cs.Status == "Drained" {
-			return true
-		}
-	}
-	return false
 }
 
 func (r *ScalerReconciler) reconcileNodePool(nodePool *opensearchv1.NodePool) (bool, error) {

--- a/opensearch-operator/pkg/reconcilers/scaler_test.go
+++ b/opensearch-operator/pkg/reconcilers/scaler_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 

--- a/opensearch-operator/pkg/reconcilers/scaler_test.go
+++ b/opensearch-operator/pkg/reconcilers/scaler_test.go
@@ -344,4 +344,55 @@ var _ = Describe("Scaler Controller", func() {
 			Expect(currentStatus.Conditions[0]).To(Equal(targetNodeName))
 		})
 	})
+
+	Context("When coordinating with upgrade", func() {
+		It("Should skip scaling while an upgrade is in progress", func() {
+			spec := opensearchv1.OpenSearchCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-namespace",
+				},
+				Spec: opensearchv1.ClusterSpec{
+					General: opensearchv1.GeneralConfig{
+						Version: "2.12.0",
+					},
+					NodePools: []opensearchv1.NodePool{
+						{Component: "masters", Replicas: 3},
+					},
+				},
+				Status: opensearchv1.ClusterStatus{
+					Version: "2.11.0",
+				},
+			}
+
+			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			underTest := newScalerReconciler(mockClient, &spec)
+			result, err := underTest.Reconcile()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeFalse())
+			// No StatefulSet lookups — upgrade guard returns before pool work
+			mockClient.AssertExpectations(GinkgoT())
+		})
+	})
+
+	Context("When accumulating requeue across node pools", func() {
+		It("Should keep Requeue when an earlier pool requested it (regression #1454)", func() {
+			// Previously only the last pool's requeue was combined on the success
+			// path, so a drain on a non-last pool reported Requeue=false and the
+			// main chain proceeded into upgrade/restart.
+			results := &reconciler.CombinedResult{}
+			poolRequeues := []bool{true, false} // first pool draining, last idle
+			for _, requeue := range poolRequeues {
+				results.Combine(&ctrl.Result{Requeue: requeue}, nil)
+			}
+			Expect(results.Result.Requeue).To(BeTrue())
+
+			// Demonstrate the old overwrite bug for clarity
+			requeue := false
+			for _, r := range poolRequeues {
+				requeue = r
+			}
+			Expect(requeue).To(BeFalse())
+		})
+	})
 })

--- a/opensearch-operator/pkg/reconcilers/scaler_test.go
+++ b/opensearch-operator/pkg/reconcilers/scaler_test.go
@@ -347,11 +347,13 @@ var _ = Describe("Scaler Controller", func() {
 	})
 
 	Context("When coordinating with upgrade", func() {
-		It("Should skip scaling while an upgrade is in progress", func() {
+		It("Should skip replica scaling while an upgrade is in progress but still clean up removed pools", func() {
+			clusterName := "test-cluster"
+			clusterNamespace := "test-namespace"
 			spec := opensearchv1.OpenSearchCluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster",
-					Namespace: "test-namespace",
+					Name:      clusterName,
+					Namespace: clusterNamespace,
 				},
 				Spec: opensearchv1.ClusterSpec{
 					General: opensearchv1.GeneralConfig{
@@ -366,12 +368,33 @@ var _ = Describe("Scaler Controller", func() {
 				},
 			}
 
+			mastersSts := appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      clusterName + "-masters",
+					Namespace: clusterNamespace,
+					Labels:    map[string]string{helpers.ClusterLabel: clusterName},
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: ptr.To[int32](3),
+				},
+				Status: appsv1.StatefulSetStatus{
+					AvailableReplicas: 3,
+				},
+			}
+
 			mockClient := k8s.NewMockK8sClient(GinkgoT())
+			// Upgrade guard skips reconcileNodePool, but readiness + cleanup still run.
+			mockClient.On("GetStatefulSet", clusterName+"-masters", clusterNamespace).Return(mastersSts, nil)
+			mockClient.On("ListStatefulSets",
+				client.InNamespace(clusterNamespace),
+				client.MatchingLabels{helpers.ClusterLabel: clusterName}).Return(appsv1.StatefulSetList{
+				Items: []appsv1.StatefulSet{mastersSts},
+			}, nil)
+
 			underTest := newScalerReconciler(mockClient, &spec)
 			result, err := underTest.Reconcile()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeFalse())
-			// No StatefulSet lookups — upgrade guard returns before pool work
 			mockClient.AssertExpectations(GinkgoT())
 		})
 	})

--- a/opensearch-operator/pkg/reconcilers/scaler_test.go
+++ b/opensearch-operator/pkg/reconcilers/scaler_test.go
@@ -372,7 +372,10 @@ var _ = Describe("Scaler Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      clusterName + "-masters",
 					Namespace: clusterNamespace,
-					Labels:    map[string]string{helpers.ClusterLabel: clusterName},
+					Labels: map[string]string{
+						helpers.ClusterLabel:  clusterName,
+						helpers.NodePoolLabel: "masters",
+					},
 				},
 				Spec: appsv1.StatefulSetSpec{
 					Replicas: ptr.To[int32](3),

--- a/opensearch-operator/pkg/reconcilers/terminal_error.go
+++ b/opensearch-operator/pkg/reconcilers/terminal_error.go
@@ -1,0 +1,43 @@
+package reconcilers
+
+import "errors"
+
+// TerminalError marks a permanent configuration problem. The affected
+// sub-reconciler should stop its own work, but the main reconcile chain
+// should continue so unrelated maintenance (scaler, upgrade, restart, etc.)
+// is not frozen until the operator restarts or the CR is deleted.
+type TerminalError struct {
+	Err error
+}
+
+func (e *TerminalError) Error() string {
+	if e == nil || e.Err == nil {
+		return "terminal error"
+	}
+	return e.Err.Error()
+}
+
+func (e *TerminalError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// AsTerminal wraps err as a TerminalError. A nil err is returned unchanged.
+func AsTerminal(err error) error {
+	if err == nil {
+		return nil
+	}
+	var existing *TerminalError
+	if errors.As(err, &existing) {
+		return err
+	}
+	return &TerminalError{Err: err}
+}
+
+// IsTerminal reports whether err is or wraps a TerminalError.
+func IsTerminal(err error) bool {
+	var terminal *TerminalError
+	return errors.As(err, &terminal)
+}

--- a/opensearch-operator/pkg/reconcilers/terminal_error_test.go
+++ b/opensearch-operator/pkg/reconcilers/terminal_error_test.go
@@ -1,0 +1,36 @@
+package reconcilers
+
+import (
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TerminalError", func() {
+	It("wraps and detects permanent errors", func() {
+		base := errors.New("invalid version")
+		err := AsTerminal(base)
+
+		Expect(IsTerminal(err)).To(BeTrue())
+		Expect(IsTerminal(base)).To(BeFalse())
+		Expect(errors.Is(err, base)).To(BeTrue())
+		Expect(err.Error()).To(Equal("invalid version"))
+	})
+
+	It("is a no-op for nil and already-terminal errors", func() {
+		Expect(AsTerminal(nil)).To(BeNil())
+
+		once := AsTerminal(fmt.Errorf("pdb invalid"))
+		twice := AsTerminal(once)
+		Expect(twice).To(Equal(once))
+		Expect(IsTerminal(twice)).To(BeTrue())
+	})
+
+	It("unwraps through fmt.Errorf wrapping", func() {
+		err := fmt.Errorf("upgrade failed: %w", AsTerminal(ErrVersionDowngrade))
+		Expect(IsTerminal(err)).To(BeTrue())
+		Expect(errors.Is(err, ErrVersionDowngrade)).To(BeTrue())
+	})
+})

--- a/opensearch-operator/pkg/reconcilers/upgrade.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade.go
@@ -92,11 +92,13 @@ func (r *UpgradeReconciler) Reconcile() (ctrl.Result, error) {
 
 	annotations := map[string]string{"cluster-name": r.instance.GetName()}
 
-	// If version validation fails log a warning and do nothing
+	// If version validation fails log a warning and do nothing. Return a
+	// terminal error so the main chain can continue (restart, snapshots, etc.)
+	// instead of freezing all maintenance on a permanent spec mistake.
 	if err := r.validateUpgrade(); err != nil {
 		r.logger.V(1).Error(err, "version validation failed", "currentVersion", r.instance.Status.Version, "requestedVersion", r.instance.Spec.General.Version)
-		r.recorder.AnnotatedEventf(r.instance, annotations, "Normal", "Upgrade", "Failed to validation version, currentVersion: %s , requestedVersion: %s", r.instance.Status.Version, r.instance.Spec.General.Version)
-		return ctrl.Result{}, err
+		r.recorder.AnnotatedEventf(r.instance, annotations, "Warning", "Upgrade", "Failed to validation version, currentVersion: %s , requestedVersion: %s", r.instance.Status.Version, r.instance.Spec.General.Version)
+		return ctrl.Result{}, AsTerminal(err)
 	}
 
 	// Set phase to UPGRADING if not already set

--- a/opensearch-operator/pkg/reconcilers/upgrade_test.go
+++ b/opensearch-operator/pkg/reconcilers/upgrade_test.go
@@ -1,0 +1,44 @@
+package reconcilers
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/mocks/github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/reconcilers/k8s"
+	"github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/pkg/helpers"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+)
+
+var _ = Describe("Upgrade version validation", func() {
+	It("returns a terminal error on downgrade so the chain can continue", func() {
+		spec := &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			Spec: opensearchv1.ClusterSpec{
+				General: opensearchv1.GeneralConfig{Version: "2.10.0"},
+			},
+			Status: opensearchv1.ClusterStatus{
+				Initialized: true,
+				Version:     "2.11.0",
+			},
+		}
+		mockClient := k8s.NewMockK8sClient(GinkgoT())
+		ctx := NewReconcilerContext(&helpers.MockEventRecorder{}, spec, nil)
+		underTest := &UpgradeReconciler{
+			client:            mockClient,
+			ctx:               context.Background(),
+			recorder:          &record.FakeRecorder{Events: make(chan string, 10)},
+			reconcilerContext: &ctx,
+			instance:          spec,
+			logger:            logr.Discard(),
+		}
+
+		_, err := underTest.Reconcile()
+		Expect(err).To(HaveOccurred())
+		Expect(IsTerminal(err)).To(BeTrue())
+		Expect(err.Error()).To(ContainSubstring("downgrade"))
+	})
+})

--- a/opensearch-operator/pkg/reconcilers/util/util.go
+++ b/opensearch-operator/pkg/reconcilers/util/util.go
@@ -481,7 +481,14 @@ func isDefaultNodeLifecycleToleration(t corev1.Toleration) bool {
 // been restarted (updated revision) or no longer exists. Call this when DrainDataNodes or
 // SmartScaler use the exclude list, so that a failed RemoveExcludeNodeHost (e.g. connection
 // refused after DeletePod) gets retried and does not leave nodes permanently excluded.
+//
+// Skips cleanup while the scaler has a node in Excluded/Drained — isPodStale treats an
+// up-to-date existing pod as stale, which would strip the live drain exclusion.
 func CleanStaleExclusionList(k8sClient k8s.K8sClient, instance *opensearchv1.OpenSearchCluster, osClient *services.OsClusterClient, logger logr.Logger) (ctrl.Result, error) {
+	if scalerHasExcludeOrDrainInProgress(instance) {
+		logger.V(1).Info("Skipping stale exclusion cleanup; scaler drain in progress")
+		return ctrl.Result{}, nil
+	}
 	excluded, err := services.GetExcludedNodeNames(osClient)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -505,6 +512,20 @@ func CleanStaleExclusionList(k8sClient k8s.K8sClient, instance *opensearchv1.Ope
 		}
 	}
 	return ctrl.Result{}, nil
+}
+
+// scalerHasExcludeOrDrainInProgress reports whether any Scaler component status is
+// Excluded or Drained (active smart scale-down).
+func scalerHasExcludeOrDrainInProgress(instance *opensearchv1.OpenSearchCluster) bool {
+	for _, cs := range instance.Status.ComponentsStatus {
+		if cs.Component != "Scaler" {
+			continue
+		}
+		if cs.Status == "Excluded" || cs.Status == "Drained" {
+			return true
+		}
+	}
+	return false
 }
 
 // isPodStale returns true if the named pod should no longer be in the exclude list:

--- a/opensearch-operator/pkg/reconcilers/util/util_test.go
+++ b/opensearch-operator/pkg/reconcilers/util/util_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	opensearchv1 "github.com/opensearch-project/opensearch-k8s-operator/opensearch-operator/api/opensearch.org/v1"
@@ -456,6 +457,50 @@ var _ = Describe("isPodStale", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(stale).To(BeTrue())
 		})
+	})
+})
+
+var _ = Describe("CleanStaleExclusionList drain guard", func() {
+	It("skips OpenSearch calls when scaler has Excluded status", func() {
+		instance := &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+			Status: opensearchv1.ClusterStatus{
+				ComponentsStatus: []opensearchv1.ComponentStatus{
+					{Component: "Scaler", Status: "Excluded", Description: "data"},
+				},
+			},
+		}
+		Expect(scalerHasExcludeOrDrainInProgress(instance)).To(BeTrue())
+		// nil clients would panic if cleanup did not short-circuit
+		res, err := CleanStaleExclusionList(nil, instance, nil, logr.Discard())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.IsZero()).To(BeTrue())
+	})
+
+	It("skips OpenSearch calls when scaler has Drained status", func() {
+		instance := &opensearchv1.OpenSearchCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+			Status: opensearchv1.ClusterStatus{
+				ComponentsStatus: []opensearchv1.ComponentStatus{
+					{Component: "Scaler", Status: "Drained", Description: "data"},
+				},
+			},
+		}
+		Expect(scalerHasExcludeOrDrainInProgress(instance)).To(BeTrue())
+		res, err := CleanStaleExclusionList(nil, instance, nil, logr.Discard())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.IsZero()).To(BeTrue())
+	})
+
+	It("does not treat Running scaler status as in-progress drain", func() {
+		instance := &opensearchv1.OpenSearchCluster{
+			Status: opensearchv1.ClusterStatus{
+				ComponentsStatus: []opensearchv1.ComponentStatus{
+					{Component: "Scaler", Status: "Running", Description: "data"},
+				},
+			},
+		}
+		Expect(scalerHasExcludeOrDrainInProgress(instance)).To(BeFalse())
 	})
 })
 


### PR DESCRIPTION
### Description
treat permanent validation failures as terminal, and coordinate scaler/upgrade/restart so drains and upgrades do not interleave
fix https://github.com/opensearch-project/opensearch-k8s-operator/issues/1454

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

### Check List
- [ ] Commits are signed per the DCO using --signoff 
- [ ] Unittest added for the new/changed functionality and all unit tests are successful
- [ ] Customer-visible features documented
- [ ] No linter warnings (`make lint`)

If CRDs are changed:
- [ ] CRD YAMLs updated (`make manifests`) and also copied into the helm chart
- [ ] Changes to CRDs documented

Please refer to the [PR guidelines](https://github.com/opensearch-project/opensearch-k8s-operator/blob/main/docs/developing.md#submitting-a-pr) before submitting this pull request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
